### PR TITLE
modify error msg for dma copy

### DIFF
--- a/src/op/copy.cc
+++ b/src/op/copy.cc
@@ -928,8 +928,7 @@ CopyInst CopyNode::GetCopyInst(Target target, bool disable_tma_lower,
     return CopyInst::kTMemLoad;
   } else if (CheckTMemStore(target)) {
     return CopyInst::kTMemStore;
-  } else if (TargetIsSunmmio(target)) {
-    CheckSunmmioDMACopy(target);
+  } else if (TargetIsSunmmio(target) && CheckSunmmioDMACopy(target)) {
     return CopyInst::kSunmmioDMACopy;
   } else {
     return CopyInst::kNormal;


### PR DESCRIPTION
原有的报错语句位置不对，导致报错信息与实际错误不符。对应进行了修改。