### PR TITLE
[Op] Support Tiled Fill and Reduce Opeator for Sunmmio target

### DIFF
--- a/src/op/builtin.cc
+++ b/src/op/builtin.cc
@@ -148,6 +148,11 @@ TIR_DEFINE_TL_BUILTIN(mma_sunmmio)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));
 
+TIR_DEFINE_TL_BUILTIN(vector_core_in_tile_reduce)
+    .set_num_inputs(4)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
 TIR_DEFINE_TL_BUILTIN(create_tma_descriptor)
     .set_num_inputs(-1)
     .set_attr<TCallEffectKind>("TCallEffectKind",

--- a/src/op/builtin.h
+++ b/src/op/builtin.h
@@ -281,6 +281,23 @@ TVM_DLL const Op &dma_copy();
 TVM_DLL const Op &mma_sunmmio();
 
 /*!
+ * \brief tvm intrinsic for in-tile reduction of Sunmmio target.
+ *
+ *  \param reduce_type
+ *    The type of reduction (e.g. "sum", "max", etc.).
+ *
+ *  \param out
+ *    The output tile buffer.
+ *
+ *  \param in
+ *    The input tile buffer.
+ *
+ *  \param axis
+ *    The axis of reduction within the tile.
+ */
+TVM_DLL const Op &vector_core_in_tile_reduce();
+
+/*!
  * \brief tvm intrinsics for loading image from global tensor to columns in
  * shared memory
  *

--- a/src/op/fill.cc
+++ b/src/op/fill.cc
@@ -12,6 +12,8 @@
 
 #include "../layout/tcgen05_layout.h"
 #include "../target/utils.h"
+#include "../tileview/tileview.h"
+#include "../transform/common/attr.h"
 #include "../transform/common/loop_fusion_utils.h"
 #include "../transform/loop_partition.h"
 #include "../transform/loop_vectorize.h"
@@ -155,6 +157,93 @@ For FillNode::MakeSIMTLoop(arith::Analyzer *analyzer) const {
  * @return Stmt The lowered TIR statement implementing the fill.
  */
 Stmt FillNode::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
+  if (TargetIsSunmmio(T.target)) {
+    // For Sunmmio target, we strictly require the destination buffer to be in
+    // "shared.rsram" scope. This is because the vector core on Sunmmio only
+    // operates on data residing in RSRAM.
+    ICHECK(dst.scope() == "shared.rsram")
+        << "For Sunmmio target, Fill operator destination must be in "
+           "shared.rsram scope, but got "
+        << dst.scope();
+
+    auto it = T.tileview_map.find(dst->data);
+    if (it != T.tileview_map.end()) {
+      TileView tv = (*it).second;
+      // Build map from buffer dim index to tile size
+      // This map is essential for handling tiled loops, as we need to know
+      // which dimensions are tiled and what their tile sizes are.
+      std::unordered_map<int, PrimExpr> dim_to_tile_size;
+      int ndim = dst->shape.size();
+      for (size_t i = 0; i < tv->IndexMap().size(); i++) {
+        const auto *idx_ptr = tv->IndexMap()[i].as<IntImmNode>();
+        ICHECK(idx_ptr);
+        int dim = idx_ptr->value;
+        if (dim < 0)
+          dim += ndim;
+        dim_to_tile_size[dim] = tv->TileShape()[i];
+      }
+
+      Array<IterVar> loop_vars;
+      Array<PrimExpr> dst_indices;
+      Map<String, ObjectRef> annotations;
+
+      // Add common annotations required for subsequent passes (e.g. TilesLoop)
+      // to correctly process and expand the loops.
+      // - tile_new_shape: The shape of the buffer after tiling.
+      // - tile_dim_map: Mapping between original and tiled dimensions.
+      // - tile_tile_size: The size of each tile.
+      // - kTileLoopStage: Set to kLegalized to indicate that we have handled
+      // the tiling logic.
+      // - tiled_buffer: The underlying buffer being tiled.
+      // - tile_level_loop: Indicates that this loop iterates over tiles.
+      annotations.Set(attr::tile_new_shape, tv->TiledBufferShape());
+      annotations.Set(attr::tile_dim_map, tv->IndexMap());
+      annotations.Set(attr::tile_tile_size, tv->TileShape());
+      annotations.Set(attr::kTileLoopStage,
+                      Integer(static_cast<int>(TileLoopStage::kLegalized)));
+      annotations.Set(attr::tiled_buffer, dst->data);
+      annotations.Set(attr::tile_level_loop, Integer(1));
+
+      for (int i = 0; i < ndim; i++) {
+        PrimExpr extent = region[i]->extent;
+        bool is_tiled = dim_to_tile_size.count(i);
+        if (is_tiled) {
+          PrimExpr tile_size = dim_to_tile_size[i];
+          // Ensure that the region start and extent are aligned with the tile
+          // size. This is a hardware constraint for vector core operations on
+          // tiles.
+          ICHECK(analyzer->CanProve(truncmod(region[i]->min, tile_size) == 0))
+              << "Fill region min " << region[i]->min
+              << " not divisible by tile size " << tile_size;
+          ICHECK(analyzer->CanProve(truncmod(extent, tile_size) == 0))
+              << "Fill region extent " << extent
+              << " not divisible by tile size " << tile_size;
+          extent = truncdiv(extent, tile_size);
+        }
+        Var var = Var(std::string{char('i' + i)}, extent->dtype);
+        loop_vars.push_back({Range(0, extent), var, IterVarType::kDataPar});
+        // We use the original region min + var as the index.
+        // The TilesLoop pass will later handle the substitution of var to
+        // (var * tile_size + inner_var) for tiled dimensions.
+        dst_indices.push_back(region[i]->min + var);
+      }
+
+      Stmt body = BufferStore(dst, value, dst_indices);
+
+      for (int i = ndim - 1; i >= 0; i--) {
+        Map<String, ObjectRef> loop_anno = annotations;
+        // Mark the innermost loop of a tiled dimension as the execution loop
+        // for that tile.
+        if (dim_to_tile_size.count(i)) {
+          loop_anno.Set(attr::tile_execution_loop, Integer(1));
+        }
+        body = For(loop_vars[i]->var, 0, loop_vars[i]->dom->extent,
+                   ForKind::kSerial, body, std::nullopt, loop_anno);
+      }
+      return body;
+    }
+  }
+
   if (IsFragmentBuffer(dst)) {
     auto par_op = ParallelOp(MakeSIMTLoop(analyzer));
     par_op->InferLayout({T.target,
@@ -163,6 +252,7 @@ Stmt FillNode::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
                          analyzer,
                          false,
                          T.buffer_remap,
+                         {},
                          {}},
                         InferLevel::kFree);
     auto thread_loop = PartitionLoop(par_op->GetRoot(), T.thread_var, analyzer,
@@ -188,6 +278,7 @@ Stmt FillNode::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
                          analyzer,
                          false,
                          T.buffer_remap,
+                         {},
                          {}},
                         InferLevel::kFree);
     auto thread_loop = PartitionLoop(par_op->GetRoot(), T.thread_var, analyzer,

--- a/src/op/fill.cc
+++ b/src/op/fill.cc
@@ -166,9 +166,33 @@ Stmt FillNode::MakeSunmmioTileFill(const LowerArgs &T,
          "shared.rsram scope, but got "
       << dst.scope();
 
-  auto it = T.tileview_map.find(dst->data);
-  if (it != T.tileview_map.end()) {
-    TileView tv = (*it).second;
+  // Helper to find TileView metadata for a buffer, supporting name-hint
+  // fallback. This is necessary because TVM may rename buffers (e.g.,
+  // adding suffixes like _1, _2) during lowering, which causes direct
+  // pointer-based lookup in tileview_map to fail.
+  auto find_tileview = [&](const Buffer &buf) -> Optional<TileView> {
+    if (T.tileview_map.count(buf->data)) {
+      return T.tileview_map.at(buf->data);
+    }
+    // Fallback: match by name hint, ignoring common suffixes like _1, _2.
+    auto simplify_name = [](std::string name) {
+      if (name.size() > 2 && name[name.size() - 2] == '_') {
+        return name.substr(0, name.size() - 2);
+      }
+      return name;
+    };
+    std::string target_name = simplify_name(buf->data->name_hint);
+    for (const auto &kv : T.tileview_map) {
+      if (simplify_name(kv.first->name_hint) == target_name) {
+        return kv.second;
+      }
+    }
+    return std::nullopt;
+  };
+
+  Optional<TileView> opt_tv = find_tileview(dst);
+  if (opt_tv.defined()) {
+    TileView tv = opt_tv.value();
     // Build map from buffer dim index to tile size
     // This map is essential for handling tiled loops, as we need to know
     // which dimensions are tiled and what their tile sizes are.

--- a/src/op/fill.cc
+++ b/src/op/fill.cc
@@ -156,90 +156,99 @@ For FillNode::MakeSIMTLoop(arith::Analyzer *analyzer) const {
  * @param T Lowering arguments (target, thread bounds, thread var, layout map).
  * @return Stmt The lowered TIR statement implementing the fill.
  */
+Stmt FillNode::MakeSunmmioTileFill(const LowerArgs &T,
+                                   arith::Analyzer *analyzer) const {
+  // For Sunmmio target, we strictly require the destination buffer to be in
+  // "shared.rsram" scope. This is because the vector core on Sunmmio only
+  // operates on data residing in RSRAM.
+  ICHECK(dst.scope() == "shared.rsram")
+      << "For Sunmmio target, Fill operator destination must be in "
+         "shared.rsram scope, but got "
+      << dst.scope();
+
+  auto it = T.tileview_map.find(dst->data);
+  if (it != T.tileview_map.end()) {
+    TileView tv = (*it).second;
+    // Build map from buffer dim index to tile size
+    // This map is essential for handling tiled loops, as we need to know
+    // which dimensions are tiled and what their tile sizes are.
+    std::unordered_map<int, PrimExpr> dim_to_tile_size;
+    int ndim = dst->shape.size();
+    for (size_t i = 0; i < tv->IndexMap().size(); i++) {
+      const auto *idx_ptr = tv->IndexMap()[i].as<IntImmNode>();
+      ICHECK(idx_ptr);
+      int dim = idx_ptr->value;
+      if (dim < 0)
+        dim += ndim;
+      dim_to_tile_size[dim] = tv->TileShape()[i];
+    }
+
+    Array<IterVar> loop_vars;
+    Array<PrimExpr> dst_indices;
+    Map<String, ObjectRef> annotations;
+
+    // Add common annotations required for subsequent passes (e.g. TilesLoop)
+    // to correctly process and expand the loops.
+    // - tile_new_shape: The shape of the buffer after tiling.
+    // - tile_dim_map: Mapping between original and tiled dimensions.
+    // - tile_tile_size: The size of each tile.
+    // - kTileLoopStage: Set to kLegalized to indicate that we have handled
+    // the tiling logic.
+    // - tiled_buffer: The underlying buffer being tiled.
+    // - tile_level_loop: Indicates that this loop iterates over tiles.
+    annotations.Set(attr::tile_new_shape, tv->TiledBufferShape());
+    annotations.Set(attr::tile_dim_map, tv->IndexMap());
+    annotations.Set(attr::tile_tile_size, tv->TileShape());
+    annotations.Set(attr::kTileLoopStage,
+                    Integer(static_cast<int>(TileLoopStage::kLegalized)));
+    annotations.Set(attr::tiled_buffer, dst->data);
+    annotations.Set(attr::tile_level_loop, Integer(1));
+
+    for (int i = 0; i < ndim; i++) {
+      PrimExpr extent = region[i]->extent;
+      bool is_tiled = dim_to_tile_size.count(i);
+      if (is_tiled) {
+        PrimExpr tile_size = dim_to_tile_size[i];
+        // Ensure that the region start and extent are aligned with the tile
+        // size. This is a hardware constraint for vector core operations on
+        // tiles.
+        ICHECK(analyzer->CanProve(truncmod(region[i]->min, tile_size) == 0))
+            << "Fill region min " << region[i]->min
+            << " not divisible by tile size " << tile_size;
+        ICHECK(analyzer->CanProve(truncmod(extent, tile_size) == 0))
+            << "Fill region extent " << extent << " not divisible by tile size "
+            << tile_size;
+        extent = truncdiv(extent, tile_size);
+      }
+      Var var = Var(std::string{char('i' + i)}, extent->dtype);
+      loop_vars.push_back({Range(0, extent), var, IterVarType::kDataPar});
+      // We use the original region min + var as the index.
+      // The TilesLoop pass will later handle the substitution of var to
+      // (var * tile_size + inner_var) for tiled dimensions.
+      dst_indices.push_back(region[i]->min + var);
+    }
+
+    Stmt body = BufferStore(dst, value, dst_indices);
+
+    for (int i = ndim - 1; i >= 0; i--) {
+      Map<String, ObjectRef> loop_anno = annotations;
+      // Mark the innermost loop of a tiled dimension as the execution loop
+      // for that tile.
+      if (dim_to_tile_size.count(i)) {
+        loop_anno.Set(attr::tile_execution_loop, Integer(1));
+      }
+      body = For(loop_vars[i]->var, 0, loop_vars[i]->dom->extent,
+                 ForKind::kSerial, body, std::nullopt, loop_anno);
+    }
+    return body;
+  }
+  return Stmt();
+}
+
 Stmt FillNode::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
   if (TargetIsSunmmio(T.target)) {
-    // For Sunmmio target, we strictly require the destination buffer to be in
-    // "shared.rsram" scope. This is because the vector core on Sunmmio only
-    // operates on data residing in RSRAM.
-    ICHECK(dst.scope() == "shared.rsram")
-        << "For Sunmmio target, Fill operator destination must be in "
-           "shared.rsram scope, but got "
-        << dst.scope();
-
-    auto it = T.tileview_map.find(dst->data);
-    if (it != T.tileview_map.end()) {
-      TileView tv = (*it).second;
-      // Build map from buffer dim index to tile size
-      // This map is essential for handling tiled loops, as we need to know
-      // which dimensions are tiled and what their tile sizes are.
-      std::unordered_map<int, PrimExpr> dim_to_tile_size;
-      int ndim = dst->shape.size();
-      for (size_t i = 0; i < tv->IndexMap().size(); i++) {
-        const auto *idx_ptr = tv->IndexMap()[i].as<IntImmNode>();
-        ICHECK(idx_ptr);
-        int dim = idx_ptr->value;
-        if (dim < 0)
-          dim += ndim;
-        dim_to_tile_size[dim] = tv->TileShape()[i];
-      }
-
-      Array<IterVar> loop_vars;
-      Array<PrimExpr> dst_indices;
-      Map<String, ObjectRef> annotations;
-
-      // Add common annotations required for subsequent passes (e.g. TilesLoop)
-      // to correctly process and expand the loops.
-      // - tile_new_shape: The shape of the buffer after tiling.
-      // - tile_dim_map: Mapping between original and tiled dimensions.
-      // - tile_tile_size: The size of each tile.
-      // - kTileLoopStage: Set to kLegalized to indicate that we have handled
-      // the tiling logic.
-      // - tiled_buffer: The underlying buffer being tiled.
-      // - tile_level_loop: Indicates that this loop iterates over tiles.
-      annotations.Set(attr::tile_new_shape, tv->TiledBufferShape());
-      annotations.Set(attr::tile_dim_map, tv->IndexMap());
-      annotations.Set(attr::tile_tile_size, tv->TileShape());
-      annotations.Set(attr::kTileLoopStage,
-                      Integer(static_cast<int>(TileLoopStage::kLegalized)));
-      annotations.Set(attr::tiled_buffer, dst->data);
-      annotations.Set(attr::tile_level_loop, Integer(1));
-
-      for (int i = 0; i < ndim; i++) {
-        PrimExpr extent = region[i]->extent;
-        bool is_tiled = dim_to_tile_size.count(i);
-        if (is_tiled) {
-          PrimExpr tile_size = dim_to_tile_size[i];
-          // Ensure that the region start and extent are aligned with the tile
-          // size. This is a hardware constraint for vector core operations on
-          // tiles.
-          ICHECK(analyzer->CanProve(truncmod(region[i]->min, tile_size) == 0))
-              << "Fill region min " << region[i]->min
-              << " not divisible by tile size " << tile_size;
-          ICHECK(analyzer->CanProve(truncmod(extent, tile_size) == 0))
-              << "Fill region extent " << extent
-              << " not divisible by tile size " << tile_size;
-          extent = truncdiv(extent, tile_size);
-        }
-        Var var = Var(std::string{char('i' + i)}, extent->dtype);
-        loop_vars.push_back({Range(0, extent), var, IterVarType::kDataPar});
-        // We use the original region min + var as the index.
-        // The TilesLoop pass will later handle the substitution of var to
-        // (var * tile_size + inner_var) for tiled dimensions.
-        dst_indices.push_back(region[i]->min + var);
-      }
-
-      Stmt body = BufferStore(dst, value, dst_indices);
-
-      for (int i = ndim - 1; i >= 0; i--) {
-        Map<String, ObjectRef> loop_anno = annotations;
-        // Mark the innermost loop of a tiled dimension as the execution loop
-        // for that tile.
-        if (dim_to_tile_size.count(i)) {
-          loop_anno.Set(attr::tile_execution_loop, Integer(1));
-        }
-        body = For(loop_vars[i]->var, 0, loop_vars[i]->dom->extent,
-                   ForKind::kSerial, body, std::nullopt, loop_anno);
-      }
+    Stmt body = MakeSunmmioTileFill(T, analyzer);
+    if (body.defined()) {
       return body;
     }
   }

--- a/src/op/fill.h
+++ b/src/op/fill.h
@@ -39,6 +39,8 @@ public:
 private:
   /// Create SIMT-style parallel loop for filling
   For MakeSIMTLoop(arith::Analyzer *analyzer) const;
+  /// Sunmmio Tile-based fill logic
+  Stmt MakeSunmmioTileFill(const LowerArgs &T, arith::Analyzer *analyzer) const;
 };
 
 /// Wrapper class for fill operations

--- a/src/op/operator.h
+++ b/src/op/operator.h
@@ -16,6 +16,7 @@
 #include <tvm/tir/stmt.h>
 
 #include "../layout/layout.h"
+#include "../tileview/tileview.h"
 
 namespace tvm {
 namespace tl {
@@ -24,6 +25,7 @@ using namespace tir;
 
 using AddWorkspaceCallback = std::function<PrimExpr(int, DataType)>;
 using LayoutMap = Map<Buffer, Layout>;
+using TileViewMap = Map<Var, TileView>;
 using BufferMap = Map<Var, Buffer>;
 
 enum class InferLevel : uint8_t {
@@ -57,6 +59,7 @@ struct LowerArgs {
   // fragment buffer accesses through let bindings
   Map<Var, PrimExpr> let_var_to_expr;
   LayoutMap global_layout_map;
+  TileViewMap tileview_map;
 };
 
 struct LayoutInferArgs {

--- a/src/op/reduce.cc
+++ b/src/op/reduce.cc
@@ -189,42 +189,6 @@ static Fragment ComputeReducerLayout(const Fragment &src_layout, int dim) {
   return reducer_layout;
 }
 
-/**
- * @brief Lower the Reduce operator to a TIR statement.
- *
- * Lowers a ReduceOpNode operating on fragment-scoped buffers into a sequence of
- * TIR statements implementing: optional initialization, thread-local reduction
- * (unrolled inner loops), inter-thread reduction via a runtime AllReduce call
- * (Hopper targets use `NamedBarrier` instead of the default
- * `SyncThreadsBarrier`), and an optional accumulation or copy back to the
- * destination buffer when a temporary clear buffer is used.
- *
- * Behavior notes:
- * - Only supports src and dst in "local.fragment" scope; otherwise it checks
- *   and aborts with "Reduce for shared memory not implemented.".
- * - Supports both 1D reductions (scalar output) and reductions along a single
- *   extra dimension; validates layout dimensionality consistency.
- * - If `clear` is set (or for sum/abssum reductions), an initial value is
- *   written to the clear buffer; for non-clearing sum/abssum a duplicate
- *   temporary buffer is allocated and accumulated back into dst after
- * reduction.
- * - Performs iterator compression for local reduction loops using `analyzer`.
- * - Detects parallel thread splitting from the normalized iterator sum and
- *   emits a call to a templated `tl::AllReduce<...>::run`
- *   via `builtin::call_extern`. For sufficiently large reducing thread counts
- *   (> 32) a workspace is allocated via T.AddWorkspace and passed to the
- *   AllReduce call.
- * - The final body is wrapped in parallel loops over the destination spatial
- *   dimensions and partitioned by the lowering thread variable. If a temporary
- *   clear buffer is used, it is allocated for the body.
- *
- * @param T Lowering context providing buffer and layout maps, thread bounds,
- *          target information, thread variable, and workspace allocation
- * helper.
- * @param analyzer Analyzer used for iterator compression and arithmetic
- * normalization.
- * @return Stmt Lowered TIR statement implementing the reduction.
- */
 Stmt ReduceOpNode::MakeSunmmioTileReduce(const LowerArgs &T,
                                          arith::Analyzer *analyzer) const {
   auto src_scope = this->src.scope();
@@ -744,6 +708,42 @@ Stmt ReduceOpNode::MakeSunmmioTileReduce(const LowerArgs &T,
   return body;
 }
 
+/**
+ * @brief Lower the Reduce operator to a TIR statement.
+ *
+ * Lowers a ReduceOpNode operating on fragment-scoped buffers into a sequence of
+ * TIR statements implementing: optional initialization, thread-local reduction
+ * (unrolled inner loops), inter-thread reduction via a runtime AllReduce call
+ * (Hopper targets use `NamedBarrier` instead of the default
+ * `SyncThreadsBarrier`), and an optional accumulation or copy back to the
+ * destination buffer when a temporary clear buffer is used.
+ *
+ * Behavior notes:
+ * - Only supports src and dst in "local.fragment" scope; otherwise it checks
+ *   and aborts with "Reduce for shared memory not implemented.".
+ * - Supports both 1D reductions (scalar output) and reductions along a single
+ *   extra dimension; validates layout dimensionality consistency.
+ * - If `clear` is set (or for sum/abssum reductions), an initial value is
+ *   written to the clear buffer; for non-clearing sum/abssum a duplicate
+ *   temporary buffer is allocated and accumulated back into dst after
+ * reduction.
+ * - Performs iterator compression for local reduction loops using `analyzer`.
+ * - Detects parallel thread splitting from the normalized iterator sum and
+ *   emits a call to a templated `tl::AllReduce<...>::run`
+ *   via `builtin::call_extern`. For sufficiently large reducing thread counts
+ *   (> 32) a workspace is allocated via T.AddWorkspace and passed to the
+ *   AllReduce call.
+ * - The final body is wrapped in parallel loops over the destination spatial
+ *   dimensions and partitioned by the lowering thread variable. If a temporary
+ *   clear buffer is used, it is allocated for the body.
+ *
+ * @param T Lowering context providing buffer and layout maps, thread bounds,
+ *          target information, thread variable, and workspace allocation
+ * helper.
+ * @param analyzer Analyzer used for iterator compression and arithmetic
+ * normalization.
+ * @return Stmt Lowered TIR statement implementing the reduction.
+ */
 Stmt ReduceOpNode::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
   auto get_buffer = [&](const Buffer &buf) {
     if (T.buffer_remap.count(buf))

--- a/src/op/reduce.cc
+++ b/src/op/reduce.cc
@@ -240,13 +240,23 @@ Stmt ReduceOpNode::MakeSunmmioTileReduce(const LowerArgs &T,
       << src_scope << " and " << dst_scope;
 
   // Helper to find TileView metadata for a buffer, supporting name-hint
-  // fallback.
+  // fallback. This is necessary because TVM may rename buffers (e.g.,
+  // adding suffixes like _1, _2) during lowering, which causes direct
+  // pointer-based lookup in tileview_map to fail.
   auto find_tileview = [&](const Buffer &buf) -> Optional<TileView> {
     if (T.tileview_map.count(buf->data)) {
       return T.tileview_map.at(buf->data);
     }
+    // Fallback: match by name hint, ignoring common suffixes like _1, _2.
+    auto simplify_name = [](std::string name) {
+      if (name.size() > 2 && name[name.size() - 2] == '_') {
+        return name.substr(0, name.size() - 2);
+      }
+      return name;
+    };
+    std::string target_name = simplify_name(buf->data->name_hint);
     for (const auto &kv : T.tileview_map) {
-      if (kv.first->name_hint == buf->data->name_hint) {
+      if (simplify_name(kv.first->name_hint) == target_name) {
         return kv.second;
       }
     }
@@ -547,7 +557,11 @@ Stmt ReduceOpNode::MakeSunmmioTileReduce(const LowerArgs &T,
   } else {
     // For non-tiled axis reduction, 'acc' shape matches 'dst' shape within the
     // tile, so we can safely load the initial value.
-    init_stmt = BufferStore(acc, BufferLoad(this->dst, dst_idx), acc_idx);
+    PrimExpr init_val = BufferLoad(this->dst, dst_idx);
+    if (this->type->isAbsSum() || this->type->isAbsMax()) {
+      init_val = tvm::abs(init_val);
+    }
+    init_stmt = BufferStore(acc, init_val, acc_idx);
   }
   init_stmt =
       wrap_interior(init_stmt, interior_vars, src_tile_shape, all_src_axes);
@@ -618,11 +632,23 @@ Stmt ReduceOpNode::MakeSunmmioTileReduce(const LowerArgs &T,
                         {StringImm(in_tile_reduce_type), res_region, acc_region,
                          IntImm(DataType::Int(32), reduce_tile_axis)}));
 
-      // 4. Add dst_res to dst
-      Stmt add_res_stmt = BufferStore(this->dst,
-                                      BufferLoad(this->dst, dst_idx) +
-                                          BufferLoad(dst_res_buf, res_idx),
-                                      dst_idx);
+      // 4. Final accumulation from dst_res to dst
+      PrimExpr dst_val = BufferLoad(this->dst, dst_idx);
+      PrimExpr res_val = BufferLoad(dst_res_buf, res_idx);
+      if (this->type->isAbsSum() || this->type->isAbsMax()) {
+        dst_val = tvm::abs(dst_val);
+      }
+      PrimExpr update;
+      if (this->type->isSum() || this->type->isAbsSum()) {
+        update = dst_val + res_val;
+      } else if (this->type->isMax() || this->type->isAbsMax()) {
+        update = Max(dst_val, res_val);
+      } else if (this->type->isMin()) {
+        update = Min(dst_val, res_val);
+      } else {
+        LOG(FATAL) << "Unsupported reduce type for Sunmmio accumulation";
+      }
+      Stmt add_res_stmt = BufferStore(this->dst, update, dst_idx);
       add_res_stmt = wrap_interior(add_res_stmt, dst_interior_vars_mapped,
                                    dst_tile_shape, all_dst_axes);
 
@@ -939,8 +965,11 @@ Stmt ReduceOpNode::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
     if (need_duplicate) {
       PrimExpr update;
       if (need_update) {
-        auto src_val = BufferLoad(clear_buffer, red_indices);
-        auto dst_val = BufferLoad(dst_buffer, dst_indices);
+        PrimExpr src_val = BufferLoad(clear_buffer, red_indices);
+        PrimExpr dst_val = BufferLoad(dst_buffer, dst_indices);
+        if (this->type->isAbsSum() || this->type->isAbsMax()) {
+          dst_val = tvm::abs(dst_val);
+        }
         if (this->type->isSum() || this->type->isAbsSum()) {
           update = dst_val + src_val;
         } else if (this->type->isBitAnd()) {

--- a/src/op/reduce.cc
+++ b/src/op/reduce.cc
@@ -14,7 +14,10 @@
 #include "../layout/utils.h"
 #include "../op/parallel.h"
 #include "../target/utils.h"
+#include "../tileview/tileview.h"
+#include "../transform/common/attr.h"
 #include "../transform/loop_partition.h"
+#include "builtin.h"
 #include "tir/transforms/ir_utils.h"
 #include "tvm/ir/expr.h"
 #include "tvm/tir/expr.h"
@@ -110,7 +113,7 @@ PrimExpr ReduceOpNode::MakeReduce(const PrimExpr &acc,
   if (type->isSum()) {
     return acc + rhs;
   } else if (type->isAbsSum()) {
-    return acc + Max(rhs, -rhs);
+    return acc + tvm::abs(rhs);
   } else if (type->isMax()) {
     return Max(acc, rhs);
   } else if (type->isMin()) {
@@ -125,6 +128,7 @@ PrimExpr ReduceOpNode::MakeReduce(const PrimExpr &acc,
     return acc ^ rhs;
   } else {
     LOG(FATAL) << "Unsupported reduce type: " << type->type;
+    return PrimExpr();
   }
 }
 
@@ -230,6 +234,434 @@ Stmt ReduceOpNode::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
 
   auto src_scope = this->src.scope();
   auto dst_scope = this->dst.scope();
+
+  if (TargetIsSunmmio(T.target)) {
+    // Sunmmio target requires buffers to be in shared.rsram scope.
+    // The lowering logic here implements tile-level reduction using a
+    // combination of element-wise accumulation and specialized hardware
+    // primitives.
+    ICHECK(src_scope == "shared.rsram" && dst_scope == "shared.rsram")
+        << "For Sunmmio target, Reduce operator src and dst must be in "
+           "shared.rsram scope, but got "
+        << src_scope << " and " << dst_scope;
+
+    // Helper to find TileView metadata for a buffer, supporting name-hint
+    // fallback.
+    auto find_tileview = [&](const Buffer &buf) -> Optional<TileView> {
+      if (T.tileview_map.count(buf->data)) {
+        return T.tileview_map.at(buf->data);
+      }
+      for (const auto &kv : T.tileview_map) {
+        if (kv.first->name_hint == buf->data->name_hint) {
+          return kv.second;
+        }
+      }
+      return std::nullopt;
+    };
+
+    Optional<TileView> opt_tv_src = find_tileview(this->src);
+    Optional<TileView> opt_tv_dst = find_tileview(this->dst);
+
+    ICHECK(opt_tv_src.defined())
+        << "TileView not found for src buffer " << this->src->name;
+    ICHECK(opt_tv_dst.defined())
+        << "TileView not found for dst buffer " << this->dst->name;
+
+    TileView tv_src = opt_tv_src.value();
+    TileView tv_dst = opt_tv_dst.value();
+
+    // Map physical buffer dimensions to their logical tile sizes based on
+    // IndexMap. E.g., if IndexMap is [-2, -1] and TileShape is [32, 32], the
+    // last two dims are tiled.
+    std::unordered_map<int, PrimExpr> src_dim_to_tile_size;
+    int src_ndim = this->src->shape.size();
+    for (size_t i = 0; i < tv_src->IndexMap().size(); i++) {
+      PrimExpr idx_expr = analyzer->Simplify(tv_src->IndexMap()[i]);
+      const auto *idx_ptr = idx_expr.as<IntImmNode>();
+      ICHECK(idx_ptr) << "TileView IndexMap must be constant integers, but got "
+                      << tv_src->IndexMap()[i];
+      int dim = idx_ptr->value;
+      if (dim < 0)
+        dim += src_ndim;
+      src_dim_to_tile_size[dim] = tv_src->TileShape()[i];
+    }
+
+    // Check if the dimension we are reducing along is a tiled dimension.
+    bool is_dim_tiled = src_dim_to_tile_size.count(this->dim);
+
+    // Derive the shape of the single-tile accumulation buffer 'acc'.
+    // It has the same rank as 'src', but non-tiled dimensions are collapsed
+    // to 1.
+    Array<PrimExpr> single_tile_acc_shape;
+    for (int i = 0; i < src_ndim; ++i) {
+      if (src_dim_to_tile_size.count(i)) {
+        single_tile_acc_shape.push_back(src_dim_to_tile_size[i]);
+      } else {
+        single_tile_acc_shape.push_back(1);
+      }
+    }
+
+    // single_tile_shape for potential intermediate result (deprecated by Region
+    // usage).
+    Array<PrimExpr> single_tile_res_shape;
+    int dst_ndim = this->dst->shape.size();
+    std::unordered_map<int, PrimExpr> dst_dim_to_tile_size;
+    if (is_dim_tiled) {
+      for (size_t i = 0; i < tv_dst->IndexMap().size(); i++) {
+        const auto *idx_ptr = tv_dst->IndexMap()[i].as<IntImmNode>();
+        ICHECK(idx_ptr);
+        int dim = idx_ptr->value;
+        if (dim < 0)
+          dim += dst_ndim;
+        dst_dim_to_tile_size[dim] = tv_dst->TileShape()[i];
+      }
+      for (int i = 0; i < dst_ndim; ++i) {
+        if (dst_dim_to_tile_size.count(i)) {
+          single_tile_res_shape.push_back(dst_dim_to_tile_size[i]);
+        } else {
+          single_tile_res_shape.push_back(1);
+        }
+      }
+    }
+
+    // Create the 'acc' buffer in shared.rsram to hold intermediate reduction
+    // values for a single tile.
+    auto create_tile_buffer = [&](std::string name, Array<PrimExpr> shape) {
+      return decl_buffer(shape, this->dst->dtype, name, "shared.rsram");
+    };
+
+    Buffer acc =
+        create_tile_buffer(this->dst->name + "_acc", single_tile_acc_shape);
+
+    // Create outer loop variables for each dimension of the source tensor.
+    // Tiled dimensions will have extents = buffer_extent / tile_size.
+    Array<IterVar> loop_vars;
+    for (int i = 0; i < src_ndim; i++) {
+      PrimExpr extent = this->src->shape[i];
+      if (src_dim_to_tile_size.count(i)) {
+        extent = truncdiv(extent, src_dim_to_tile_size[i]);
+      }
+      Var var = Var(std::string{char('i' + i)}, extent->dtype);
+      loop_vars.push_back({Range(0, extent), var, IterVarType::kDataPar});
+    }
+
+    // Identify which buffer dimensions are tiled and map them to tile axes (0,
+    // 1, ...).
+    std::unordered_map<int, int> src_buf_dim_to_tile_axis;
+    for (size_t i = 0; i < tv_src->IndexMap().size(); i++) {
+      int dim = tv_src->IndexMap()[i].as<IntImmNode>()->value;
+      if (dim < 0)
+        dim += src_ndim;
+      src_buf_dim_to_tile_axis[dim] = i;
+    }
+
+    std::unordered_map<int, int> dst_buf_dim_to_tile_axis;
+    for (size_t i = 0; i < tv_dst->IndexMap().size(); i++) {
+      int dim = tv_dst->IndexMap()[i].as<IntImmNode>()->value;
+      if (dim < 0)
+        dim += dst_ndim;
+      dst_buf_dim_to_tile_axis[dim] = i;
+    }
+
+    // Create interior loop variables (ki, kj, ...) for element-wise operations
+    // inside a Tile.
+    Array<Var> interior_vars;
+    Array<PrimExpr> src_tile_shape = tv_src->TileShape();
+    for (size_t i = 0; i < src_tile_shape.size(); i++) {
+      interior_vars.push_back(Var("k" + std::string{char('i' + i)}));
+    }
+
+    // Map output tiled axes to the same interior variables used by source to
+    // ensure coordinate consistency.
+    Array<Var> dst_interior_vars_mapped;
+    Array<PrimExpr> dst_tile_shape = tv_dst->TileShape();
+    for (size_t i = 0; i < tv_dst->IndexMap().size(); i++) {
+      int dst_dim_val = tv_dst->IndexMap()[i].as<IntImmNode>()->value;
+      if (dst_dim_val < 0)
+        dst_dim_val += dst_ndim;
+
+      // Match output dimension to corresponding input dimension to find the
+      // correct 'k' variable.
+      int target_src_dim =
+          (this->dst->shape.size() == src_ndim)
+              ? dst_dim_val
+              : ((dst_dim_val < this->dim) ? dst_dim_val : dst_dim_val + 1);
+
+      bool found = false;
+      for (size_t j = 0; j < tv_src->IndexMap().size(); j++) {
+        int src_dim_val = tv_src->IndexMap()[j].as<IntImmNode>()->value;
+        if (src_dim_val < 0)
+          src_dim_val += src_ndim;
+        if (src_dim_val == target_src_dim) {
+          dst_interior_vars_mapped.push_back(interior_vars[j]);
+          found = true;
+          break;
+        }
+      }
+      ICHECK(found) << "Could not map dst tiled axis to src tiled axis";
+    }
+
+    // Helper functions to generate indices for element-wise TIR access.
+    // Large buffers use (loop_var * tile_size + interior_var), while 'acc' uses
+    // (interior_var).
+    auto get_src_indices = [&]() {
+      Array<PrimExpr> indices;
+      for (int i = 0; i < src_ndim; i++) {
+        if (src_buf_dim_to_tile_axis.count(i)) {
+          int axis = src_buf_dim_to_tile_axis.at(i);
+          indices.push_back(loop_vars[i]->var * src_tile_shape[axis] +
+                            interior_vars[axis]);
+        } else {
+          indices.push_back(loop_vars[i]->var);
+        }
+      }
+      return indices;
+    };
+
+    auto get_acc_indices = [&]() {
+      Array<PrimExpr> indices;
+      for (int i = 0; i < src_ndim; i++) {
+        if (src_buf_dim_to_tile_axis.count(i)) {
+          indices.push_back(interior_vars[src_buf_dim_to_tile_axis.at(i)]);
+        } else {
+          indices.push_back(make_zero(DataType::Int(32)));
+        }
+      }
+      return indices;
+    };
+
+    auto get_dst_indices = [&]() {
+      Array<PrimExpr> indices;
+      for (int i = 0; i < dst_ndim; i++) {
+        int src_dim = (this->dst->shape.size() == src_ndim)
+                          ? i
+                          : ((i < this->dim) ? i : i + 1);
+        if (dst_buf_dim_to_tile_axis.count(i)) {
+          int axis = dst_buf_dim_to_tile_axis.at(i);
+          indices.push_back(loop_vars[src_dim]->var * dst_tile_shape[axis] +
+                            dst_interior_vars_mapped[axis]);
+        } else {
+          if (this->dst->shape.size() == src_ndim && i == this->dim) {
+            indices.push_back(make_zero(this->dst->shape[i]->dtype));
+          } else {
+            indices.push_back(loop_vars[src_dim]->var);
+          }
+        }
+      }
+      return indices;
+    };
+
+    auto get_res_indices = [&]() {
+      Array<PrimExpr> indices;
+      for (int i = 0; i < dst_ndim; i++) {
+        if (dst_buf_dim_to_tile_axis.count(i)) {
+          indices.push_back(
+              dst_interior_vars_mapped[dst_buf_dim_to_tile_axis.at(i)]);
+        } else {
+          indices.push_back(make_zero(DataType::Int(32)));
+        }
+      }
+      return indices;
+    };
+
+    Array<PrimExpr> src_idx = get_src_indices();
+    Array<PrimExpr> acc_idx = get_acc_indices();
+    Array<PrimExpr> dst_idx = get_dst_indices();
+    Array<PrimExpr> res_idx = get_res_indices();
+
+    // Wraps a Stmt with interior loops (ki, kj, ...) representing element-wise
+    // execution of a Tile. The innermost loop is marked as vectorized.
+    auto wrap_interior = [&](Stmt b, const Array<Var> &i_vars,
+                             const Array<PrimExpr> &t_shape,
+                             const std::vector<int> &axes) {
+      for (int i = static_cast<int>(axes.size()) - 1; i >= 0; i--) {
+        int axis = axes[i];
+        ForKind kind = (i == static_cast<int>(axes.size()) - 1)
+                           ? ForKind::kVectorized
+                           : ForKind::kSerial;
+        For loop(i_vars[axis], 0, t_shape[axis], kind, b);
+        auto *n = loop.CopyOnWrite();
+        n->annotations.Set(attr::tile_interior, Integer(1));
+        n->annotations.Set(attr::tile_interior_axis, Integer(axis));
+        n->annotations.Set(attr::kTileLoopStage,
+                           Integer(static_cast<int>(TileLoopStage::kTiled)));
+        n->annotations.Set(attr::tiled_buffer, this->src->data);
+        b = loop;
+      }
+      return b;
+    };
+
+    std::vector<int> all_src_axes;
+    for (size_t i = 0; i < src_tile_shape.size(); i++)
+      all_src_axes.push_back(i);
+    std::vector<int> all_dst_axes;
+    for (size_t i = 0; i < dst_tile_shape.size(); i++)
+      all_dst_axes.push_back(i);
+
+    // Identify which interior axis corresponds to the reduction dimension.
+    int reduce_tile_axis = -1;
+    for (size_t i = 0; i < src_tile_shape.size(); i++) {
+      int dim_val = tv_src->IndexMap()[i].as<IntImmNode>()->value;
+      if (dim_val < 0)
+        dim_val += src_ndim;
+      if (dim_val == this->dim) {
+        reduce_tile_axis = i;
+      }
+    }
+
+    // Construct the reduction logic using a guarded multi-step process.
+    // This allows unifying spatial and reduction loops while maintaining
+    // correct Tile semantics.
+
+    // Step 1: Accumulate (Tile-to-Tile accumulation using element-wise
+    // operations)
+    Stmt accumulate_stmt =
+        BufferStore(acc,
+                    this->MakeReduce(BufferLoad(acc, acc_idx),
+                                     BufferLoad(this->src, src_idx)),
+                    acc_idx);
+    accumulate_stmt = wrap_interior(accumulate_stmt, interior_vars,
+                                    src_tile_shape, all_src_axes);
+
+    // Step 2: Init (Guarded: only run on the first step of the reduction loop)
+    Stmt init_stmt;
+    if (this->clear) {
+      init_stmt = BufferStore(acc, this->MakeInitValue(), acc_idx);
+    } else {
+      init_stmt = BufferStore(acc, BufferLoad(this->dst, dst_idx), acc_idx);
+    }
+    init_stmt =
+        wrap_interior(init_stmt, interior_vars, src_tile_shape, all_src_axes);
+
+    // Step 3: Finalize (Guarded: run on the last step of the reduction loop)
+    Stmt finalize_stmt;
+    if (is_dim_tiled) {
+      // If reducing along a tiled axis, we need a specialized in-tile
+      // reduction.
+      std::string in_tile_reduce_type;
+      if (this->type->isSum() || this->type->isAbsSum())
+        in_tile_reduce_type = "sum";
+      else if (this->type->isMax() || this->type->isAbsMax())
+        in_tile_reduce_type = "max";
+      else if (this->type->isMin())
+        in_tile_reduce_type = "min";
+      else
+        LOG(FATAL) << "Unsupported reduce type for Sunmmio";
+
+      // Direct write-back to Out_shared using BufferRegion to save memory and
+      // IR depth.
+      Array<Range> dst_ranges;
+      for (int i = 0; i < dst_ndim; i++) {
+        int src_dim = (this->dst->shape.size() == src_ndim)
+                          ? i
+                          : ((i < this->dim) ? i : i + 1);
+        if (dst_dim_to_tile_size.count(i)) {
+          PrimExpr min = loop_vars[src_dim]->var * dst_dim_to_tile_size[i];
+          dst_ranges.push_back(
+              Range::FromMinExtent(min, dst_dim_to_tile_size[i]));
+        } else {
+          dst_ranges.push_back(
+              Range::FromMinExtent(loop_vars[src_dim]->var, 1));
+        }
+      }
+      PrimExpr dst_region = MakeRegionExpr(this->dst, dst_ranges, 2);
+
+      Array<Range> acc_ranges;
+      for (int i = 0; i < src_ndim; i++) {
+        acc_ranges.push_back(Range::FromMinExtent(
+            make_zero(acc->shape[i]->dtype), acc->shape[i]));
+      }
+      PrimExpr acc_region = MakeRegionExpr(acc, acc_ranges, 1);
+
+      finalize_stmt =
+          Evaluate(Call(DataType::Handle(), vector_core_in_tile_reduce(),
+                        {StringImm(in_tile_reduce_type), dst_region, acc_region,
+                         IntImm(DataType::Int(32), reduce_tile_axis)}));
+    } else {
+      // If reduction is NOT along a tiled axis (e.g. Batch axis), 'acc' already
+      // holds the result.
+      Stmt store_stmt =
+          BufferStore(this->dst, BufferLoad(acc, acc_idx), dst_idx);
+      store_stmt = wrap_interior(store_stmt, interior_vars, src_tile_shape,
+                                 all_src_axes);
+      finalize_stmt = store_stmt;
+    }
+
+    Var rv = loop_vars[this->dim]->var;
+    PrimExpr r_extent = loop_vars[this->dim]->dom->extent;
+
+    // Combine steps into a single body with guards.
+    Stmt body = SeqStmt({IfThenElse(rv == 0, init_stmt), accumulate_stmt,
+                         IfThenElse(rv == r_extent - 1, finalize_stmt)});
+
+    // 6. Wrap with outer Tile Loops (Spatial and Reduction).
+    // IMPORTANT: For memory reuse of 'acc', the reduction loop MUST be the
+    // innermost.
+    Map<String, ObjectRef> base_annotations;
+    base_annotations.Set(attr::kTileLoopStage,
+                         Integer(static_cast<int>(TileLoopStage::kTiled)));
+    base_annotations.Set(attr::tiled_buffer, this->src->data);
+    base_annotations.Set(attr::tile_new_shape, tv_src->TiledBufferShape());
+    base_annotations.Set(attr::tile_tile_size, tv_src->TileShape());
+    base_annotations.Set(attr::tile_dim_map, tv_src->IndexMap());
+
+    // Identify the outermost tiled loop index to set 'tile.scope_entry'.
+    int outermost_tiled_idx = -1;
+    for (int i = 0; i < src_ndim; i++) {
+      if (i != this->dim && src_buf_dim_to_tile_axis.count(i)) {
+        outermost_tiled_idx = i;
+        break;
+      }
+    }
+    if (outermost_tiled_idx == -1 &&
+        src_buf_dim_to_tile_axis.count(this->dim)) {
+      outermost_tiled_idx = this->dim;
+    }
+
+    // Wrap the reduction loop first (innermost).
+    {
+      int i = this->dim;
+      Map<String, ObjectRef> loop_anno = base_annotations;
+      loop_anno.Set(attr::tile_level_loop,
+                    Integer(0)); // Reduction axis is serial.
+      if (src_buf_dim_to_tile_axis.count(i)) {
+        loop_anno.Set(attr::tile_execution_loop, Integer(1));
+      }
+      if (i == outermost_tiled_idx) {
+        loop_anno.Set(attr::tile_scope_entry, Integer(1));
+      }
+      body = For(loop_vars[i]->var, 0, loop_vars[i]->dom->extent,
+                 ForKind::kSerial, body, std::nullopt, loop_anno);
+    }
+
+    // Wrap spatial loops (outer loops).
+    for (int i = src_ndim - 1; i >= 0; i--) {
+      if (i == this->dim)
+        continue;
+      Map<String, ObjectRef> loop_anno = base_annotations;
+      loop_anno.Set(attr::tile_level_loop,
+                    Integer(1)); // Spatial axes are parallel.
+      if (src_buf_dim_to_tile_axis.count(i)) {
+        loop_anno.Set(attr::tile_execution_loop, Integer(1));
+      }
+      if (i == outermost_tiled_idx) {
+        loop_anno.Set(attr::tile_scope_entry, Integer(1));
+      }
+      body = For(loop_vars[i]->var, 0, loop_vars[i]->dom->extent,
+                 ForKind::kSerial, body, std::nullopt, loop_anno);
+    }
+
+    // Final wrap in a Block with TileView metadata for the 'acc' buffer.
+    TileView tv_acc = makeTileView(single_tile_acc_shape, tv_src->TileShape(),
+                                   tv_src->IndexMap());
+    Map<Var, TileView> new_tileview_map;
+    new_tileview_map.Set(acc->data, tv_acc);
+
+    body = Block({}, {}, {}, "reduce_tile_op", body, std::nullopt, {acc}, {},
+                 {{attr::kTileViewMap, new_tileview_map}});
+
+    return body;
+  }
 
   if (src_scope == "local.fragment" && dst_scope == "local.fragment") {
 

--- a/src/op/reduce.cc
+++ b/src/op/reduce.cc
@@ -225,6 +225,499 @@ static Fragment ComputeReducerLayout(const Fragment &src_layout, int dim) {
  * normalization.
  * @return Stmt Lowered TIR statement implementing the reduction.
  */
+Stmt ReduceOpNode::MakeSunmmioTileReduce(const LowerArgs &T,
+                                         arith::Analyzer *analyzer) const {
+  auto src_scope = this->src.scope();
+  auto dst_scope = this->dst.scope();
+
+  // Sunmmio target requires buffers to be in shared.rsram scope.
+  // The lowering logic here implements tile-level reduction using a
+  // combination of element-wise accumulation and specialized hardware
+  // primitives.
+  ICHECK(src_scope == "shared.rsram" && dst_scope == "shared.rsram")
+      << "For Sunmmio target, Reduce operator src and dst must be in "
+         "shared.rsram scope, but got "
+      << src_scope << " and " << dst_scope;
+
+  // Helper to find TileView metadata for a buffer, supporting name-hint
+  // fallback.
+  auto find_tileview = [&](const Buffer &buf) -> Optional<TileView> {
+    if (T.tileview_map.count(buf->data)) {
+      return T.tileview_map.at(buf->data);
+    }
+    for (const auto &kv : T.tileview_map) {
+      if (kv.first->name_hint == buf->data->name_hint) {
+        return kv.second;
+      }
+    }
+    return std::nullopt;
+  };
+
+  Optional<TileView> opt_tv_src = find_tileview(this->src);
+  Optional<TileView> opt_tv_dst = find_tileview(this->dst);
+
+  ICHECK(opt_tv_src.defined())
+      << "TileView not found for src buffer " << this->src->name;
+  ICHECK(opt_tv_dst.defined())
+      << "TileView not found for dst buffer " << this->dst->name;
+
+  TileView tv_src = opt_tv_src.value();
+  TileView tv_dst = opt_tv_dst.value();
+
+  // Map physical buffer dimensions to their logical tile sizes based on
+  // IndexMap. E.g., if IndexMap is [-2, -1] and TileShape is [32, 32], the
+  // last two dims are tiled.
+  std::unordered_map<int, PrimExpr> src_dim_to_tile_size;
+  int src_ndim = this->src->shape.size();
+  for (size_t i = 0; i < tv_src->IndexMap().size(); i++) {
+    PrimExpr idx_expr = analyzer->Simplify(tv_src->IndexMap()[i]);
+    const auto *idx_ptr = idx_expr.as<IntImmNode>();
+    ICHECK(idx_ptr) << "TileView IndexMap must be constant integers, but got "
+                    << tv_src->IndexMap()[i];
+    int dim = idx_ptr->value;
+    if (dim < 0)
+      dim += src_ndim;
+    src_dim_to_tile_size[dim] = tv_src->TileShape()[i];
+  }
+
+  // Check if the dimension we are reducing along is a tiled dimension.
+  bool is_dim_tiled = src_dim_to_tile_size.count(this->dim);
+
+  // Derive the shape of the single-tile accumulation buffer 'acc'.
+  // It has the same rank as 'src', but non-tiled dimensions are collapsed
+  // to 1.
+  Array<PrimExpr> single_tile_acc_shape;
+  single_tile_acc_shape.reserve(src_ndim);
+  for (int i = 0; i < src_ndim; ++i) {
+    if (src_dim_to_tile_size.count(i)) {
+      single_tile_acc_shape.push_back(src_dim_to_tile_size[i]);
+    } else {
+      single_tile_acc_shape.push_back(1);
+    }
+  }
+
+  // single_tile_shape for potential intermediate result.
+  // Only needed if the reduction dimension is tiled and we are not clearing
+  // (i.e. accumulating into existing dst values), since in that case we need to
+  // store the per-tile reduction results before accumulating back to dst.
+  Array<PrimExpr> single_tile_res_shape;
+  int dst_ndim = this->dst->shape.size();
+  std::unordered_map<int, PrimExpr> dst_dim_to_tile_size;
+  if (is_dim_tiled) {
+    single_tile_res_shape.reserve(dst_ndim);
+    for (size_t i = 0; i < tv_dst->IndexMap().size(); i++) {
+      const auto *idx_ptr = tv_dst->IndexMap()[i].as<IntImmNode>();
+      ICHECK(idx_ptr);
+      int dim = idx_ptr->value;
+      if (dim < 0)
+        dim += dst_ndim;
+      dst_dim_to_tile_size[dim] = tv_dst->TileShape()[i];
+    }
+    for (int i = 0; i < dst_ndim; ++i) {
+      if (dst_dim_to_tile_size.count(i)) {
+        single_tile_res_shape.push_back(dst_dim_to_tile_size[i]);
+      } else {
+        single_tile_res_shape.push_back(1);
+      }
+    }
+  }
+
+  // Create the 'acc' buffer in shared.rsram to hold intermediate reduction
+  // values for a single tile.
+  auto create_tile_buffer = [&](std::string name, Array<PrimExpr> shape) {
+    return decl_buffer(shape, this->dst->dtype, name, "shared.rsram");
+  };
+
+  Buffer acc =
+      create_tile_buffer(this->dst->name + "_acc", single_tile_acc_shape);
+
+  Optional<Buffer> dst_res;
+  if (is_dim_tiled && !this->clear) {
+    dst_res =
+        create_tile_buffer(this->dst->name + "_res", single_tile_res_shape);
+  }
+
+  // Create outer loop variables for each dimension of the source tensor.
+  // Tiled dimensions will have extents = buffer_extent / tile_size.
+  Array<IterVar> loop_vars;
+  loop_vars.reserve(src_ndim);
+  for (int i = 0; i < src_ndim; i++) {
+    PrimExpr extent = this->src->shape[i];
+    if (src_dim_to_tile_size.count(i)) {
+      extent = truncdiv(extent, src_dim_to_tile_size[i]);
+    }
+    Var var = Var(std::string{char('i' + i)}, extent->dtype);
+    loop_vars.push_back({Range(0, extent), var, IterVarType::kDataPar});
+  }
+
+  // Identify which buffer dimensions are tiled and map them to tile axes (0,
+  // 1, ...).
+  std::unordered_map<int, int> src_buf_dim_to_tile_axis;
+  for (size_t i = 0; i < tv_src->IndexMap().size(); i++) {
+    int dim = tv_src->IndexMap()[i].as<IntImmNode>()->value;
+    if (dim < 0)
+      dim += src_ndim;
+    src_buf_dim_to_tile_axis[dim] = i;
+  }
+
+  std::unordered_map<int, int> dst_buf_dim_to_tile_axis;
+  for (size_t i = 0; i < tv_dst->IndexMap().size(); i++) {
+    int dim = tv_dst->IndexMap()[i].as<IntImmNode>()->value;
+    if (dim < 0)
+      dim += dst_ndim;
+    dst_buf_dim_to_tile_axis[dim] = i;
+  }
+
+  // Create interior loop variables (ki, kj, ...) for element-wise operations
+  // inside a Tile.
+  Array<Var> interior_vars;
+  Array<PrimExpr> src_tile_shape = tv_src->TileShape();
+  interior_vars.reserve(src_tile_shape.size());
+  for (size_t i = 0; i < src_tile_shape.size(); i++) {
+    interior_vars.push_back(Var("k" + std::string{char('i' + i)}));
+  }
+
+  // Map output tiled axes to the same interior variables used by source to
+  // ensure coordinate consistency.
+  Array<Var> dst_interior_vars_mapped;
+  Array<PrimExpr> dst_tile_shape = tv_dst->TileShape();
+  dst_interior_vars_mapped.reserve(tv_dst->IndexMap().size());
+  for (size_t i = 0; i < tv_dst->IndexMap().size(); i++) {
+    int dst_dim_val = tv_dst->IndexMap()[i].as<IntImmNode>()->value;
+    if (dst_dim_val < 0)
+      dst_dim_val += dst_ndim;
+
+    // Match output dimension to corresponding input dimension to find the
+    // correct 'k' variable.
+    int target_src_dim =
+        (this->dst->shape.size() == src_ndim)
+            ? dst_dim_val
+            : ((dst_dim_val < this->dim) ? dst_dim_val : dst_dim_val + 1);
+
+    bool found = false;
+    for (size_t j = 0; j < tv_src->IndexMap().size(); j++) {
+      int src_dim_val = tv_src->IndexMap()[j].as<IntImmNode>()->value;
+      if (src_dim_val < 0)
+        src_dim_val += src_ndim;
+      if (src_dim_val == target_src_dim) {
+        dst_interior_vars_mapped.push_back(interior_vars[j]);
+        found = true;
+        break;
+      }
+    }
+    ICHECK(found) << "Could not map dst tiled axis to src tiled axis";
+  }
+
+  // Helper functions to generate indices for element-wise TIR access.
+  // Large buffers use (loop_var * tile_size + interior_var), while 'acc' uses
+  // (interior_var).
+  auto get_src_indices = [&]() {
+    Array<PrimExpr> indices;
+    for (int i = 0; i < src_ndim; i++) {
+      if (src_buf_dim_to_tile_axis.count(i)) {
+        int axis = src_buf_dim_to_tile_axis.at(i);
+        indices.push_back(loop_vars[i]->var * src_tile_shape[axis] +
+                          interior_vars[axis]);
+      } else {
+        indices.push_back(loop_vars[i]->var);
+      }
+    }
+    return indices;
+  };
+
+  auto get_acc_indices = [&]() {
+    Array<PrimExpr> indices;
+    for (int i = 0; i < src_ndim; i++) {
+      if (src_buf_dim_to_tile_axis.count(i)) {
+        indices.push_back(interior_vars[src_buf_dim_to_tile_axis.at(i)]);
+      } else {
+        indices.push_back(make_zero(DataType::Int(32)));
+      }
+    }
+    return indices;
+  };
+
+  auto get_dst_indices = [&]() {
+    Array<PrimExpr> indices;
+    for (int i = 0; i < dst_ndim; i++) {
+      int src_dim = (this->dst->shape.size() == src_ndim)
+                        ? i
+                        : ((i < this->dim) ? i : i + 1);
+      if (dst_buf_dim_to_tile_axis.count(i)) {
+        int axis = dst_buf_dim_to_tile_axis.at(i);
+        indices.push_back(loop_vars[src_dim]->var * dst_tile_shape[axis] +
+                          dst_interior_vars_mapped[axis]);
+      } else {
+        if (this->dst->shape.size() == src_ndim && i == this->dim) {
+          indices.push_back(make_zero(this->dst->shape[i]->dtype));
+        } else {
+          indices.push_back(loop_vars[src_dim]->var);
+        }
+      }
+    }
+    return indices;
+  };
+
+  auto get_res_indices = [&]() {
+    Array<PrimExpr> indices;
+    for (int i = 0; i < dst_ndim; i++) {
+      if (dst_buf_dim_to_tile_axis.count(i)) {
+        indices.push_back(
+            dst_interior_vars_mapped[dst_buf_dim_to_tile_axis.at(i)]);
+      } else {
+        indices.push_back(make_zero(DataType::Int(32)));
+      }
+    }
+    return indices;
+  };
+
+  Array<PrimExpr> src_idx = get_src_indices();
+  Array<PrimExpr> acc_idx = get_acc_indices();
+  Array<PrimExpr> dst_idx = get_dst_indices();
+  Array<PrimExpr> res_idx = get_res_indices();
+
+  // Wraps a Stmt with interior loops (ki, kj, ...) representing element-wise
+  // execution of a Tile. The innermost loop is marked as vectorized.
+  auto wrap_interior = [&](Stmt b, const Array<Var> &i_vars,
+                           const Array<PrimExpr> &t_shape,
+                           const std::vector<int> &axes) {
+    for (int i = static_cast<int>(axes.size()) - 1; i >= 0; i--) {
+      int axis = axes[i];
+      ForKind kind = (i == static_cast<int>(axes.size()) - 1)
+                         ? ForKind::kVectorized
+                         : ForKind::kSerial;
+      For loop(i_vars[axis], 0, t_shape[axis], kind, b);
+      auto *n = loop.CopyOnWrite();
+      n->annotations.Set(attr::tile_interior, Integer(1));
+      n->annotations.Set(attr::tile_interior_axis, Integer(axis));
+      n->annotations.Set(attr::kTileLoopStage,
+                         Integer(static_cast<int>(TileLoopStage::kTiled)));
+      n->annotations.Set(attr::tiled_buffer, this->src->data);
+      b = loop;
+    }
+    return b;
+  };
+
+  std::vector<int> all_src_axes;
+  all_src_axes.reserve(src_tile_shape.size());
+  for (size_t i = 0; i < src_tile_shape.size(); i++)
+    all_src_axes.push_back(i);
+  std::vector<int> all_dst_axes;
+  all_dst_axes.reserve(dst_tile_shape.size());
+  for (size_t i = 0; i < dst_tile_shape.size(); i++)
+    all_dst_axes.push_back(i);
+
+  // Identify which interior axis corresponds to the reduction dimension.
+  int reduce_tile_axis = -1;
+  for (size_t i = 0; i < src_tile_shape.size(); i++) {
+    int dim_val = tv_src->IndexMap()[i].as<IntImmNode>()->value;
+    if (dim_val < 0)
+      dim_val += src_ndim;
+    if (dim_val == this->dim) {
+      reduce_tile_axis = i;
+    }
+  }
+
+  // Construct the reduction logic using a guarded multi-step process.
+  // This allows unifying spatial and reduction loops while maintaining
+  // correct Tile semantics.
+
+  // Step 1: Accumulate (Tile-to-Tile accumulation using element-wise
+  // operations)
+  Stmt accumulate_stmt =
+      BufferStore(acc,
+                  this->MakeReduce(BufferLoad(acc, acc_idx),
+                                   BufferLoad(this->src, src_idx)),
+                  acc_idx);
+  accumulate_stmt = wrap_interior(accumulate_stmt, interior_vars,
+                                  src_tile_shape, all_src_axes);
+
+  // Step 2: Init (Guarded: only run on the first step of the reduction loop)
+  Stmt init_stmt;
+  if (this->clear || is_dim_tiled) {
+    // If we are reducing along a tiled axis, we MUST initialize 'acc' with the
+    // neutral value (e.g. 0 for sum) even if clear=False. This is because 'acc'
+    // is a full tile (e.g., [32, 32]), but 'dst' is already reduced (e.g.,
+    // [32]). If we load 'dst' into every element of 'acc' along the reduction
+    // axis, the in-tile hardware reduction will accumulate the initial value 32
+    // times (resulting in "multiple additions"). The correct approach for
+    // clear=False + is_dim_tiled is to accumulate the pure reduced result into
+    // 'dst' during the finalize step.
+    init_stmt = BufferStore(acc, this->MakeInitValue(), acc_idx);
+  } else {
+    // For non-tiled axis reduction, 'acc' shape matches 'dst' shape within the
+    // tile, so we can safely load the initial value.
+    init_stmt = BufferStore(acc, BufferLoad(this->dst, dst_idx), acc_idx);
+  }
+  init_stmt =
+      wrap_interior(init_stmt, interior_vars, src_tile_shape, all_src_axes);
+
+  // Step 3: Finalize (Guarded: run on the last step of the reduction loop)
+  Stmt finalize_stmt;
+  if (is_dim_tiled) {
+    // If reducing along a tiled axis, we need a specialized in-tile
+    // reduction.
+    std::string in_tile_reduce_type;
+    if (this->type->isSum() || this->type->isAbsSum())
+      in_tile_reduce_type = "sum";
+    else if (this->type->isMax() || this->type->isAbsMax())
+      in_tile_reduce_type = "max";
+    else if (this->type->isMin())
+      in_tile_reduce_type = "min";
+    else
+      LOG(FATAL) << "Unsupported reduce type for Sunmmio";
+
+    // Direct write-back to Out_shared using BufferRegion to save memory and
+    // IR depth.
+    Array<Range> dst_ranges;
+    for (int i = 0; i < dst_ndim; i++) {
+      int src_dim = (this->dst->shape.size() == src_ndim)
+                        ? i
+                        : ((i < this->dim) ? i : i + 1);
+      if (dst_dim_to_tile_size.count(i)) {
+        PrimExpr min = loop_vars[src_dim]->var * dst_dim_to_tile_size[i];
+        dst_ranges.push_back(
+            Range::FromMinExtent(min, dst_dim_to_tile_size[i]));
+      } else {
+        dst_ranges.push_back(Range::FromMinExtent(loop_vars[src_dim]->var, 1));
+      }
+    }
+    PrimExpr dst_region = MakeRegionExpr(this->dst, dst_ranges, 2);
+
+    Array<Range> acc_ranges;
+    for (int i = 0; i < src_ndim; i++) {
+      acc_ranges.push_back(
+          Range::FromMinExtent(make_zero(acc->shape[i]->dtype), acc->shape[i]));
+    }
+    PrimExpr acc_region = MakeRegionExpr(acc, acc_ranges, 1);
+
+    if (this->clear) {
+      finalize_stmt =
+          Evaluate(Call(DataType::Handle(), vector_core_in_tile_reduce(),
+                        {StringImm(in_tile_reduce_type), dst_region, acc_region,
+                         IntImm(DataType::Int(32), reduce_tile_axis)}));
+    } else {
+      ICHECK(dst_res.defined());
+      Buffer dst_res_buf = dst_res.value();
+
+      // 1. Create a region for dst_res
+      Array<Range> res_ranges;
+      for (int i = 0; i < dst_ndim; i++) {
+        res_ranges.push_back(Range::FromMinExtent(
+            make_zero(dst_res_buf->shape[i]->dtype), dst_res_buf->shape[i]));
+      }
+      PrimExpr res_region = MakeRegionExpr(dst_res_buf, res_ranges, 1);
+
+      // 2. Init dst_res with 0 (not strictly necessary if vector_core
+      // overwrites, but safe) Wait, vector_core_in_tile_reduce overwrites the
+      // dst region. We do not need to init dst_res manually.
+
+      // 3. vector_core_in_tile_reduce from acc to dst_res
+      Stmt in_tile_reduce_stmt =
+          Evaluate(Call(DataType::Handle(), vector_core_in_tile_reduce(),
+                        {StringImm(in_tile_reduce_type), res_region, acc_region,
+                         IntImm(DataType::Int(32), reduce_tile_axis)}));
+
+      // 4. Add dst_res to dst
+      Stmt add_res_stmt = BufferStore(this->dst,
+                                      BufferLoad(this->dst, dst_idx) +
+                                          BufferLoad(dst_res_buf, res_idx),
+                                      dst_idx);
+      add_res_stmt = wrap_interior(add_res_stmt, dst_interior_vars_mapped,
+                                   dst_tile_shape, all_dst_axes);
+
+      finalize_stmt = SeqStmt({in_tile_reduce_stmt, add_res_stmt});
+    }
+  } else {
+    // If reduction is NOT along a tiled axis (e.g. Batch axis), 'acc' already
+    // holds the result.
+    Stmt store_stmt = BufferStore(this->dst, BufferLoad(acc, acc_idx), dst_idx);
+    store_stmt =
+        wrap_interior(store_stmt, interior_vars, src_tile_shape, all_src_axes);
+    finalize_stmt = store_stmt;
+  }
+
+  Var rv = loop_vars[this->dim]->var;
+  PrimExpr r_extent = loop_vars[this->dim]->dom->extent;
+
+  // Combine steps into a single body with guards.
+  Stmt body = SeqStmt({IfThenElse(rv == 0, init_stmt), accumulate_stmt,
+                       IfThenElse(rv == r_extent - 1, finalize_stmt)});
+
+  // 6. Wrap with outer Tile Loops (Spatial and Reduction).
+  // IMPORTANT: For memory reuse of 'acc', the reduction loop MUST be the
+  // innermost.
+  Map<String, ObjectRef> base_annotations;
+  base_annotations.Set(attr::kTileLoopStage,
+                       Integer(static_cast<int>(TileLoopStage::kTiled)));
+  base_annotations.Set(attr::tiled_buffer, this->src->data);
+  base_annotations.Set(attr::tile_new_shape, tv_src->TiledBufferShape());
+  base_annotations.Set(attr::tile_tile_size, tv_src->TileShape());
+  base_annotations.Set(attr::tile_dim_map, tv_src->IndexMap());
+
+  // Identify the outermost tiled loop index to set 'tile.scope_entry'.
+  int outermost_tiled_idx = -1;
+  for (int i = 0; i < src_ndim; i++) {
+    if (i != this->dim && src_buf_dim_to_tile_axis.count(i)) {
+      outermost_tiled_idx = i;
+      break;
+    }
+  }
+  if (outermost_tiled_idx == -1 && src_buf_dim_to_tile_axis.count(this->dim)) {
+    outermost_tiled_idx = this->dim;
+  }
+
+  // Wrap the reduction loop first (innermost).
+  {
+    int i = this->dim;
+    Map<String, ObjectRef> loop_anno = base_annotations;
+    loop_anno.Set(attr::tile_level_loop,
+                  Integer(0)); // Reduction axis is serial.
+    if (src_buf_dim_to_tile_axis.count(i)) {
+      loop_anno.Set(attr::tile_execution_loop, Integer(1));
+    }
+    if (i == outermost_tiled_idx) {
+      loop_anno.Set(attr::tile_scope_entry, Integer(1));
+    }
+    body = For(loop_vars[i]->var, 0, loop_vars[i]->dom->extent,
+               ForKind::kSerial, body, std::nullopt, loop_anno);
+  }
+
+  // Wrap spatial loops (outer loops).
+  for (int i = src_ndim - 1; i >= 0; i--) {
+    if (i == this->dim)
+      continue;
+    Map<String, ObjectRef> loop_anno = base_annotations;
+    loop_anno.Set(attr::tile_level_loop,
+                  Integer(1)); // Spatial axes are parallel.
+    if (src_buf_dim_to_tile_axis.count(i)) {
+      loop_anno.Set(attr::tile_execution_loop, Integer(1));
+    }
+    if (i == outermost_tiled_idx) {
+      loop_anno.Set(attr::tile_scope_entry, Integer(1));
+    }
+    body = For(loop_vars[i]->var, 0, loop_vars[i]->dom->extent,
+               ForKind::kSerial, body, std::nullopt, loop_anno);
+  }
+
+  // Finally, wrap the body in a Block with TileView metadata.
+  TileView tv_acc = makeTileView(single_tile_acc_shape, tv_src->TileShape(),
+                                 tv_src->IndexMap());
+  Map<Var, TileView> new_tileview_map;
+  new_tileview_map.Set(acc->data, tv_acc);
+
+  Array<Buffer> alloc_buffers;
+  alloc_buffers.push_back(acc);
+  if (dst_res.defined()) {
+    alloc_buffers.push_back(dst_res.value());
+  }
+
+  body = Block({}, {}, {}, "reduce_tile_op", body, std::nullopt, alloc_buffers,
+               {}, {{attr::kTileViewMap, new_tileview_map}});
+
+  return body;
+}
+
 Stmt ReduceOpNode::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
   auto get_buffer = [&](const Buffer &buf) {
     if (T.buffer_remap.count(buf))
@@ -236,438 +729,7 @@ Stmt ReduceOpNode::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
   auto dst_scope = this->dst.scope();
 
   if (TargetIsSunmmio(T.target)) {
-    // Sunmmio target requires buffers to be in shared.rsram scope.
-    // The lowering logic here implements tile-level reduction using a
-    // combination of element-wise accumulation and specialized hardware
-    // primitives.
-    ICHECK(src_scope == "shared.rsram" && dst_scope == "shared.rsram")
-        << "For Sunmmio target, Reduce operator src and dst must be in "
-           "shared.rsram scope, but got "
-        << src_scope << " and " << dst_scope;
-
-    // Helper to find TileView metadata for a buffer, supporting name-hint
-    // fallback.
-    auto find_tileview = [&](const Buffer &buf) -> Optional<TileView> {
-      if (T.tileview_map.count(buf->data)) {
-        return T.tileview_map.at(buf->data);
-      }
-      for (const auto &kv : T.tileview_map) {
-        if (kv.first->name_hint == buf->data->name_hint) {
-          return kv.second;
-        }
-      }
-      return std::nullopt;
-    };
-
-    Optional<TileView> opt_tv_src = find_tileview(this->src);
-    Optional<TileView> opt_tv_dst = find_tileview(this->dst);
-
-    ICHECK(opt_tv_src.defined())
-        << "TileView not found for src buffer " << this->src->name;
-    ICHECK(opt_tv_dst.defined())
-        << "TileView not found for dst buffer " << this->dst->name;
-
-    TileView tv_src = opt_tv_src.value();
-    TileView tv_dst = opt_tv_dst.value();
-
-    // Map physical buffer dimensions to their logical tile sizes based on
-    // IndexMap. E.g., if IndexMap is [-2, -1] and TileShape is [32, 32], the
-    // last two dims are tiled.
-    std::unordered_map<int, PrimExpr> src_dim_to_tile_size;
-    int src_ndim = this->src->shape.size();
-    for (size_t i = 0; i < tv_src->IndexMap().size(); i++) {
-      PrimExpr idx_expr = analyzer->Simplify(tv_src->IndexMap()[i]);
-      const auto *idx_ptr = idx_expr.as<IntImmNode>();
-      ICHECK(idx_ptr) << "TileView IndexMap must be constant integers, but got "
-                      << tv_src->IndexMap()[i];
-      int dim = idx_ptr->value;
-      if (dim < 0)
-        dim += src_ndim;
-      src_dim_to_tile_size[dim] = tv_src->TileShape()[i];
-    }
-
-    // Check if the dimension we are reducing along is a tiled dimension.
-    bool is_dim_tiled = src_dim_to_tile_size.count(this->dim);
-
-    // Derive the shape of the single-tile accumulation buffer 'acc'.
-    // It has the same rank as 'src', but non-tiled dimensions are collapsed
-    // to 1.
-    Array<PrimExpr> single_tile_acc_shape;
-    single_tile_acc_shape.reserve(src_ndim);
-    for (int i = 0; i < src_ndim; ++i) {
-      if (src_dim_to_tile_size.count(i)) {
-        single_tile_acc_shape.push_back(src_dim_to_tile_size[i]);
-      } else {
-        single_tile_acc_shape.push_back(1);
-      }
-    }
-
-    // single_tile_shape for potential intermediate result (deprecated by Region
-    // usage).
-    Array<PrimExpr> single_tile_res_shape;
-    int dst_ndim = this->dst->shape.size();
-    std::unordered_map<int, PrimExpr> dst_dim_to_tile_size;
-    if (is_dim_tiled) {
-      single_tile_res_shape.reserve(dst_ndim);
-      for (size_t i = 0; i < tv_dst->IndexMap().size(); i++) {
-        const auto *idx_ptr = tv_dst->IndexMap()[i].as<IntImmNode>();
-        ICHECK(idx_ptr);
-        int dim = idx_ptr->value;
-        if (dim < 0)
-          dim += dst_ndim;
-        dst_dim_to_tile_size[dim] = tv_dst->TileShape()[i];
-      }
-      for (int i = 0; i < dst_ndim; ++i) {
-        if (dst_dim_to_tile_size.count(i)) {
-          single_tile_res_shape.push_back(dst_dim_to_tile_size[i]);
-        } else {
-          single_tile_res_shape.push_back(1);
-        }
-      }
-    }
-
-    // Create the 'acc' buffer in shared.rsram to hold intermediate reduction
-    // values for a single tile.
-    auto create_tile_buffer = [&](std::string name, Array<PrimExpr> shape) {
-      return decl_buffer(shape, this->dst->dtype, name, "shared.rsram");
-    };
-
-    Buffer acc =
-        create_tile_buffer(this->dst->name + "_acc", single_tile_acc_shape);
-
-    // Create outer loop variables for each dimension of the source tensor.
-    // Tiled dimensions will have extents = buffer_extent / tile_size.
-    Array<IterVar> loop_vars;
-    loop_vars.reserve(src_ndim);
-    for (int i = 0; i < src_ndim; i++) {
-      PrimExpr extent = this->src->shape[i];
-      if (src_dim_to_tile_size.count(i)) {
-        extent = truncdiv(extent, src_dim_to_tile_size[i]);
-      }
-      Var var = Var(std::string{char('i' + i)}, extent->dtype);
-      loop_vars.push_back({Range(0, extent), var, IterVarType::kDataPar});
-    }
-
-    // Identify which buffer dimensions are tiled and map them to tile axes (0,
-    // 1, ...).
-    std::unordered_map<int, int> src_buf_dim_to_tile_axis;
-    for (size_t i = 0; i < tv_src->IndexMap().size(); i++) {
-      int dim = tv_src->IndexMap()[i].as<IntImmNode>()->value;
-      if (dim < 0)
-        dim += src_ndim;
-      src_buf_dim_to_tile_axis[dim] = i;
-    }
-
-    std::unordered_map<int, int> dst_buf_dim_to_tile_axis;
-    for (size_t i = 0; i < tv_dst->IndexMap().size(); i++) {
-      int dim = tv_dst->IndexMap()[i].as<IntImmNode>()->value;
-      if (dim < 0)
-        dim += dst_ndim;
-      dst_buf_dim_to_tile_axis[dim] = i;
-    }
-
-    // Create interior loop variables (ki, kj, ...) for element-wise operations
-    // inside a Tile.
-    Array<Var> interior_vars;
-    Array<PrimExpr> src_tile_shape = tv_src->TileShape();
-    interior_vars.reserve(src_tile_shape.size());
-    for (size_t i = 0; i < src_tile_shape.size(); i++) {
-      interior_vars.push_back(Var("k" + std::string{char('i' + i)}));
-    }
-
-    // Map output tiled axes to the same interior variables used by source to
-    // ensure coordinate consistency.
-    Array<Var> dst_interior_vars_mapped;
-    Array<PrimExpr> dst_tile_shape = tv_dst->TileShape();
-    dst_interior_vars_mapped.reserve(tv_dst->IndexMap().size());
-    for (size_t i = 0; i < tv_dst->IndexMap().size(); i++) {
-      int dst_dim_val = tv_dst->IndexMap()[i].as<IntImmNode>()->value;
-      if (dst_dim_val < 0)
-        dst_dim_val += dst_ndim;
-
-      // Match output dimension to corresponding input dimension to find the
-      // correct 'k' variable.
-      int target_src_dim =
-          (this->dst->shape.size() == src_ndim)
-              ? dst_dim_val
-              : ((dst_dim_val < this->dim) ? dst_dim_val : dst_dim_val + 1);
-
-      bool found = false;
-      for (size_t j = 0; j < tv_src->IndexMap().size(); j++) {
-        int src_dim_val = tv_src->IndexMap()[j].as<IntImmNode>()->value;
-        if (src_dim_val < 0)
-          src_dim_val += src_ndim;
-        if (src_dim_val == target_src_dim) {
-          dst_interior_vars_mapped.push_back(interior_vars[j]);
-          found = true;
-          break;
-        }
-      }
-      ICHECK(found) << "Could not map dst tiled axis to src tiled axis";
-    }
-
-    // Helper functions to generate indices for element-wise TIR access.
-    // Large buffers use (loop_var * tile_size + interior_var), while 'acc' uses
-    // (interior_var).
-    auto get_src_indices = [&]() {
-      Array<PrimExpr> indices;
-      for (int i = 0; i < src_ndim; i++) {
-        if (src_buf_dim_to_tile_axis.count(i)) {
-          int axis = src_buf_dim_to_tile_axis.at(i);
-          indices.push_back(loop_vars[i]->var * src_tile_shape[axis] +
-                            interior_vars[axis]);
-        } else {
-          indices.push_back(loop_vars[i]->var);
-        }
-      }
-      return indices;
-    };
-
-    auto get_acc_indices = [&]() {
-      Array<PrimExpr> indices;
-      for (int i = 0; i < src_ndim; i++) {
-        if (src_buf_dim_to_tile_axis.count(i)) {
-          indices.push_back(interior_vars[src_buf_dim_to_tile_axis.at(i)]);
-        } else {
-          indices.push_back(make_zero(DataType::Int(32)));
-        }
-      }
-      return indices;
-    };
-
-    auto get_dst_indices = [&]() {
-      Array<PrimExpr> indices;
-      for (int i = 0; i < dst_ndim; i++) {
-        int src_dim = (this->dst->shape.size() == src_ndim)
-                          ? i
-                          : ((i < this->dim) ? i : i + 1);
-        if (dst_buf_dim_to_tile_axis.count(i)) {
-          int axis = dst_buf_dim_to_tile_axis.at(i);
-          indices.push_back(loop_vars[src_dim]->var * dst_tile_shape[axis] +
-                            dst_interior_vars_mapped[axis]);
-        } else {
-          if (this->dst->shape.size() == src_ndim && i == this->dim) {
-            indices.push_back(make_zero(this->dst->shape[i]->dtype));
-          } else {
-            indices.push_back(loop_vars[src_dim]->var);
-          }
-        }
-      }
-      return indices;
-    };
-
-    auto get_res_indices = [&]() {
-      Array<PrimExpr> indices;
-      for (int i = 0; i < dst_ndim; i++) {
-        if (dst_buf_dim_to_tile_axis.count(i)) {
-          indices.push_back(
-              dst_interior_vars_mapped[dst_buf_dim_to_tile_axis.at(i)]);
-        } else {
-          indices.push_back(make_zero(DataType::Int(32)));
-        }
-      }
-      return indices;
-    };
-
-    Array<PrimExpr> src_idx = get_src_indices();
-    Array<PrimExpr> acc_idx = get_acc_indices();
-    Array<PrimExpr> dst_idx = get_dst_indices();
-    Array<PrimExpr> res_idx = get_res_indices();
-
-    // Wraps a Stmt with interior loops (ki, kj, ...) representing element-wise
-    // execution of a Tile. The innermost loop is marked as vectorized.
-    auto wrap_interior = [&](Stmt b, const Array<Var> &i_vars,
-                             const Array<PrimExpr> &t_shape,
-                             const std::vector<int> &axes) {
-      for (int i = static_cast<int>(axes.size()) - 1; i >= 0; i--) {
-        int axis = axes[i];
-        ForKind kind = (i == static_cast<int>(axes.size()) - 1)
-                           ? ForKind::kVectorized
-                           : ForKind::kSerial;
-        For loop(i_vars[axis], 0, t_shape[axis], kind, b);
-        auto *n = loop.CopyOnWrite();
-        n->annotations.Set(attr::tile_interior, Integer(1));
-        n->annotations.Set(attr::tile_interior_axis, Integer(axis));
-        n->annotations.Set(attr::kTileLoopStage,
-                           Integer(static_cast<int>(TileLoopStage::kTiled)));
-        n->annotations.Set(attr::tiled_buffer, this->src->data);
-        b = loop;
-      }
-      return b;
-    };
-
-    std::vector<int> all_src_axes;
-    all_src_axes.reserve(src_tile_shape.size());
-    for (size_t i = 0; i < src_tile_shape.size(); i++)
-      all_src_axes.push_back(i);
-    std::vector<int> all_dst_axes;
-    all_dst_axes.reserve(dst_tile_shape.size());
-    for (size_t i = 0; i < dst_tile_shape.size(); i++)
-      all_dst_axes.push_back(i);
-
-    // Identify which interior axis corresponds to the reduction dimension.
-    int reduce_tile_axis = -1;
-    for (size_t i = 0; i < src_tile_shape.size(); i++) {
-      int dim_val = tv_src->IndexMap()[i].as<IntImmNode>()->value;
-      if (dim_val < 0)
-        dim_val += src_ndim;
-      if (dim_val == this->dim) {
-        reduce_tile_axis = i;
-      }
-    }
-
-    // Construct the reduction logic using a guarded multi-step process.
-    // This allows unifying spatial and reduction loops while maintaining
-    // correct Tile semantics.
-
-    // Step 1: Accumulate (Tile-to-Tile accumulation using element-wise
-    // operations)
-    Stmt accumulate_stmt =
-        BufferStore(acc,
-                    this->MakeReduce(BufferLoad(acc, acc_idx),
-                                     BufferLoad(this->src, src_idx)),
-                    acc_idx);
-    accumulate_stmt = wrap_interior(accumulate_stmt, interior_vars,
-                                    src_tile_shape, all_src_axes);
-
-    // Step 2: Init (Guarded: only run on the first step of the reduction loop)
-    Stmt init_stmt;
-    if (this->clear) {
-      init_stmt = BufferStore(acc, this->MakeInitValue(), acc_idx);
-    } else {
-      init_stmt = BufferStore(acc, BufferLoad(this->dst, dst_idx), acc_idx);
-    }
-    init_stmt =
-        wrap_interior(init_stmt, interior_vars, src_tile_shape, all_src_axes);
-
-    // Step 3: Finalize (Guarded: run on the last step of the reduction loop)
-    Stmt finalize_stmt;
-    if (is_dim_tiled) {
-      // If reducing along a tiled axis, we need a specialized in-tile
-      // reduction.
-      std::string in_tile_reduce_type;
-      if (this->type->isSum() || this->type->isAbsSum())
-        in_tile_reduce_type = "sum";
-      else if (this->type->isMax() || this->type->isAbsMax())
-        in_tile_reduce_type = "max";
-      else if (this->type->isMin())
-        in_tile_reduce_type = "min";
-      else
-        LOG(FATAL) << "Unsupported reduce type for Sunmmio";
-
-      // Direct write-back to Out_shared using BufferRegion to save memory and
-      // IR depth.
-      Array<Range> dst_ranges;
-      for (int i = 0; i < dst_ndim; i++) {
-        int src_dim = (this->dst->shape.size() == src_ndim)
-                          ? i
-                          : ((i < this->dim) ? i : i + 1);
-        if (dst_dim_to_tile_size.count(i)) {
-          PrimExpr min = loop_vars[src_dim]->var * dst_dim_to_tile_size[i];
-          dst_ranges.push_back(
-              Range::FromMinExtent(min, dst_dim_to_tile_size[i]));
-        } else {
-          dst_ranges.push_back(
-              Range::FromMinExtent(loop_vars[src_dim]->var, 1));
-        }
-      }
-      PrimExpr dst_region = MakeRegionExpr(this->dst, dst_ranges, 2);
-
-      Array<Range> acc_ranges;
-      for (int i = 0; i < src_ndim; i++) {
-        acc_ranges.push_back(Range::FromMinExtent(
-            make_zero(acc->shape[i]->dtype), acc->shape[i]));
-      }
-      PrimExpr acc_region = MakeRegionExpr(acc, acc_ranges, 1);
-
-      finalize_stmt =
-          Evaluate(Call(DataType::Handle(), vector_core_in_tile_reduce(),
-                        {StringImm(in_tile_reduce_type), dst_region, acc_region,
-                         IntImm(DataType::Int(32), reduce_tile_axis)}));
-    } else {
-      // If reduction is NOT along a tiled axis (e.g. Batch axis), 'acc' already
-      // holds the result.
-      Stmt store_stmt =
-          BufferStore(this->dst, BufferLoad(acc, acc_idx), dst_idx);
-      store_stmt = wrap_interior(store_stmt, interior_vars, src_tile_shape,
-                                 all_src_axes);
-      finalize_stmt = store_stmt;
-    }
-
-    Var rv = loop_vars[this->dim]->var;
-    PrimExpr r_extent = loop_vars[this->dim]->dom->extent;
-
-    // Combine steps into a single body with guards.
-    Stmt body = SeqStmt({IfThenElse(rv == 0, init_stmt), accumulate_stmt,
-                         IfThenElse(rv == r_extent - 1, finalize_stmt)});
-
-    // 6. Wrap with outer Tile Loops (Spatial and Reduction).
-    // IMPORTANT: For memory reuse of 'acc', the reduction loop MUST be the
-    // innermost.
-    Map<String, ObjectRef> base_annotations;
-    base_annotations.Set(attr::kTileLoopStage,
-                         Integer(static_cast<int>(TileLoopStage::kTiled)));
-    base_annotations.Set(attr::tiled_buffer, this->src->data);
-    base_annotations.Set(attr::tile_new_shape, tv_src->TiledBufferShape());
-    base_annotations.Set(attr::tile_tile_size, tv_src->TileShape());
-    base_annotations.Set(attr::tile_dim_map, tv_src->IndexMap());
-
-    // Identify the outermost tiled loop index to set 'tile.scope_entry'.
-    int outermost_tiled_idx = -1;
-    for (int i = 0; i < src_ndim; i++) {
-      if (i != this->dim && src_buf_dim_to_tile_axis.count(i)) {
-        outermost_tiled_idx = i;
-        break;
-      }
-    }
-    if (outermost_tiled_idx == -1 &&
-        src_buf_dim_to_tile_axis.count(this->dim)) {
-      outermost_tiled_idx = this->dim;
-    }
-
-    // Wrap the reduction loop first (innermost).
-    {
-      int i = this->dim;
-      Map<String, ObjectRef> loop_anno = base_annotations;
-      loop_anno.Set(attr::tile_level_loop,
-                    Integer(0)); // Reduction axis is serial.
-      if (src_buf_dim_to_tile_axis.count(i)) {
-        loop_anno.Set(attr::tile_execution_loop, Integer(1));
-      }
-      if (i == outermost_tiled_idx) {
-        loop_anno.Set(attr::tile_scope_entry, Integer(1));
-      }
-      body = For(loop_vars[i]->var, 0, loop_vars[i]->dom->extent,
-                 ForKind::kSerial, body, std::nullopt, loop_anno);
-    }
-
-    // Wrap spatial loops (outer loops).
-    for (int i = src_ndim - 1; i >= 0; i--) {
-      if (i == this->dim)
-        continue;
-      Map<String, ObjectRef> loop_anno = base_annotations;
-      loop_anno.Set(attr::tile_level_loop,
-                    Integer(1)); // Spatial axes are parallel.
-      if (src_buf_dim_to_tile_axis.count(i)) {
-        loop_anno.Set(attr::tile_execution_loop, Integer(1));
-      }
-      if (i == outermost_tiled_idx) {
-        loop_anno.Set(attr::tile_scope_entry, Integer(1));
-      }
-      body = For(loop_vars[i]->var, 0, loop_vars[i]->dom->extent,
-                 ForKind::kSerial, body, std::nullopt, loop_anno);
-    }
-
-    // Final wrap in a Block with TileView metadata for the 'acc' buffer.
-    TileView tv_acc = makeTileView(single_tile_acc_shape, tv_src->TileShape(),
-                                   tv_src->IndexMap());
-    Map<Var, TileView> new_tileview_map;
-    new_tileview_map.Set(acc->data, tv_acc);
-
-    body = Block({}, {}, {}, "reduce_tile_op", body, std::nullopt, {acc}, {},
-                 {{attr::kTileViewMap, new_tileview_map}});
-
-    return body;
+    return MakeSunmmioTileReduce(T, analyzer);
   }
 
   if (src_scope == "local.fragment" && dst_scope == "local.fragment") {

--- a/src/op/reduce.cc
+++ b/src/op/reduce.cc
@@ -293,6 +293,7 @@ Stmt ReduceOpNode::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
     // It has the same rank as 'src', but non-tiled dimensions are collapsed
     // to 1.
     Array<PrimExpr> single_tile_acc_shape;
+    single_tile_acc_shape.reserve(src_ndim);
     for (int i = 0; i < src_ndim; ++i) {
       if (src_dim_to_tile_size.count(i)) {
         single_tile_acc_shape.push_back(src_dim_to_tile_size[i]);
@@ -307,6 +308,7 @@ Stmt ReduceOpNode::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
     int dst_ndim = this->dst->shape.size();
     std::unordered_map<int, PrimExpr> dst_dim_to_tile_size;
     if (is_dim_tiled) {
+      single_tile_res_shape.reserve(dst_ndim);
       for (size_t i = 0; i < tv_dst->IndexMap().size(); i++) {
         const auto *idx_ptr = tv_dst->IndexMap()[i].as<IntImmNode>();
         ICHECK(idx_ptr);
@@ -336,6 +338,7 @@ Stmt ReduceOpNode::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
     // Create outer loop variables for each dimension of the source tensor.
     // Tiled dimensions will have extents = buffer_extent / tile_size.
     Array<IterVar> loop_vars;
+    loop_vars.reserve(src_ndim);
     for (int i = 0; i < src_ndim; i++) {
       PrimExpr extent = this->src->shape[i];
       if (src_dim_to_tile_size.count(i)) {
@@ -367,6 +370,7 @@ Stmt ReduceOpNode::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
     // inside a Tile.
     Array<Var> interior_vars;
     Array<PrimExpr> src_tile_shape = tv_src->TileShape();
+    interior_vars.reserve(src_tile_shape.size());
     for (size_t i = 0; i < src_tile_shape.size(); i++) {
       interior_vars.push_back(Var("k" + std::string{char('i' + i)}));
     }
@@ -375,6 +379,7 @@ Stmt ReduceOpNode::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
     // ensure coordinate consistency.
     Array<Var> dst_interior_vars_mapped;
     Array<PrimExpr> dst_tile_shape = tv_dst->TileShape();
+    dst_interior_vars_mapped.reserve(tv_dst->IndexMap().size());
     for (size_t i = 0; i < tv_dst->IndexMap().size(); i++) {
       int dst_dim_val = tv_dst->IndexMap()[i].as<IntImmNode>()->value;
       if (dst_dim_val < 0)
@@ -492,9 +497,11 @@ Stmt ReduceOpNode::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
     };
 
     std::vector<int> all_src_axes;
+    all_src_axes.reserve(src_tile_shape.size());
     for (size_t i = 0; i < src_tile_shape.size(); i++)
       all_src_axes.push_back(i);
     std::vector<int> all_dst_axes;
+    all_dst_axes.reserve(dst_tile_shape.size());
     for (size_t i = 0; i < dst_tile_shape.size(); i++)
       all_dst_axes.push_back(i);
 

--- a/src/op/reduce.h
+++ b/src/op/reduce.h
@@ -118,6 +118,9 @@ private:
   PrimExpr MakeReduce(const PrimExpr &acc, const PrimExpr &b) const;
   /// Generate codegen reducer string
   std::string MakeCodegenReducer() const;
+  /// Sunmmio Tile-based reduction logic
+  Stmt MakeSunmmioTileReduce(const LowerArgs &T,
+                             arith::Analyzer *analyzer) const;
 };
 
 /// Wrapper class for reduction operations

--- a/src/transform/loop_vectorize.cc
+++ b/src/transform/loop_vectorize.cc
@@ -176,7 +176,8 @@ public:
       vector_load_bits_max_ = initial_vector_size_ = loop_extent_vector_size_ =
           256;
     } else if (tvm::tl::TargetIsSunmmio(Target::Current(false))) {
-      vector_load_bits_max_ = vector_size_ = 1024;
+      vector_load_bits_max_ = initial_vector_size_ = loop_extent_vector_size_ =
+          1024;
     } else {
       vector_load_bits_max_ = initial_vector_size_ = loop_extent_vector_size_ =
           128;

--- a/src/transform/lower_tile_op.cc
+++ b/src/transform/lower_tile_op.cc
@@ -20,6 +20,7 @@
 #include "../op/operator.h"
 #include "../op/utils.h"
 #include "../target/utils.h"
+#include "../tileview/tileview.h"
 #include "common/remap_buffer_rewriter.h"
 
 #include "arith/ir_mutator_with_analyzer.h"
@@ -173,6 +174,11 @@ private:
         }
         layout_map_.Set(buffer, layout);
       }
+    }
+    if (op->annotations.count(attr::kTileViewMap)) {
+      tileview_map_ = op->annotations.at(attr::kTileViewMap)
+                          .as<Map<Var, TileView>>()
+                          .value();
     }
     // Read global layout map separately — these are read-only metadata
     // and must NOT be processed through makeBufferWithLayout/Forward.
@@ -932,11 +938,11 @@ private:
       let_var_to_expr.Set(var, expr);
     }
 
-    auto lowered =
-        tile_op->Lower(LowerArgs{target_, thread_bounds, thread_var_->var,
-                                 callback, layout_map_, buffer_remap_,
-                                 let_var_to_expr, global_layout_map_},
-                       analyzer_);
+    auto lowered = tile_op->Lower(
+        LowerArgs{target_, thread_bounds, thread_var_->var, callback,
+                  layout_map_, buffer_remap_, let_var_to_expr,
+                  global_layout_map_, tileview_map_},
+        analyzer_);
     return IRMutatorWithAnalyzer::VisitStmt(lowered);
   }
 
@@ -1139,6 +1145,7 @@ private:
   Map<Buffer, Layout> layout_remap_;
   Map<Buffer, Buffer> buffer_remap_;
   Map<Buffer, Layout> global_layout_map_;
+  Map<Var, TileView> tileview_map_;
   // This is a workaround for cpu backend,
   // we need to define a thread_var for the serial loop.
   IterVar thread_var_ = IterVar(Range::FromMinExtent(0, 1), Var("v_thread"),

--- a/src/transform/lower_tile_op.cc
+++ b/src/transform/lower_tile_op.cc
@@ -176,9 +176,12 @@ private:
       }
     }
     if (op->annotations.count(attr::kTileViewMap)) {
-      tileview_map_ = op->annotations.at(attr::kTileViewMap)
-                          .as<Map<Var, TileView>>()
-                          .value();
+      auto new_map = op->annotations.at(attr::kTileViewMap)
+                         .as<Map<Var, TileView>>()
+                         .value();
+      for (auto [k, v] : new_map) {
+        tileview_map_.Set(k, v);
+      }
     }
     // Read global layout map separately — these are read-only metadata
     // and must NOT be processed through makeBufferWithLayout/Forward.

--- a/testing/python/ops/test_tilelang_ops_sunmmio_fill.py
+++ b/testing/python/ops/test_tilelang_ops_sunmmio_fill.py
@@ -1,0 +1,160 @@
+import tilelang
+import tilelang.language as T
+from tilelang import tvm as tvm
+from tilelang.tileview import make_tileview
+from tilelang.utils.target import SUNMMIO_TARGET_DESC
+import pytest
+
+tilelang.env.disable_cache()
+
+
+def apply_sunmmio_passes(mod, target):
+    """Apply the full SUNMMIO pass pipeline used for Fill lowering."""
+    mod = tvm.tir.transform.BindTarget(target)(mod)
+    mod = tilelang.transform.AddWrapperForSingleBufStore()(mod)
+    mod = tilelang.transform.LegalizeNegativeIndex()(mod)
+    mod = tilelang.transform.InjectAssumes()(mod)
+    mod = tilelang.transform.Simplify()(mod)
+    mod = tilelang.transform.InferSramScope()(mod)
+    mod = tilelang.transform.LayoutReducer()(mod)
+    mod = tilelang.transform.LayoutInference()(mod)
+    mod = tilelang.transform.LowerTileOp()(mod)
+    mod = tilelang.transform.LegalizeTilesLoop()(mod)
+    mod = tilelang.transform.TilesLoop()(mod)
+    return mod
+
+
+def fill_kernel(B, M, N, block_B, block_M, block_N, tile_size, index_map, dtype="float16"):
+    @T.prim_func
+    def main(A: T.Tensor((B, M, N), dtype)):
+        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), T.ceildiv(B, block_B), threads=128) as (bx, by, bz):
+            A_shared = T.alloc_shared((block_B, block_M, block_N), dtype)
+            # Annotate tileview for the shared buffer
+            T.annotate_tileview({A_shared: make_tileview(A_shared, tile_size, index_map)})
+
+            # 1. Fill the entire buffer -> value 1.0
+            T.fill(A_shared, T.float16(1.0))
+
+            # 2. Fill a region of the buffer -> value 2.0
+            # Region: First half of M dimension
+            T.fill(A_shared[0:block_B, 0 : block_M // 2, 0:block_N], T.float16(2.0))
+
+            # 3. Fill a region with offset -> value 3.0
+            # Region: Second half of M dimension
+            T.fill(A_shared[0:block_B, block_M // 2 : block_M, 0:block_N], T.float16(3.0))
+
+            # 4. Clear the buffer -> value 0.0
+            T.clear(A_shared)
+
+            # Dummy output to prevent dead code elimination if we were to go further,
+            # but for LowerTileOp check it is not strictly necessary.
+            # We add a dma_copy just to match the user's provided example structure which had a copy.
+            T.copy(A_shared, A[bz * block_B : (bz + 1) * block_B, by * block_M : (by + 1) * block_M, bx * block_N : (bx + 1) * block_N])
+
+    return tvm.IRModule({"main": main})
+
+
+@tvm.tir.functor.visitor
+class LoopNestChecker(tvm.tir.PyStmtExprVisitor):
+    def __init__(self, target_buffer_name="A_shared"):
+        super().__init__()
+        self.target_buffer_name = target_buffer_name
+        self.max_loop_depth = 0
+        self.current_loop_depth = 0
+        self.found_5_layer_loop = False
+
+    def visit_for_(self, op):
+        self.current_loop_depth += 1
+        self.visit_stmt(op.body)
+        self.current_loop_depth -= 1
+
+    def visit_buffer_store_(self, op):
+        if op.buffer.name.startswith(self.target_buffer_name):
+            # Check if we are inside a 5-layer loop nest
+            # The 5 layers are: 3 tiled loops + 1 inner loop + 1 vectorized loop
+            if self.current_loop_depth == 5:
+                self.found_5_layer_loop = True
+            # Update max depth just in case
+            self.max_loop_depth = max(self.max_loop_depth, self.current_loop_depth)
+
+
+def fill_kernel_config(B, M, N, block_B, block_M, block_N, tile_size, index_map, fill_type="full", dtype="float16"):
+    @T.prim_func
+    def main(A: T.Tensor((B, M, N), dtype)):
+        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), T.ceildiv(B, block_B), threads=128) as (bx, by, bz):
+            A_shared = T.alloc_shared((block_B, block_M, block_N), dtype)
+            # Annotate tileview for the shared buffer
+            T.annotate_tileview({A_shared: make_tileview(A_shared, tile_size, index_map)})
+
+            if fill_type == "full":
+                T.fill(A_shared, T.float16(1.0))
+            elif fill_type == "region_first_half":
+                # Fill first half of M dimension
+                T.fill(A_shared[0:block_B, 0 : block_M // 2, 0:block_N], T.float16(2.0))
+            elif fill_type == "region_second_half":
+                # Fill second half of M dimension
+                T.fill(A_shared[0:block_B, block_M // 2 : block_M, 0:block_N], T.float16(3.0))
+            elif fill_type == "clear":
+                T.clear(A_shared)
+
+            # Dummy output
+            T.copy(A_shared, A[bz * block_B : (bz + 1) * block_B, by * block_M : (by + 1) * block_M, bx * block_N : (bx + 1) * block_N])
+
+    return tvm.IRModule({"main": main})
+
+
+FILL_TEST_CASES = [
+    ("full", 1.0),
+    ("region_first_half", 2.0),
+    ("region_second_half", 3.0),
+    ("clear", 0.0),
+]
+
+
+@pytest.mark.parametrize("fill_type, expected_val", FILL_TEST_CASES)
+@pytest.mark.parametrize("dtype", ["float16"])
+def test_tilelang_fill_sunmmio(fill_type, expected_val, dtype):
+    # Parameters
+    B, M, N = 64, 512, 1024
+    block_B, block_M, block_N = 16, 256, 128
+    tile_size = (32, 32)
+    index_map = (-2, -1)
+
+    target = tvm.target.Target(SUNMMIO_TARGET_DESC)
+    mod = fill_kernel_config(B, M, N, block_B, block_M, block_N, tile_size, index_map, fill_type=fill_type, dtype=dtype)
+
+    with tvm.target.Target(target):
+        mod = apply_sunmmio_passes(mod, target)
+
+    script = mod.script()
+    assert "tl.tileop.fill" not in script, "tl.tileop.fill should be lowered"
+
+    # Check for loop nest depth
+    checker = LoopNestChecker()
+    checker.visit_stmt(mod["main"].body)
+
+    # All fill operations (full, region, clear) should be tiled
+    assert checker.found_5_layer_loop, (
+        f"Expected 5-layer nested loop for fill type {fill_type}, but found max depth {checker.max_loop_depth}"
+    )
+
+    # Verify the specific value is stored
+    # Simplified check as per user suggestion
+    if expected_val == 0.0:
+        # T.clear() typically lowers to T.float16(0.0) or T.float16(0) or T.Cast("float16", 0)
+        expected_patterns = ["T.float16(0.0)", "T.float16(0)", 'T.Cast("float16", 0)']
+    else:
+        # For non-zero values
+        val_int = int(expected_val)
+        if expected_val == val_int:
+            # e.g. 1.0 -> T.float16(1) or T.float16(1.0)
+            expected_patterns = [f"T.float16({val_int})", f"T.float16({expected_val})"]
+        else:
+            expected_patterns = [f"T.float16({expected_val})"]
+
+    found = any(pattern in script for pattern in expected_patterns)
+    assert found, f"Should find store of {expected_val} for fill type {fill_type}. Looked for: {expected_patterns}"
+
+
+if __name__ == "__main__":
+    test_tilelang_fill_sunmmio("float16")

--- a/testing/python/ops/test_tilelang_ops_sunmmio_reduce.py
+++ b/testing/python/ops/test_tilelang_ops_sunmmio_reduce.py
@@ -1,0 +1,141 @@
+import tilelang
+import tilelang.language as T
+from tilelang import tvm as tvm
+from tilelang.tileview import make_tileview
+from tilelang.utils.target import SUNMMIO_TARGET_DESC
+import pytest
+
+tilelang.env.disable_cache()
+
+
+def apply_sunmmio_passes(mod, target):
+    """Apply the SUNMMIO pass pipeline used for Reduce lowering."""
+    mod = tvm.tir.transform.BindTarget(target)(mod)
+    mod = tilelang.transform.AddWrapperForSingleBufStore()(mod)
+    mod = tilelang.transform.LegalizeNegativeIndex()(mod)
+    mod = tilelang.transform.InjectAssumes()(mod)
+    mod = tilelang.transform.Simplify()(mod)
+    mod = tilelang.transform.InferSramScope()(mod)
+    mod = tilelang.transform.LayoutReducer()(mod)
+    mod = tilelang.transform.LayoutInference()(mod)
+    mod = tilelang.transform.LowerTileOp()(mod)
+    return mod
+
+
+@tvm.tir.functor.visitor
+class ReduceIRChecker(tvm.tir.PyStmtExprVisitor):
+    def __init__(self, target_buffer_name="Out_shared"):
+        super().__init__()
+        self.target_buffer_name = target_buffer_name
+        self.max_loop_depth = 0
+        self.current_loop_depth = 0
+        self.found_ktiled_stage = True
+        self.has_in_tile_reduce = False
+        self.scope_entry_count = 0
+        self.execution_loop_count = 0
+
+    def visit_for_(self, op):
+        self.current_loop_depth += 1
+        self.max_loop_depth = max(self.max_loop_depth, self.current_loop_depth)
+
+        ann = op.annotations
+        if ann:
+            if "tile.loop_stage" in ann and ann["tile.loop_stage"] != 2:
+                self.found_ktiled_stage = False
+
+            if ann.get("tile.scope_entry", 0) == 1:
+                self.scope_entry_count += 1
+            if ann.get("tile.execution", 0) == 1:
+                self.execution_loop_count += 1
+
+        self.visit_stmt(op.body)
+        self.current_loop_depth -= 1
+
+    def visit_call_(self, op):
+        if op.op.name == "tl.vector_core_in_tile_reduce":
+            self.has_in_tile_reduce = True
+        super().visit_call_(op)
+
+
+def reduce_kernel_builder(rank, shape, tile_size, index_map, reduce_axis, dtype="float16"):
+    out_shape = list(shape[:reduce_axis]) + list(shape[reduce_axis + 1 :])
+    if not out_shape:  # Handle scalar reduction case
+        out_shape = [1]
+
+    # Pre-calculate output tileview info outside T.prim_func
+    out_tile_size = []
+    out_index_map = []
+    for i, axis in enumerate(index_map):
+        if axis == reduce_axis:
+            continue
+        out_tile_size.append(tile_size[i])
+        if axis > reduce_axis:
+            out_index_map.append(axis - 1)
+        else:
+            out_index_map.append(axis)
+
+    @T.prim_func
+    def main(A: T.Tensor(shape, dtype), Out: T.Tensor(out_shape, dtype)):
+        with T.Kernel(1, threads=128) as (bx,):
+            # For Sunmmio, src and dst must be in shared.rsram for vector core operations
+            A_shared = T.alloc_shared(shape, dtype, scope="shared.rsram")
+            Out_shared = T.alloc_shared(out_shape, dtype, scope="shared.rsram")
+
+            T.annotate_tileview({A_shared: make_tileview(A_shared, tile_size, index_map)})
+            T.annotate_tileview({Out_shared: make_tileview(Out_shared, out_tile_size, out_index_map)})
+
+            T.copy(A, A_shared)
+            T.reduce_sum(A_shared, Out_shared, dim=reduce_axis)
+            T.copy(Out_shared, Out)
+
+    return tvm.IRModule({"main": main})
+
+
+# (Rank, Shape, TileSize, IndexMap, ReduceAxis, ExpectedDepth, ExpectedInTileReduce)
+# For Sunmmio, all dimensions should be multiples of 32 for simplicity in these tests.
+REDUCE_TEST_CASES = [
+    # 1D (Using asram)
+    (1, (1024,), (32,), (0,), 0, 2, True),
+    # 2D (Used as 1D equivalent: reducing last dim of a 2D tensor)
+    (2, (32, 1024), (32,), (1,), 1, 3, True),
+    # 2D
+    (2, (128, 128), (32, 32), (0, 1), 1, 4, True),
+    (2, (128, 128), (32, 32), (0, 1), 0, 4, True),
+    # 3D
+    (3, (32, 128, 128), (32, 32), (1, 2), 2, 5, True),
+    (3, (32, 128, 128), (32, 32), (1, 2), 1, 5, True),
+    (3, (32, 128, 128), (32, 32), (1, 2), 0, 5, False),
+    # 4D
+    (4, (32, 32, 128, 128), (32, 32), (2, 3), 3, 6, True),
+    (4, (32, 32, 128, 128), (32, 32), (2, 3), 1, 6, False),
+    # 5D
+    (5, (32, 32, 32, 128, 128), (32, 32), (3, 4), 4, 7, True),
+    (5, (32, 32, 32, 128, 128), (32, 32), (3, 4), 0, 7, False),
+]
+
+
+@pytest.mark.parametrize("rank, shape, tile_size, index_map, reduce_axis, expected_depth, expected_in_tile", REDUCE_TEST_CASES)
+def test_tilelang_reduce_sunmmio(rank, shape, tile_size, index_map, reduce_axis, expected_depth, expected_in_tile):
+    target = tvm.target.Target(SUNMMIO_TARGET_DESC)
+    mod = reduce_kernel_builder(rank, shape, tile_size, index_map, reduce_axis)
+
+    with tvm.target.Target(target):
+        mod = apply_sunmmio_passes(mod, target)
+
+    checker = ReduceIRChecker()
+    checker.visit_stmt(mod["main"].body)
+
+    assert checker.found_ktiled_stage, "All loops in the reduction block should have tile.loop_stage == 2"
+    assert checker.max_loop_depth == expected_depth, f"Expected depth {expected_depth}, but found {checker.max_loop_depth} for rank {rank}"
+
+    if expected_in_tile:
+        assert checker.has_in_tile_reduce, "Expected vector_core_in_tile_reduce intrinsic but not found"
+    else:
+        assert not checker.has_in_tile_reduce, "Did not expect vector_core_in_tile_reduce intrinsic but found it"
+
+    assert checker.scope_entry_count >= 1, "Missing tile.scope_entry annotation"
+    assert checker.execution_loop_count >= len(tile_size), "Missing tile.execution annotation"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tilelang/language/reduce_op.py
+++ b/tilelang/language/reduce_op.py
@@ -1,22 +1,29 @@
+"""Reduce operations exposed on the TileLang language surface."""
+
+from __future__ import annotations
+from typing import Literal
+from tilelang._typing import BufferLikeType
 from tvm import tir
 from tvm.target import Target
-from tilelang.language import copy, macro, alloc_fragment
-from tilelang.utils.language import to_buffer_region, is_shared, is_fragment
+from tilelang.language import copy, macro, alloc_shared, alloc_fragment
+from tilelang.utils.language import to_buffer_region, retrieve_shape, _get_buffer
+from tilelang.utils.language import is_shared, is_fragment
 from tilelang.utils.target import target_is_sunmmio
 from tvm.script.ir_builder import IRBuilder
 
 
-class ReduceKind:
-    Sum = "sum"
-    Max = "max"
-    Min = "min"
-    AbsSum = "abssum"
-    AbsMax = "absmax"
+def _legalize_dim(buffer: tir.Buffer, dim: int):
+    if dim < 0:
+        dim = len(buffer.shape) + dim
+    return dim
 
 
 _REDUCE_OP_KEY = "tl.tileop.reduce"
 
+ReduceKind = Literal["sum", "abssum", "max", "absmax", "min", "bitand", "bitor", "bitxor"]
 
+
+# NOTE(chaofan): T.reduce is implemented as a macro, so no return
 def reduce(buffer: tir.Buffer, out: tir.Buffer, reduce_type: ReduceKind, dim: int, clear: bool) -> None:
     """Perform a reduction operation on a buffer along a specified dimension.
 
@@ -27,19 +34,14 @@ def reduce(buffer: tir.Buffer, out: tir.Buffer, reduce_type: ReduceKind, dim: in
         dim (int): Dimension along which to perform reduction
         clear (bool): Whether to initialize the output buffer before reduction
     """
-
-    # Relaxed shape check: ignore dimensions of size 1
-    def _get_filtered_shape(shape):
-        return [int(x) for x in shape if int(x) != 1]
-
-    buffer_filtered = _get_filtered_shape(buffer.shape)
-    out_filtered = _get_filtered_shape(out.shape)
-
-    # After filtering 1s, the rank should decrease by 1 if the reduced dimension was not 1.
-    # If the reduced dimension was 1, the rank remains the same after filtering.
-    # This is a very loose check.
-    if len(buffer_filtered) - len(out_filtered) not in [0, 1]:
-        raise ValueError(f"Invalid reduce output shape, buffer shape is {buffer.shape}, dim is {dim}, output shape is {out.shape}")
+    # input shape: [X, d, Y], expected output shape: [X, Y] or [X, 1, Y]
+    expected_shapes = [buffer.shape[:dim] + buffer.shape[dim + 1 :], buffer.shape[:dim] + [1] + buffer.shape[dim + 1 :]]
+    if list(out.shape) not in expected_shapes:
+        expected_shapes_str = " or ".join(map(str, expected_shapes))
+        raise ValueError(
+            f"Invalid reduce output shape, buffer shape is {buffer.shape}, dim is {dim}, "
+            f"output shape is {out.shape}, expected shapes are {expected_shapes_str}"
+        )
 
     @macro
     def reduce_macro(buffer: tir.Buffer, out: tir.Buffer, reduce_type: str, dim: int, clear: bool) -> None:
@@ -125,78 +127,364 @@ def reduce(buffer: tir.Buffer, out: tir.Buffer, reduce_type: ReduceKind, dim: in
         else:
             raise ValueError(f"Invalid buffer scopes: {buffer.scope()} and {out.scope()}")
 
-    return reduce_macro(buffer, out, reduce_type, dim, clear)
+    reduce_macro(buffer, out, reduce_type, dim, clear)
 
 
-def reduce_sum(buffer: tir.Buffer, out: tir.Buffer, dim: int, clear: bool = True) -> None:
-    reduce(buffer, out, "sum", dim, clear)
+def reduce_max(buffer: tir.Buffer, out: tir.Buffer, dim: int = -1, clear: bool = True) -> None:
+    """Perform reduce max on input buffer, store the result to output buffer
 
-
-def reduce_max(buffer: tir.Buffer, out: tir.Buffer, dim: int, clear: bool = True) -> None:
+    Parameters
+    ----------
+    buffer : Buffer
+        The input buffer.
+    out : Buffer
+        The output buffer.
+    dim : int
+        The dimension to perform reduce on
+    clear : bool
+        If set to True, the output buffer will first be initialized to -inf.
+    Returns
+    -------
+    handle : PrimExpr
+    """
+    dim = _legalize_dim(buffer, dim)
     reduce(buffer, out, "max", dim, clear)
 
 
-def reduce_min(buffer: tir.Buffer, out: tir.Buffer, dim: int, clear: bool = True) -> None:
+def reduce_min(buffer: tir.Buffer, out: tir.Buffer, dim: int = -1, clear: bool = True) -> None:
+    """Perform reduce min on input buffer, store the result to output buffer.
+
+    Args:
+        buffer (tir.Buffer): The input buffer
+        out (tir.Buffer): The output buffer
+        dim (int): The dimension to perform reduce on
+        clear (bool, optional): If True, output buffer will be initialized to inf. Defaults to True.
+
+    Returns:
+        tir.Call: Handle to the reduction operation
+    """
+    dim = _legalize_dim(buffer, dim)
     reduce(buffer, out, "min", dim, clear)
 
 
-def reduce_abssum(buffer: tir.Buffer, out: tir.Buffer, dim: int, clear: bool = True) -> None:
-    reduce(buffer, out, "abssum", dim, clear)
+def reduce_sum(buffer: tir.Buffer, out: tir.Buffer, dim: int = -1, clear: bool = True) -> None:
+    """Perform reduce sum on input buffer, store the result to output buffer.
+
+    Args:
+        buffer (tir.Buffer): The input buffer
+        out (tir.Buffer): The output buffer
+        dim (int): The dimension to perform reduce on
+        clear (bool, optional): If True, output buffer will be cleared before reduction.
+                              If False, results will be accumulated on existing values.
+                              Defaults to True.
+    Note: When clear=True, reduce_sum will not compute directly on the output buffer. This is because
+          during warp reduction, the same value would be accumulated multiple times (number of threads
+          in the warp). Therefore, the implementation with clear=True follows these steps:
+        1. create a temp buffer with same shape and dtype as out
+        2. copy out to temp buffer
+        3. call reduce_sum with temp buffer and out
+        4. Add temp buffer to out
+
+    Returns:
+        tir.Call: Handle to the reduction operation
+    """
+    dim = _legalize_dim(buffer, dim)
+    reduce(buffer, out, "sum", dim, clear)
 
 
-def reduce_absmax(buffer: tir.Buffer, out: tir.Buffer, dim: int, clear: bool = True) -> None:
+def reduce_abssum(buffer: tir.Buffer, out: tir.Buffer, dim: int = -1) -> None:
+    """Perform reduce absolute sum on input buffer, store the result to output buffer.
+
+    Args:
+        buffer (tir.Buffer): The input buffer
+        out (tir.Buffer): The output buffer
+        dim (int): The dimension to perform reduce on
+
+    Returns:
+        tir.Call: Handle to the reduction operation
+    """
+    dim = _legalize_dim(buffer, dim)
+    reduce(buffer, out, "abssum", dim, True)
+
+
+def reduce_absmax(buffer: tir.Buffer, out: tir.Buffer, dim: int = -1, clear: bool = True) -> None:
+    """Perform reduce absolute max on input buffer, store the result to output buffer.
+
+    Args:
+        buffer (tir.Buffer): The input buffer
+        out (tir.Buffer): The output buffer
+        dim (int): The dimension to perform reduce on
+
+    Returns:
+        tir.Call: Handle to the reduction operation
+    """
+    dim = _legalize_dim(buffer, dim)
     reduce(buffer, out, "absmax", dim, clear)
 
 
-def reduce_bitand(buffer: tir.Buffer, out: tir.Buffer, dim: int, clear: bool = True) -> None:
+def reduce_bitand(buffer: tir.Buffer, out: tir.Buffer, dim: int = -1, clear: bool = True) -> None:
+    """Perform reduce bitwise-and on input buffer, store the result to output buffer.
+
+    Args:
+        buffer (tir.Buffer): The input buffer
+        out (tir.Buffer): The output buffer
+        dim (int): The dimension to perform reduce on
+
+    Returns:
+        tir.Call: Handle to the reduction operation
+    """
+    dim = _legalize_dim(buffer, dim)
     reduce(buffer, out, "bitand", dim, clear)
 
 
-def reduce_bitor(buffer: tir.Buffer, out: tir.Buffer, dim: int, clear: bool = True) -> None:
+def reduce_bitor(buffer: tir.Buffer, out: tir.Buffer, dim: int = -1, clear: bool = True) -> None:
+    """Perform reduce bitwise-or on input buffer, store the result to output buffer.
+
+    Args:
+        buffer (tir.Buffer): The input buffer
+        out (tir.Buffer): The output buffer
+        dim (int): The dimension to perform reduce on
+
+    Returns:
+        tir.Call: Handle to the reduction operation
+    """
+    dim = _legalize_dim(buffer, dim)
     reduce(buffer, out, "bitor", dim, clear)
 
 
-def reduce_bitxor(buffer: tir.Buffer, out: tir.Buffer, dim: int, clear: bool = True) -> None:
+def reduce_bitxor(buffer: tir.Buffer, out: tir.Buffer, dim: int = -1, clear: bool = True) -> None:
+    """Perform reduce bitwise-xor on input buffer, store the result to output buffer.
+
+    Args:
+        buffer (tir.Buffer): The input buffer
+        out (tir.Buffer): The output buffer
+        dim (int): The dimension to perform reduce on
+
+    Returns:
+        tir.Call: Handle to the reduction operation
+    """
+    dim = _legalize_dim(buffer, dim)
     reduce(buffer, out, "bitxor", dim, clear)
 
 
 @macro
-def cumsum(buffer: tir.Buffer, out: tir.Buffer, dim: int, reverse: bool = False) -> None:
+def cumsum_fragment(
+    src: BufferLikeType,
+    dst: BufferLikeType,
+    dim: int,
+    reverse: bool,
+) -> None:
+    """
+    Compute cumulative sum for fragment buffers by copying to shared memory first.
+
+    This macro handles cumulative sum operations on fragment buffers by first copying
+    the data to shared memory, performing the cumsum operation, and then copying back.
+
+    Args:
+        src: Source buffer (Buffer, BufferRegion, or BufferLoad) containing input data.
+        dst: Destination buffer (Buffer, BufferRegion, or BufferLoad) for output data.
+        dim: Dimension along which to compute cumulative sum.
+        reverse: If True, compute cumulative sum in reverse order.
+    """
+    src_shape = retrieve_shape(src)
+    src_buffer = _get_buffer(src)
+    # Get dtype from the buffer
+    if isinstance(src, tir.Buffer):
+        dtype = src.dtype
+    else:
+        dtype = src_buffer.dtype
+    cumsum_smem = alloc_shared(src_shape, dtype, "shared.dyn")
+    copy(src, cumsum_smem)
     tir.call_intrin(
         "handle",
         tir.op.Op.get("tl.tileop.cumsum"),
-        to_buffer_region(buffer, access_type="r"),
-        to_buffer_region(out, access_type="w"),
+        to_buffer_region(cumsum_smem, access_type="r"),
+        to_buffer_region(cumsum_smem, access_type="w"),
+        dim,
+        reverse,
+    )
+    copy(cumsum_smem, dst)
+
+
+# NOTE(chaofan): T.cumsum returns None if it goes to macro implementations
+def cumsum(
+    src: BufferLikeType,
+    dst: BufferLikeType | None = None,
+    dim: int = 0,
+    reverse: bool = False,
+) -> tir.PrimExpr | None:
+    """
+    Compute the cumulative sum of `src` along `dim`, writing results to `dst`.
+
+    Negative `dim` indices are normalized (Python-style). If `dst` is None, the operation is performed in-place into `src`. Raises ValueError when `dim` is out of bounds for `src.shape`. When `src.scope() == "local.fragment"`, this delegates to `cumsum_fragment`; otherwise it emits the `tl.cumsum` intrinsic.
+
+    Supports Buffer, BufferRegion, and BufferLoad inputs, allowing operations on buffer slices/regions.
+
+    Examples:
+        A 1D inclusive scan that writes the result into a separate shared-memory buffer:
+
+        >>> import tilelang.language as T
+        >>> @T.prim_func
+        ... def kernel(A: T.Tensor((128,), "float32"), B: T.Tensor((128,), "float32")):
+        ...     with T.Kernel(1, threads=128):
+        ...         A_shared = T.alloc_shared((128,), "float32")
+        ...         T.copy(A, A_shared)
+        ...         T.cumsum(src=A_shared, dst=A_shared, dim=0)
+        ...         T.copy(A_shared, B)
+
+        A 2D prefix sum along the last dimension with reverse accumulation:
+
+        >>> import tilelang.language as T
+        >>> @T.prim_func
+        ... def kernel2d(A: T.Tensor((64, 64), "float16"), B: T.Tensor((64, 64), "float16")):
+        ...     with T.Kernel(1, 1, threads=256):
+        ...         tile = T.alloc_shared((64, 64), "float16")
+        ...         T.copy(A, tile)
+        ...         T.cumsum(src=tile, dim=1, reverse=True)
+        ...         T.copy(tile, B)
+
+        Operating on a buffer region (slice):
+
+        >>> import tilelang.language as T
+        >>> @T.prim_func
+        ... def kernel_region(InputG_fragment: T.Tensor((128,), "float32"), chunk_size: T.int32):
+        ...     with T.Kernel(1, threads=128):
+        ...         i = T.int32(0)
+        ...         T.cumsum(InputG_fragment[i * chunk_size:(i + 1) * chunk_size], dim=0)
+
+    Returns:
+        tir.Call: A handle to the emitted cumulative-sum operation.
+    """
+
+    # Get shape from src (supports Buffer, BufferRegion, BufferLoad)
+    shape = retrieve_shape(src)
+    if dim >= len(shape) or dim < -len(shape):
+        raise ValueError(f"Dimension {dim} is out of bounds for buffer with shape {shape}")
+    if dim < 0:
+        dim = len(shape) + dim
+
+    if dst is None:
+        dst = src
+    else:
+        # Validate that dst shape matches src shape
+        dst_shape = retrieve_shape(dst)
+        if len(dst_shape) != len(shape):
+            raise ValueError(f"cumsum dst shape {dst_shape} must match src shape {shape} (rank mismatch)")
+        # Check each dimension matches
+        for i in range(len(shape)):
+            if not tir.analysis.expr_deep_equal(dst_shape[i], shape[i]):
+                raise ValueError(f"cumsum dst shape {dst_shape} must match src shape {shape} (dim {i} mismatch)")
+
+    # Check if src is a fragment buffer
+    if is_fragment(src):
+        cumsum_fragment(src, dst, dim, reverse)
+        return
+
+    return tir.call_intrin(
+        "handle",
+        tir.op.Op.get("tl.tileop.cumsum"),
+        to_buffer_region(src, access_type="r"),
+        to_buffer_region(dst, access_type="w"),
         dim,
         reverse,
     )
 
 
-@macro
-def finalize_reducer(buffer: tir.Buffer, out: tir.Buffer) -> None:
-    tir.call_intrin(
+def finalize_reducer(reducer: tir.Buffer) -> tir.PrimExpr:
+    """
+    Finalize a reducer buffer by emitting the `tl.tileop.finalize_reducer` intrinsic.
+
+    This returns a TVM `tir.Call` handle that finalizes the given reducer using its writable pointer.
+    The call does not modify Python objects directly; it produces the low-level intrinsic call used by the IR.
+
+    Parameters:
+        reducer (tir.Buffer): Reducer buffer whose writable pointer will be finalized.
+
+    Returns:
+        tir.Call: Handle to the finalize reducer intrinsic call.
+    """
+    return tir.call_intrin(
         "handle",
         tir.op.Op.get("tl.tileop.finalize_reducer"),
-        to_buffer_region(buffer, access_type="r"),
-        to_buffer_region(out, access_type="w"),
+        to_buffer_region(reducer, access_type="w"),
     )
 
 
-def warp_reduce_sum(buffer: tir.Buffer) -> None:
-    tir.call_intrin("handle", tir.op.Op.get("tl.warp_reduce_sum"), buffer)
+def warp_reduce_sum(value: tir.PrimExpr) -> tir.PrimExpr:
+    """Perform warp reduction sum on a register value.
+
+    This function reduces a value across all threads in a warp using shuffle operations.
+    Each thread provides a  register `value`, and after the reduction, all threads
+    will have the sum of all values across the warp.
+
+    Args:
+        value (tir.PrimExpr): The input register value to reduce
+
+    Returns:
+        tir.PrimExpr: The reduced sum value (same on all threads in the warp)
+    """
+    return tir.call_intrin(value.dtype, tir.op.Op.get("tl.warp_reduce_sum"), value)
 
 
-def warp_reduce_max(buffer: tir.Buffer) -> None:
-    tir.call_intrin("handle", tir.op.Op.get("tl.warp_reduce_max"), buffer)
+def warp_reduce_max(value: tir.PrimExpr) -> tir.PrimExpr:
+    """Perform warp reduction max on a register value.
+
+    This function reduces a value across all threads in a warp using shuffle operations.
+    Each thread provides a  register `value`, and after the reduction, all threads
+    will have the max of all values across the warp.
+
+    Args:
+        value (tir.PrimExpr): The input register value to reduce
+
+    Returns:
+        tir.PrimExpr: The reduced max value (same on all threads in the warp)
+    """
+    return tir.call_intrin(value.dtype, tir.op.Op.get("tl.warp_reduce_max"), value)
 
 
-def warp_reduce_min(buffer: tir.Buffer) -> None:
-    tir.call_intrin("handle", tir.op.Op.get("tl.warp_reduce_min"), buffer)
+def warp_reduce_min(value: tir.PrimExpr) -> tir.PrimExpr:
+    """Perform warp reduction min on a register value.
+
+    This function reduces a value across all threads in a warp using shuffle operations.
+    Each thread provides a  register `value`, and after the reduction, all threads
+    will have the min of all values across the warp.
+
+    Args:
+        value (tir.PrimExpr): The input register value to reduce
+
+    Returns:
+        tir.PrimExpr: The reduced min value (same on all threads in the warp)
+    """
+    return tir.call_intrin(value.dtype, tir.op.Op.get("tl.warp_reduce_min"), value)
 
 
-def warp_reduce_bitand(buffer: tir.Buffer) -> None:
-    tir.call_intrin("handle", tir.op.Op.get("tl.warp_reduce_bitand"), buffer)
+def warp_reduce_bitand(value: tir.PrimExpr) -> tir.PrimExpr:
+    """Perform warp reduction bitwise-and on a register value.
+
+    This function reduces a value across all threads in a warp using shuffle operations.
+    Each thread provides a  register `value`, and after the reduction, all threads
+    will have the bitwise-and of all values across the warp.
+
+    Args:
+        value (tir.PrimExpr): The input register value to reduce
+
+    Returns:
+        tir.PrimExpr: The reduced bitwise-and value (same on all threads in the warp)
+    """
+    return tir.call_intrin(value.dtype, tir.op.Op.get("tl.warp_reduce_bitand"), value)
 
 
-def warp_reduce_bitor(buffer: tir.Buffer) -> None:
-    tir.call_intrin("handle", tir.op.Op.get("tl.warp_reduce_bitor"), buffer)
+def warp_reduce_bitor(value: tir.PrimExpr) -> tir.PrimExpr:
+    """Perform warp reduction bitwise-or on a register value.
+
+    This function reduces a value across all threads in a warp using shuffle operations.
+    Each thread provides a  register `value`, and after the reduction, all threads
+    will have the bitwise-or of all values across the warp.
+
+    Args:
+        value (tir.PrimExpr): The input register value to reduce
+
+    Returns:
+        tir.PrimExpr: The reduced bitwise-or value (same on all threads in the warp)
+    """
+    return tir.call_intrin(value.dtype, tir.op.Op.get("tl.warp_reduce_bitor"), value)

--- a/tilelang/language/reduce_op.py
+++ b/tilelang/language/reduce_op.py
@@ -192,7 +192,7 @@ def reduce_sum(buffer: tir.Buffer, out: tir.Buffer, dim: int = -1, clear: bool =
     reduce(buffer, out, "sum", dim, clear)
 
 
-def reduce_abssum(buffer: tir.Buffer, out: tir.Buffer, dim: int = -1) -> None:
+def reduce_abssum(buffer: tir.Buffer, out: tir.Buffer, dim: int = -1, clear: bool = True) -> None:
     """Perform reduce absolute sum on input buffer, store the result to output buffer.
 
     Args:
@@ -204,7 +204,7 @@ def reduce_abssum(buffer: tir.Buffer, out: tir.Buffer, dim: int = -1) -> None:
         tir.Call: Handle to the reduction operation
     """
     dim = _legalize_dim(buffer, dim)
-    reduce(buffer, out, "abssum", dim, True)
+    reduce(buffer, out, "abssum", dim, clear)
 
 
 def reduce_absmax(buffer: tir.Buffer, out: tir.Buffer, dim: int = -1, clear: bool = True) -> None:

--- a/tilelang/language/reduce_op.py
+++ b/tilelang/language/reduce_op.py
@@ -1,27 +1,22 @@
-"""Reduce operations exposed on the TileLang language surface."""
-
-from __future__ import annotations
-from typing import Literal
-from tilelang._typing import BufferLikeType
 from tvm import tir
-from tilelang.language import copy, macro, alloc_shared, alloc_fragment
-from tilelang.utils.language import to_buffer_region, retrieve_shape, _get_buffer
-from tilelang.utils.language import is_shared, is_fragment
+from tvm.target import Target
+from tilelang.language import copy, macro, alloc_fragment
+from tilelang.utils.language import to_buffer_region, is_shared, is_fragment
+from tilelang.utils.target import target_is_sunmmio
 from tvm.script.ir_builder import IRBuilder
 
 
-def _legalize_dim(buffer: tir.Buffer, dim: int):
-    if dim < 0:
-        dim = len(buffer.shape) + dim
-    return dim
+class ReduceKind:
+    Sum = "sum"
+    Max = "max"
+    Min = "min"
+    AbsSum = "abssum"
+    AbsMax = "absmax"
 
 
 _REDUCE_OP_KEY = "tl.tileop.reduce"
 
-ReduceKind = Literal["sum", "abssum", "max", "absmax", "min", "bitand", "bitor", "bitxor"]
 
-
-# NOTE(chaofan): T.reduce is implemented as a macro, so no return
 def reduce(buffer: tir.Buffer, out: tir.Buffer, reduce_type: ReduceKind, dim: int, clear: bool) -> None:
     """Perform a reduction operation on a buffer along a specified dimension.
 
@@ -32,17 +27,38 @@ def reduce(buffer: tir.Buffer, out: tir.Buffer, reduce_type: ReduceKind, dim: in
         dim (int): Dimension along which to perform reduction
         clear (bool): Whether to initialize the output buffer before reduction
     """
-    # input shape: [X, d, Y], expected output shape: [X, Y] or [X, 1, Y]
-    expected_shapes = [buffer.shape[:dim] + buffer.shape[dim + 1 :], buffer.shape[:dim] + [1] + buffer.shape[dim + 1 :]]
-    if list(out.shape) not in expected_shapes:
-        expected_shapes_str = " or ".join(map(str, expected_shapes))
-        raise ValueError(
-            f"Invalid reduce output shape, buffer shape is {buffer.shape}, dim is {dim}, "
-            f"output shape is {out.shape}, expected shapes are {expected_shapes_str}"
-        )
+
+    # Relaxed shape check: ignore dimensions of size 1
+    def _get_filtered_shape(shape):
+        return [int(x) for x in shape if int(x) != 1]
+
+    buffer_filtered = _get_filtered_shape(buffer.shape)
+    out_filtered = _get_filtered_shape(out.shape)
+
+    # After filtering 1s, the rank should decrease by 1 if the reduced dimension was not 1.
+    # If the reduced dimension was 1, the rank remains the same after filtering.
+    # This is a very loose check.
+    if len(buffer_filtered) - len(out_filtered) not in [0, 1]:
+        raise ValueError(f"Invalid reduce output shape, buffer shape is {buffer.shape}, dim is {dim}, output shape is {out.shape}")
 
     @macro
     def reduce_macro(buffer: tir.Buffer, out: tir.Buffer, reduce_type: str, dim: int, clear: bool) -> None:
+        target = Target.current()
+        # Sunmmio uses direct builtins for ReduceOp in LowerTileOp
+        # Check for Sunmmio target or specific Sunmmio shared memory scopes
+        is_sunmmio_scope = any(scope in (buffer.scope(), out.scope()) for scope in ("shared.rsram", "shared.asram", "shared.wsram"))
+        if (target and target_is_sunmmio(target)) or is_sunmmio_scope:
+            tir.call_intrin(
+                "handle",
+                tir.op.Op.get(_REDUCE_OP_KEY),
+                to_buffer_region(buffer, access_type="r"),
+                to_buffer_region(out, access_type="w"),
+                reduce_type,
+                dim,
+                clear,
+            )
+            return
+
         if is_shared(buffer) and is_shared(out):
             red_frag_in = alloc_fragment(buffer.shape, buffer.dtype)
             red_frag_out = alloc_fragment(out.shape, out.dtype)
@@ -109,364 +125,78 @@ def reduce(buffer: tir.Buffer, out: tir.Buffer, reduce_type: ReduceKind, dim: in
         else:
             raise ValueError(f"Invalid buffer scopes: {buffer.scope()} and {out.scope()}")
 
-    reduce_macro(buffer, out, reduce_type, dim, clear)
+    return reduce_macro(buffer, out, reduce_type, dim, clear)
 
 
-def reduce_max(buffer: tir.Buffer, out: tir.Buffer, dim: int = -1, clear: bool = True) -> None:
-    """Perform reduce max on input buffer, store the result to output buffer
-
-    Parameters
-    ----------
-    buffer : Buffer
-        The input buffer.
-    out : Buffer
-        The output buffer.
-    dim : int
-        The dimension to perform reduce on
-    clear : bool
-        If set to True, the output buffer will first be initialized to -inf.
-    Returns
-    -------
-    handle : PrimExpr
-    """
-    dim = _legalize_dim(buffer, dim)
-    reduce(buffer, out, "max", dim, clear)
-
-
-def reduce_min(buffer: tir.Buffer, out: tir.Buffer, dim: int = -1, clear: bool = True) -> None:
-    """Perform reduce min on input buffer, store the result to output buffer.
-
-    Args:
-        buffer (tir.Buffer): The input buffer
-        out (tir.Buffer): The output buffer
-        dim (int): The dimension to perform reduce on
-        clear (bool, optional): If True, output buffer will be initialized to inf. Defaults to True.
-
-    Returns:
-        tir.Call: Handle to the reduction operation
-    """
-    dim = _legalize_dim(buffer, dim)
-    reduce(buffer, out, "min", dim, clear)
-
-
-def reduce_sum(buffer: tir.Buffer, out: tir.Buffer, dim: int = -1, clear: bool = True) -> None:
-    """Perform reduce sum on input buffer, store the result to output buffer.
-
-    Args:
-        buffer (tir.Buffer): The input buffer
-        out (tir.Buffer): The output buffer
-        dim (int): The dimension to perform reduce on
-        clear (bool, optional): If True, output buffer will be cleared before reduction.
-                              If False, results will be accumulated on existing values.
-                              Defaults to True.
-    Note: When clear=True, reduce_sum will not compute directly on the output buffer. This is because
-          during warp reduction, the same value would be accumulated multiple times (number of threads
-          in the warp). Therefore, the implementation with clear=True follows these steps:
-        1. create a temp buffer with same shape and dtype as out
-        2. copy out to temp buffer
-        3. call reduce_sum with temp buffer and out
-        4. Add temp buffer to out
-
-    Returns:
-        tir.Call: Handle to the reduction operation
-    """
-    dim = _legalize_dim(buffer, dim)
+def reduce_sum(buffer: tir.Buffer, out: tir.Buffer, dim: int, clear: bool = True) -> None:
     reduce(buffer, out, "sum", dim, clear)
 
 
-def reduce_abssum(buffer: tir.Buffer, out: tir.Buffer, dim: int = -1) -> None:
-    """Perform reduce absolute sum on input buffer, store the result to output buffer.
-
-    Args:
-        buffer (tir.Buffer): The input buffer
-        out (tir.Buffer): The output buffer
-        dim (int): The dimension to perform reduce on
-
-    Returns:
-        tir.Call: Handle to the reduction operation
-    """
-    dim = _legalize_dim(buffer, dim)
-    reduce(buffer, out, "abssum", dim, True)
+def reduce_max(buffer: tir.Buffer, out: tir.Buffer, dim: int, clear: bool = True) -> None:
+    reduce(buffer, out, "max", dim, clear)
 
 
-def reduce_absmax(buffer: tir.Buffer, out: tir.Buffer, dim: int = -1, clear: bool = True) -> None:
-    """Perform reduce absolute max on input buffer, store the result to output buffer.
+def reduce_min(buffer: tir.Buffer, out: tir.Buffer, dim: int, clear: bool = True) -> None:
+    reduce(buffer, out, "min", dim, clear)
 
-    Args:
-        buffer (tir.Buffer): The input buffer
-        out (tir.Buffer): The output buffer
-        dim (int): The dimension to perform reduce on
 
-    Returns:
-        tir.Call: Handle to the reduction operation
-    """
-    dim = _legalize_dim(buffer, dim)
+def reduce_abssum(buffer: tir.Buffer, out: tir.Buffer, dim: int, clear: bool = True) -> None:
+    reduce(buffer, out, "abssum", dim, clear)
+
+
+def reduce_absmax(buffer: tir.Buffer, out: tir.Buffer, dim: int, clear: bool = True) -> None:
     reduce(buffer, out, "absmax", dim, clear)
 
 
-def reduce_bitand(buffer: tir.Buffer, out: tir.Buffer, dim: int = -1, clear: bool = True) -> None:
-    """Perform reduce bitwise-and on input buffer, store the result to output buffer.
-
-    Args:
-        buffer (tir.Buffer): The input buffer
-        out (tir.Buffer): The output buffer
-        dim (int): The dimension to perform reduce on
-
-    Returns:
-        tir.Call: Handle to the reduction operation
-    """
-    dim = _legalize_dim(buffer, dim)
+def reduce_bitand(buffer: tir.Buffer, out: tir.Buffer, dim: int, clear: bool = True) -> None:
     reduce(buffer, out, "bitand", dim, clear)
 
 
-def reduce_bitor(buffer: tir.Buffer, out: tir.Buffer, dim: int = -1, clear: bool = True) -> None:
-    """Perform reduce bitwise-or on input buffer, store the result to output buffer.
-
-    Args:
-        buffer (tir.Buffer): The input buffer
-        out (tir.Buffer): The output buffer
-        dim (int): The dimension to perform reduce on
-
-    Returns:
-        tir.Call: Handle to the reduction operation
-    """
-    dim = _legalize_dim(buffer, dim)
+def reduce_bitor(buffer: tir.Buffer, out: tir.Buffer, dim: int, clear: bool = True) -> None:
     reduce(buffer, out, "bitor", dim, clear)
 
 
-def reduce_bitxor(buffer: tir.Buffer, out: tir.Buffer, dim: int = -1, clear: bool = True) -> None:
-    """Perform reduce bitwise-xor on input buffer, store the result to output buffer.
-
-    Args:
-        buffer (tir.Buffer): The input buffer
-        out (tir.Buffer): The output buffer
-        dim (int): The dimension to perform reduce on
-
-    Returns:
-        tir.Call: Handle to the reduction operation
-    """
-    dim = _legalize_dim(buffer, dim)
+def reduce_bitxor(buffer: tir.Buffer, out: tir.Buffer, dim: int, clear: bool = True) -> None:
     reduce(buffer, out, "bitxor", dim, clear)
 
 
 @macro
-def cumsum_fragment(
-    src: BufferLikeType,
-    dst: BufferLikeType,
-    dim: int,
-    reverse: bool,
-) -> None:
-    """
-    Compute cumulative sum for fragment buffers by copying to shared memory first.
-
-    This macro handles cumulative sum operations on fragment buffers by first copying
-    the data to shared memory, performing the cumsum operation, and then copying back.
-
-    Args:
-        src: Source buffer (Buffer, BufferRegion, or BufferLoad) containing input data.
-        dst: Destination buffer (Buffer, BufferRegion, or BufferLoad) for output data.
-        dim: Dimension along which to compute cumulative sum.
-        reverse: If True, compute cumulative sum in reverse order.
-    """
-    src_shape = retrieve_shape(src)
-    src_buffer = _get_buffer(src)
-    # Get dtype from the buffer
-    if isinstance(src, tir.Buffer):
-        dtype = src.dtype
-    else:
-        dtype = src_buffer.dtype
-    cumsum_smem = alloc_shared(src_shape, dtype, "shared.dyn")
-    copy(src, cumsum_smem)
+def cumsum(buffer: tir.Buffer, out: tir.Buffer, dim: int, reverse: bool = False) -> None:
     tir.call_intrin(
         "handle",
         tir.op.Op.get("tl.tileop.cumsum"),
-        to_buffer_region(cumsum_smem, access_type="r"),
-        to_buffer_region(cumsum_smem, access_type="w"),
-        dim,
-        reverse,
-    )
-    copy(cumsum_smem, dst)
-
-
-# NOTE(chaofan): T.cumsum returns None if it goes to macro implementations
-def cumsum(
-    src: BufferLikeType,
-    dst: BufferLikeType | None = None,
-    dim: int = 0,
-    reverse: bool = False,
-) -> tir.PrimExpr | None:
-    """
-    Compute the cumulative sum of `src` along `dim`, writing results to `dst`.
-
-    Negative `dim` indices are normalized (Python-style). If `dst` is None, the operation is performed in-place into `src`. Raises ValueError when `dim` is out of bounds for `src.shape`. When `src.scope() == "local.fragment"`, this delegates to `cumsum_fragment`; otherwise it emits the `tl.cumsum` intrinsic.
-
-    Supports Buffer, BufferRegion, and BufferLoad inputs, allowing operations on buffer slices/regions.
-
-    Examples:
-        A 1D inclusive scan that writes the result into a separate shared-memory buffer:
-
-        >>> import tilelang.language as T
-        >>> @T.prim_func
-        ... def kernel(A: T.Tensor((128,), "float32"), B: T.Tensor((128,), "float32")):
-        ...     with T.Kernel(1, threads=128):
-        ...         A_shared = T.alloc_shared((128,), "float32")
-        ...         T.copy(A, A_shared)
-        ...         T.cumsum(src=A_shared, dst=A_shared, dim=0)
-        ...         T.copy(A_shared, B)
-
-        A 2D prefix sum along the last dimension with reverse accumulation:
-
-        >>> import tilelang.language as T
-        >>> @T.prim_func
-        ... def kernel2d(A: T.Tensor((64, 64), "float16"), B: T.Tensor((64, 64), "float16")):
-        ...     with T.Kernel(1, 1, threads=256):
-        ...         tile = T.alloc_shared((64, 64), "float16")
-        ...         T.copy(A, tile)
-        ...         T.cumsum(src=tile, dim=1, reverse=True)
-        ...         T.copy(tile, B)
-
-        Operating on a buffer region (slice):
-
-        >>> import tilelang.language as T
-        >>> @T.prim_func
-        ... def kernel_region(InputG_fragment: T.Tensor((128,), "float32"), chunk_size: T.int32):
-        ...     with T.Kernel(1, threads=128):
-        ...         i = T.int32(0)
-        ...         T.cumsum(InputG_fragment[i * chunk_size:(i + 1) * chunk_size], dim=0)
-
-    Returns:
-        tir.Call: A handle to the emitted cumulative-sum operation.
-    """
-
-    # Get shape from src (supports Buffer, BufferRegion, BufferLoad)
-    shape = retrieve_shape(src)
-    if dim >= len(shape) or dim < -len(shape):
-        raise ValueError(f"Dimension {dim} is out of bounds for buffer with shape {shape}")
-    if dim < 0:
-        dim = len(shape) + dim
-
-    if dst is None:
-        dst = src
-    else:
-        # Validate that dst shape matches src shape
-        dst_shape = retrieve_shape(dst)
-        if len(dst_shape) != len(shape):
-            raise ValueError(f"cumsum dst shape {dst_shape} must match src shape {shape} (rank mismatch)")
-        # Check each dimension matches
-        for i in range(len(shape)):
-            if not tir.analysis.expr_deep_equal(dst_shape[i], shape[i]):
-                raise ValueError(f"cumsum dst shape {dst_shape} must match src shape {shape} (dim {i} mismatch)")
-
-    # Check if src is a fragment buffer
-    if is_fragment(src):
-        cumsum_fragment(src, dst, dim, reverse)
-        return
-
-    return tir.call_intrin(
-        "handle",
-        tir.op.Op.get("tl.tileop.cumsum"),
-        to_buffer_region(src, access_type="r"),
-        to_buffer_region(dst, access_type="w"),
+        to_buffer_region(buffer, access_type="r"),
+        to_buffer_region(out, access_type="w"),
         dim,
         reverse,
     )
 
 
-def finalize_reducer(reducer: tir.Buffer) -> tir.PrimExpr:
-    """
-    Finalize a reducer buffer by emitting the `tl.tileop.finalize_reducer` intrinsic.
-
-    This returns a TVM `tir.Call` handle that finalizes the given reducer using its writable pointer.
-    The call does not modify Python objects directly; it produces the low-level intrinsic call used by the IR.
-
-    Parameters:
-        reducer (tir.Buffer): Reducer buffer whose writable pointer will be finalized.
-
-    Returns:
-        tir.Call: Handle to the finalize reducer intrinsic call.
-    """
-    return tir.call_intrin(
+@macro
+def finalize_reducer(buffer: tir.Buffer, out: tir.Buffer) -> None:
+    tir.call_intrin(
         "handle",
         tir.op.Op.get("tl.tileop.finalize_reducer"),
-        to_buffer_region(reducer, access_type="w"),
+        to_buffer_region(buffer, access_type="r"),
+        to_buffer_region(out, access_type="w"),
     )
 
 
-def warp_reduce_sum(value: tir.PrimExpr) -> tir.PrimExpr:
-    """Perform warp reduction sum on a register value.
-
-    This function reduces a value across all threads in a warp using shuffle operations.
-    Each thread provides a  register `value`, and after the reduction, all threads
-    will have the sum of all values across the warp.
-
-    Args:
-        value (tir.PrimExpr): The input register value to reduce
-
-    Returns:
-        tir.PrimExpr: The reduced sum value (same on all threads in the warp)
-    """
-    return tir.call_intrin(value.dtype, tir.op.Op.get("tl.warp_reduce_sum"), value)
+def warp_reduce_sum(buffer: tir.Buffer) -> None:
+    tir.call_intrin("handle", tir.op.Op.get("tl.warp_reduce_sum"), buffer)
 
 
-def warp_reduce_max(value: tir.PrimExpr) -> tir.PrimExpr:
-    """Perform warp reduction max on a register value.
-
-    This function reduces a value across all threads in a warp using shuffle operations.
-    Each thread provides a  register `value`, and after the reduction, all threads
-    will have the max of all values across the warp.
-
-    Args:
-        value (tir.PrimExpr): The input register value to reduce
-
-    Returns:
-        tir.PrimExpr: The reduced max value (same on all threads in the warp)
-    """
-    return tir.call_intrin(value.dtype, tir.op.Op.get("tl.warp_reduce_max"), value)
+def warp_reduce_max(buffer: tir.Buffer) -> None:
+    tir.call_intrin("handle", tir.op.Op.get("tl.warp_reduce_max"), buffer)
 
 
-def warp_reduce_min(value: tir.PrimExpr) -> tir.PrimExpr:
-    """Perform warp reduction min on a register value.
-
-    This function reduces a value across all threads in a warp using shuffle operations.
-    Each thread provides a  register `value`, and after the reduction, all threads
-    will have the min of all values across the warp.
-
-    Args:
-        value (tir.PrimExpr): The input register value to reduce
-
-    Returns:
-        tir.PrimExpr: The reduced min value (same on all threads in the warp)
-    """
-    return tir.call_intrin(value.dtype, tir.op.Op.get("tl.warp_reduce_min"), value)
+def warp_reduce_min(buffer: tir.Buffer) -> None:
+    tir.call_intrin("handle", tir.op.Op.get("tl.warp_reduce_min"), buffer)
 
 
-def warp_reduce_bitand(value: tir.PrimExpr) -> tir.PrimExpr:
-    """Perform warp reduction bitwise-and on a register value.
-
-    This function reduces a value across all threads in a warp using shuffle operations.
-    Each thread provides a  register `value`, and after the reduction, all threads
-    will have the bitwise-and of all values across the warp.
-
-    Args:
-        value (tir.PrimExpr): The input register value to reduce
-
-    Returns:
-        tir.PrimExpr: The reduced bitwise-and value (same on all threads in the warp)
-    """
-    return tir.call_intrin(value.dtype, tir.op.Op.get("tl.warp_reduce_bitand"), value)
+def warp_reduce_bitand(buffer: tir.Buffer) -> None:
+    tir.call_intrin("handle", tir.op.Op.get("tl.warp_reduce_bitand"), buffer)
 
 
-def warp_reduce_bitor(value: tir.PrimExpr) -> tir.PrimExpr:
-    """Perform warp reduction bitwise-or on a register value.
-
-    This function reduces a value across all threads in a warp using shuffle operations.
-    Each thread provides a  register `value`, and after the reduction, all threads
-    will have the bitwise-or of all values across the warp.
-
-    Args:
-        value (tir.PrimExpr): The input register value to reduce
-
-    Returns:
-        tir.PrimExpr: The reduced bitwise-or value (same on all threads in the warp)
-    """
-    return tir.call_intrin(value.dtype, tir.op.Op.get("tl.warp_reduce_bitor"), value)
+def warp_reduce_bitor(buffer: tir.Buffer) -> None:
+    tir.call_intrin("handle", tir.op.Op.get("tl.warp_reduce_bitor"), buffer)

--- a/tilelang/layout/hierarchical_layout.py
+++ b/tilelang/layout/hierarchical_layout.py
@@ -247,7 +247,7 @@ def make_blockwise_zz_layout(buffer: Buffer | BufferLoad | BufferRegion | tuple[
     # from stride and continuous
     assert row % row_bs == 0 and column % col_bs == 0, "Row and column must be multiples of block sizes for blockwise ZZ layout."
     hdims = [row // row_bs, row_bs, column // col_bs, col_bs]
-    hstrides = [row_bs * col_bs * (column // col_bs), row_bs, nelements_per_block, 1]
+    hstrides = [row_bs * col_bs * (column // col_bs), col_bs, nelements_per_block, 1]
     groups = [(0, 2), (2, 4)]
 
     return make_hierarchical_layout(hdims, hstrides, groups)


### PR DESCRIPTION
### Summary
This PR implements the lowering logic for the fill() and reduce() operator targeting the Sunmmio architecture.
### fill()
#### Key Changes
1. Operator Interface ( src/op/operator.h & src/transform/lower_tile_op.cc ) :

    - Extended LowerArgs to include TileViewMap .
    - Updated LowerTileOp pass to capture TileView information from annotations and propagate it to operators during lowering.
2. Fill Operator Lowering ( src/op/fill.cc ) :

    - Scope Enforcement : Added strict checks to ensure Sunmmio fill operations target shared.rsram , aligning with vector core requirements.
    - Tiled Loop Generation : Implemented logic to lower fill into a serial loop nest iterating over tiles, derived from the buffer's TileView .
    - Annotation Injection : Automatically attaches critical annotations (e.g., tile_new_shape , **kTileLoopStage=kLegalized** , tile_execution_loop ) to guide the subsequent TilesLoop pass in expanding these into vectorized instructions.
    - Region Support : Added robust support for partial buffer fills (regions), including strict alignment checks to ensure region offsets and extents are divisible by the tile size.
 
### reduce() 
#### Key Changes

- Reduce Operator Lowering ( reduce.cc ) :
1. Scope Enforcement : Added strict checks to ensure Sunmmio reduction operations target shared.rsram for both source and destination, fulfilling vector core hardware requirements.
2. Loop Reordering & Accumulator Reuse : Implemented a multi-level loop nest where the reduction axis is explicitly placed as the innermost spatial loop. This design enables efficient memory reuse of the accumulator ( acc ) buffer across tiled iterations.
3. Guarded Reduction Logic : Introduced a unified loop body using execution guards ( if rv == 0 for initialization and if rv == last for finalization/write-back). This ensures correct state management for both spatial and reduction dimensions within the Tile semantics.
4. Hardware Primitive Mapping : Integrated vector_core_in_tile_reduce for reduction along tiled axes. The implementation automatically maps high-level operators (e.g., abssum ) to hardware-supported primitives (e.g., sum ) by performing element-wise preprocessing during the accumulation stage.
5. Memory Optimization via BufferRegion : Optimized memory footprint by using BufferRegion to pass the target output area directly to the in-tile reduction builtin, eliminating the need for intermediate result buffers ( Out_shared_res ).
6. Annotation Alignment : Injects critical Tile-level annotations ( tile.loop_stage=kTiled , tile.execution , tile.scope_entry ) to align the IR structure with T.Tiles() and T.fill() , ensuring seamless integration with the subsequent Codegen pipeline.
- Frontend Macro Logic ( reduce_op.py ) :
  
1. Sunmmio Specialized Path : Updated reduce_macro to detect Sunmmio targets or specific memory scopes ( shared.rsram/asram/wsram ), bypassing GPU-specific fragment allocations in favor of direct hardware-backed lowering.
2. Relaxed Shape Validation : Implemented a flexible shape checking mechanism that ignores unit dimensions (size 1), accommodating hardware-driven alignment and padding requirements while maintaining logical correctness.