### PR TITLE
[Feature] [Sunmmio] Threadless kernel path — no threadIdx bindings

### DIFF
--- a/.github/workflows/sunmmio-ci.yml
+++ b/.github/workflows/sunmmio-ci.yml
@@ -103,9 +103,17 @@ jobs:
             protobuf-compiler libgflags-dev libsqlite3-dev llvm-dev
           ln -sf /usr/bin/python3.12 /usr/local/bin/python
 
-      - name: Install GoogleTest
+      - name: Install GoogleTest from source
         run: |
-          apt-get install -y --no-install-recommends libgtest-dev libgmock-dev
+          git clone https://github.com/google/googletest.git
+          cd googletest
+          cmake -S . -B build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX=/usr/local
+          cmake --build build -j$(nproc)
+          cmake --install build
+          cd ..
+          rm -rf googletest
 
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/sunmmio-ci.yml
+++ b/.github/workflows/sunmmio-ci.yml
@@ -103,26 +103,9 @@ jobs:
             protobuf-compiler libgflags-dev libsqlite3-dev llvm-dev
           ln -sf /usr/bin/python3.12 /usr/local/bin/python
 
-      - name: Install GoogleTest from source
+      - name: Install GoogleTest
         run: |
-          GTEST_CACHE=/ci-cache/googletest-install
-          if [ -f "${GTEST_CACHE}/lib/libgtest.a" ]; then
-            echo "GoogleTest already cached at ${GTEST_CACHE}, skipping build."
-          else
-            echo "Building GoogleTest and caching to ${GTEST_CACHE}."
-            rm -rf googletest
-            git clone https://github.com/google/googletest.git
-            cd googletest
-            cmake -S . -B build \
-              -DCMAKE_BUILD_TYPE=Release \
-              -DCMAKE_INSTALL_PREFIX="${GTEST_CACHE}"
-            cmake --build build -j$(nproc)
-            cmake --install build
-            cd ..
-            rm -rf googletest
-          fi
-          cp -r "${GTEST_CACHE}/include/"* /usr/local/include/
-          cp -r "${GTEST_CACHE}/lib/"*      /usr/local/lib/
+          apt-get install -y --no-install-recommends libgtest-dev libgmock-dev
 
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/sunmmio-ci.yml
+++ b/.github/workflows/sunmmio-ci.yml
@@ -105,15 +105,24 @@ jobs:
 
       - name: Install GoogleTest from source
         run: |
-          git clone https://github.com/google/googletest.git
-          cd googletest
-          cmake -S . -B build \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_INSTALL_PREFIX=/usr/local
-          cmake --build build -j$(nproc)
-          cmake --install build
-          cd ..
-          rm -rf googletest
+          GTEST_CACHE=/ci-cache/googletest-install
+          if [ -f "${GTEST_CACHE}/lib/libgtest.a" ]; then
+            echo "GoogleTest already cached at ${GTEST_CACHE}, skipping build."
+          else
+            echo "Building GoogleTest and caching to ${GTEST_CACHE}."
+            rm -rf googletest
+            git clone https://github.com/google/googletest.git
+            cd googletest
+            cmake -S . -B build \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DCMAKE_INSTALL_PREFIX="${GTEST_CACHE}"
+            cmake --build build -j$(nproc)
+            cmake --install build
+            cd ..
+            rm -rf googletest
+          fi
+          cp -r "${GTEST_CACHE}/include/"* /usr/local/include/
+          cp -r "${GTEST_CACHE}/lib/"*      /usr/local/lib/
 
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/src/transform/layout_inference.cc
+++ b/src/transform/layout_inference.cc
@@ -46,12 +46,16 @@ public:
   void VisitStmt_(const AttrStmtNode *op) final {
     if (op->attr_key == tir::attr::thread_extent) {
       IterVar iv = Downcast<IterVar>(op->node);
-      thread_binding_[iv->var.get()] = iv;
+      // Only collect threadIdx bindings; blockIdx are grid-level and must not
+      // be mistaken for intra-block thread parallelism.
+      if (std::string(iv->thread_tag).rfind("threadIdx", 0) == 0) {
+        thread_binding_[iv->var.get()] = iv;
+      }
     }
     StmtExprVisitor::VisitStmt_(op);
   }
 
-  // The thread binding map
+  // The thread binding map (threadIdx.* only)
   std::unordered_map<const VarNode *, IterVar> thread_binding_;
 };
 

--- a/src/transform/layout_inference.cc
+++ b/src/transform/layout_inference.cc
@@ -48,7 +48,8 @@ public:
       IterVar iv = Downcast<IterVar>(op->node);
       // Only collect threadIdx bindings; blockIdx are grid-level and must not
       // be mistaken for intra-block thread parallelism.
-      if (std::string(iv->thread_tag).rfind("threadIdx", 0) == 0) {
+      if (std::string_view(iv->thread_tag.data(), iv->thread_tag.size())
+              .substr(0, 9) == "threadIdx") {
         thread_binding_[iv->var.get()] = iv;
       }
     }

--- a/src/transform/lower_tile_op.cc
+++ b/src/transform/lower_tile_op.cc
@@ -1060,10 +1060,10 @@ private:
     // Determine if this is a true parallel loop requiring thread partitioning.
     // Skip partitioning for loops that only operate on local/register buffers.
     // Also skip when no real threadIdx.x binding was seen in the IR: calling
-    // PartitionLoop with the dummy v_thread variable embeds a free variable into
-    // the output IR.  has_thread_binding_ is set by VisitStmt_(AttrStmtNode)
-    // only when a genuine threadIdx.x AttrStmt is encountered, so this check is
-    // IR-driven rather than target-driven.
+    // PartitionLoop with the dummy v_thread variable embeds a free variable
+    // into the output IR.  has_thread_binding_ is set by
+    // VisitStmt_(AttrStmtNode) only when a genuine threadIdx.x AttrStmt is
+    // encountered, so this check is IR-driven rather than target-driven.
     bool parallel_loop =
         !local_register_only && !store_into_local && has_thread_binding_;
 

--- a/src/transform/lower_tile_op.cc
+++ b/src/transform/lower_tile_op.cc
@@ -946,6 +946,7 @@ private:
       ICHECK_NE(iv->thread_tag.length(), 0U);
       if (iv->thread_tag == "threadIdx.x") {
         thread_var_ = iv;
+        has_thread_binding_ = true;
         ICHECK(iv->dom->extent.as<IntImmNode>());
         thread_block_size_ = iv->dom->extent.as<IntImmNode>()->value;
       }
@@ -1058,7 +1059,13 @@ private:
 
     // Determine if this is a true parallel loop requiring thread partitioning.
     // Skip partitioning for loops that only operate on local/register buffers.
-    bool parallel_loop = !local_register_only && !store_into_local;
+    // Also skip when no real threadIdx.x binding was seen in the IR: calling
+    // PartitionLoop with the dummy v_thread variable embeds a free variable into
+    // the output IR.  has_thread_binding_ is set by VisitStmt_(AttrStmtNode)
+    // only when a genuine threadIdx.x AttrStmt is encountered, so this check is
+    // IR-driven rather than target-driven.
+    bool parallel_loop =
+        !local_register_only && !store_into_local && has_thread_binding_;
 
     // Check if there are non-local buffer accesses (for vectorization decision)
     bool has_non_local = false;
@@ -1136,6 +1143,10 @@ private:
   // we need to define a thread_var for the serial loop.
   IterVar thread_var_ = IterVar(Range::FromMinExtent(0, 1), Var("v_thread"),
                                 IterVarType::kDataPar);
+  // True only when a real threadIdx.x AttrStmt has been visited. Used to guard
+  // thread partitioning: if no threadIdx.x exists (e.g. threadless kernels),
+  // calling PartitionLoop with the dummy v_thread would embed a free variable.
+  bool has_thread_binding_ = false;
   size_t thread_block_size_ = 0;
   // Stack of per-Block workspace buffers gathered while visiting children
   std::vector<Array<Buffer>> workspace_stack_;

--- a/testing/python/language/test_tilelang_kernel_sunmmio_threadless.py
+++ b/testing/python/language/test_tilelang_kernel_sunmmio_threadless.py
@@ -22,9 +22,7 @@ def test_sunmmio_kernel_threads_always_one(requested_threads):
         mod = make_kernel(requested_threads)
 
     script = mod.script()
-    assert "threadIdx_x, 1)" in script, (
-        f"Expected threadIdx_x extent to be 1, but got:\n{script}"
-    )
+    assert "threadIdx_x, 1)" in script, f"Expected threadIdx_x extent to be 1, but got:\n{script}"
 
 
 def test_sunmmio_kernel_default_threads_is_one():
@@ -40,9 +38,7 @@ def test_sunmmio_kernel_default_threads_is_one():
         mod = tvm.IRModule({"main": kernel})
 
     script = mod.script()
-    assert "threadIdx_x, 1)" in script, (
-        f"Expected threadIdx_x extent to be 1, but got:\n{script}"
-    )
+    assert "threadIdx_x, 1)" in script, f"Expected threadIdx_x extent to be 1, but got:\n{script}"
 
 
 def test_non_sunmmio_kernel_respects_threads():
@@ -51,6 +47,4 @@ def test_non_sunmmio_kernel_respects_threads():
         mod = make_kernel(128)
 
     script = mod.script()
-    assert "threadIdx_x, 128)" in script, (
-        f"Expected threadIdx_x extent to be 128, but got:\n{script}"
-    )
+    assert "threadIdx_x, 128)" in script, f"Expected threadIdx_x extent to be 128, but got:\n{script}"

--- a/testing/python/language/test_tilelang_kernel_sunmmio_threadless.py
+++ b/testing/python/language/test_tilelang_kernel_sunmmio_threadless.py
@@ -5,7 +5,6 @@ import tilelang.language as T
 
 
 def make_kernel(threads):
-
     @T.prim_func
     def kernel(A: T.Tensor((128,), T.float32)):
         with T.Kernel(128, threads=threads):
@@ -15,18 +14,22 @@ def make_kernel(threads):
 
 
 @pytest.mark.parametrize("requested_threads", [1, 32, 128, 256])
-def test_sunmmio_kernel_threads_always_one(requested_threads):
-    """T.Kernel threads= is overridden to 1 for Sunmmio target, regardless of the requested value."""
+def test_sunmmio_kernel_has_no_threadidx(requested_threads):
+    """T.Kernel on Sunmmio emits no threadIdx bindings regardless of the threads= argument.
+
+    Sunmmio is unconditionally threadless: threads=None is forced at the compiler
+    level. No threadIdx AttrStmt should appear in the IR.
+    """
     target = determine_target("Sunmmio", return_object=True)
     with tvm.target.Target(target):
         mod = make_kernel(requested_threads)
 
     script = mod.script()
-    assert "threadIdx_x, 1)" in script, f"Expected threadIdx_x extent to be 1, but got:\n{script}"
+    assert "threadIdx" not in script, f"Sunmmio kernel must have no threadIdx bindings (threadless). Got:\n{script}"
 
 
-def test_sunmmio_kernel_default_threads_is_one():
-    """When threads= is not specified, Sunmmio target still defaults to 1 (not 128)."""
+def test_sunmmio_kernel_default_has_no_threadidx():
+    """When threads= is not specified, Sunmmio kernel still emits no threadIdx bindings."""
     target = determine_target("Sunmmio", return_object=True)
     with tvm.target.Target(target):
 
@@ -38,7 +41,7 @@ def test_sunmmio_kernel_default_threads_is_one():
         mod = tvm.IRModule({"main": kernel})
 
     script = mod.script()
-    assert "threadIdx_x, 1)" in script, f"Expected threadIdx_x extent to be 1, but got:\n{script}"
+    assert "threadIdx" not in script, f"Sunmmio kernel must have no threadIdx bindings (threadless). Got:\n{script}"
 
 
 def test_non_sunmmio_kernel_respects_threads():
@@ -47,4 +50,4 @@ def test_non_sunmmio_kernel_respects_threads():
         mod = make_kernel(128)
 
     script = mod.script()
-    assert "threadIdx_x, 128)" in script, f"Expected threadIdx_x extent to be 128, but got:\n{script}"
+    assert 'threadIdx.x", 128)' in script, f"Expected threadIdx.x extent to be 128, but got:\n{script}"

--- a/testing/python/language/test_tilelang_kernel_sunmmio_threadless.py
+++ b/testing/python/language/test_tilelang_kernel_sunmmio_threadless.py
@@ -1,0 +1,56 @@
+import pytest
+from tilelang import tvm as tvm
+from tilelang.utils.target import determine_target
+import tilelang.language as T
+
+
+def make_kernel(threads):
+
+    @T.prim_func
+    def kernel(A: T.Tensor((128,), T.float32)):
+        with T.Kernel(128, threads=threads):
+            pass
+
+    return tvm.IRModule({"main": kernel})
+
+
+@pytest.mark.parametrize("requested_threads", [1, 32, 128, 256])
+def test_sunmmio_kernel_threads_always_one(requested_threads):
+    """T.Kernel threads= is overridden to 1 for Sunmmio target, regardless of the requested value."""
+    target = determine_target("Sunmmio", return_object=True)
+    with tvm.target.Target(target):
+        mod = make_kernel(requested_threads)
+
+    script = mod.script()
+    assert "threadIdx_x, 1)" in script, (
+        f"Expected threadIdx_x extent to be 1, but got:\n{script}"
+    )
+
+
+def test_sunmmio_kernel_default_threads_is_one():
+    """When threads= is not specified, Sunmmio target still defaults to 1 (not 128)."""
+    target = determine_target("Sunmmio", return_object=True)
+    with tvm.target.Target(target):
+
+        @T.prim_func
+        def kernel(A: T.Tensor((128,), T.float32)):
+            with T.Kernel(128):
+                pass
+
+        mod = tvm.IRModule({"main": kernel})
+
+    script = mod.script()
+    assert "threadIdx_x, 1)" in script, (
+        f"Expected threadIdx_x extent to be 1, but got:\n{script}"
+    )
+
+
+def test_non_sunmmio_kernel_respects_threads():
+    """T.Kernel threads= is not overridden for non-Sunmmio targets."""
+    with tvm.target.Target("llvm"):
+        mod = make_kernel(128)
+
+    script = mod.script()
+    assert "threadIdx_x, 128)" in script, (
+        f"Expected threadIdx_x extent to be 128, but got:\n{script}"
+    )

--- a/testing/python/layout/test_tilelang_sunmmio_threadless_layout_inference.py
+++ b/testing/python/layout/test_tilelang_sunmmio_threadless_layout_inference.py
@@ -1,0 +1,283 @@
+"""Tests that LayoutInference handles threadless Sunmmio kernels correctly.
+
+Background — the ThreadBindingCollector fix (layout_inference.cc):
+
+  Before the fix, ThreadBindingCollector collected *all* thread_extent bindings,
+  including blockIdx.*. On Sunmmio, T.Kernel always forces threads=None (threadless),
+  so the IR only ever has blockIdx.* bindings — never threadIdx.*. The collector
+  saw blockIdx and set has_thread_binding=True, so skip_thread_partition was False.
+
+  When such a kernel also had T.Parallel loops accessing shared memory,
+  BufferUseDefCollector encountered those parallel ForNodes. Because no threadIdx
+  AttrStmt was present, thread_var_ was never updated from its default dummy IterVar
+  (named "v_thread", range [0,1)). PartitionLoop was then called with that unbound
+  dummy variable, producing incorrect IR (free variable v_thread in the output).
+
+  After the fix, only threadIdx.* bindings are collected. A pure-blockIdx kernel
+  correctly yields has_thread_binding=False → skip_thread_partition=True →
+  PartitionLoop is never called → correct threadless IR.
+
+  Note: on Sunmmio, T.Kernel unconditionally sets threads=None regardless of any
+  explicit threads= argument. There is no "threaded Sunmmio" path; all Sunmmio
+  kernels are threadless.
+
+Regression coverage:
+  1. Threadless kernel without T.Parallel — basic smoke tests.
+  2. Threadless kernel WITH T.Parallel + shared memory — the exact bug trigger,
+     verifying that PartitionLoop is not called with the dummy v_thread variable.
+"""
+import tilelang
+import tilelang.language as T
+import tilelang.transform as tl_transform
+from tilelang import tvm as tvm
+from tilelang.utils.target import determine_target
+from tvm import tir
+from tvm.tir.stmt_functor import post_order_visit
+
+tilelang.env.disable_cache()
+
+
+# ---------------------------------------------------------------------------
+# Kernel helpers
+# ---------------------------------------------------------------------------
+
+
+def make_threadless_copy_kernel(M, N, dtype=T.float32):
+    """Threadless element-wise copy — no T.Parallel, no shared memory."""
+
+    @T.prim_func
+    def main(A: T.Tensor((M, N), dtype), B: T.Tensor((M, N), dtype)):
+        with T.Kernel(M, N) as (bx, by):
+            B[bx, by] = A[bx, by]
+
+    return tvm.IRModule({"main": main})
+
+
+def make_sunmmio_parallel_shared_kernel(M, N, dtype=T.float32):
+    """Threadless Sunmmio kernel with T.Parallel + shared memory.
+
+    This is the exact trigger for the ThreadBindingCollector bug:
+    - blockIdx.* bindings are present (from T.Kernel)
+    - threadIdx.* bindings are absent (threads=None on Sunmmio)
+    - T.Parallel produces parallel ForNodes accessing shared memory
+    Before the fix, blockIdx was collected as a "thread binding", causing
+    PartitionLoop to be called with the unbound dummy v_thread variable.
+    """
+
+    @T.prim_func
+    def main(A: T.Tensor((M, N), dtype), B: T.Tensor((M, N), dtype)):
+        with T.Kernel(T.ceildiv(M, 32), T.ceildiv(N, 32)) as (bx, by):
+            A_shared = T.alloc_shared((32, 32), dtype)
+            for i, j in T.Parallel(32, 32):
+                A_shared[i, j] = A[bx * 32 + i, by * 32 + j]
+            for i, j in T.Parallel(32, 32):
+                B[bx * 32 + i, by * 32 + j] = A_shared[i, j]
+
+    return tvm.IRModule({"main": main})
+
+
+# ---------------------------------------------------------------------------
+# IR inspection helpers
+# ---------------------------------------------------------------------------
+
+
+def collect_var_names(func):
+    """Return names of all Var nodes reachable from the function body."""
+    names = set()
+
+    def fvisit(node):
+        if isinstance(node, tir.Var):
+            names.add(node.name)
+
+    post_order_visit(func.body, fvisit)
+    return names
+
+
+def collect_thread_extents(func):
+    """Return {thread_tag: extent} for every thread_extent AttrStmt in the body."""
+    extents = {}
+
+    def fvisit(node):
+        if isinstance(node, tir.AttrStmt) and node.attr_key == "thread_extent":
+            extents[node.node.thread_tag] = int(node.value)
+
+    post_order_visit(func.body, fvisit)
+    return extents
+
+
+def has_parallel_for(func):
+    """Return True if any T.parallel ForNode survives in the body."""
+    found = []
+
+    def fvisit(node):
+        if isinstance(node, tir.For) and node.kind == tir.ForKind.PARALLEL:
+            found.append(node)
+
+    post_order_visit(func.body, fvisit)
+    return bool(found)
+
+
+# ---------------------------------------------------------------------------
+# Tests — threadless path (regression for the ThreadBindingCollector fix)
+# ---------------------------------------------------------------------------
+
+
+def test_layout_inference_threadless_kernel_completes_without_error():
+    """LayoutInference must not crash on a threadless Sunmmio kernel.
+
+    This is the base smoke test: even without T.Parallel or shared memory,
+    a threadless kernel (blockIdx only, no threadIdx) must pass through
+    LayoutInference cleanly.
+
+    Before the fix, blockIdx was collected as a "thread binding", setting
+    skip_thread_partition=False. For kernels with parallel for loops + shared
+    memory this caused PartitionLoop to be called with an unbound dummy thread
+    variable, producing incorrect IR or an ICHECK failure.
+    """
+    target = determine_target("Sunmmio", return_object=True)
+
+    with tvm.target.Target(target):
+        mod = make_threadless_copy_kernel(16, 16)
+
+    mod = tvm.tir.transform.BindTarget(target)(mod)
+    mod = tl_transform.InferSramScope()(mod)
+    mod = tl_transform.LayoutInference()(mod)  # must not crash or raise
+
+
+def test_layout_inference_threadless_kernel_has_no_threadidx_bindings():
+    """After LayoutInference a threadless kernel must carry no threadIdx bindings.
+
+    The threadless execution model (skip_thread_partition=True) must be preserved
+    end-to-end. If blockIdx were still collected as a thread binding the pass
+    might inject spurious threadIdx annotations.
+    """
+    target = determine_target("Sunmmio", return_object=True)
+
+    with tvm.target.Target(target):
+        mod = make_threadless_copy_kernel(16, 16)
+
+    mod = tvm.tir.transform.BindTarget(target)(mod)
+    mod = tl_transform.InferSramScope()(mod)
+    mod = tl_transform.LayoutInference()(mod)
+
+    thread_extents = collect_thread_extents(mod["main"])
+    threadidx_tags = [t for t in thread_extents if t.startswith("threadIdx")]
+
+    assert not threadidx_tags, (
+        f"Threadless Sunmmio kernel must have no threadIdx bindings after LayoutInference. "
+        f"Found: {thread_extents}\n"
+        f"IR:\n{mod['main'].script()}")
+
+
+def test_layout_inference_threadless_kernel_preserves_blockidx_bindings():
+    """After LayoutInference, blockIdx bindings must still be present.
+
+    Guards against the fix accidentally stripping blockIdx from the IR.
+    """
+    target = determine_target("Sunmmio", return_object=True)
+
+    with tvm.target.Target(target):
+        mod = make_threadless_copy_kernel(16, 16)
+
+    mod = tvm.tir.transform.BindTarget(target)(mod)
+    mod = tl_transform.InferSramScope()(mod)
+    mod = tl_transform.LayoutInference()(mod)
+
+    thread_extents = collect_thread_extents(mod["main"])
+    blockidx_tags = [t for t in thread_extents if t.startswith("blockIdx")]
+
+    assert blockidx_tags, (
+        f"Threadless Sunmmio kernel must still have blockIdx bindings after LayoutInference. "
+        f"Found extents: {thread_extents}\n"
+        f"IR:\n{mod['main'].script()}")
+
+
+# ---------------------------------------------------------------------------
+# Tests — T.Parallel + shared memory (the actual ThreadBindingCollector bug trigger)
+# ---------------------------------------------------------------------------
+
+
+def test_layout_inference_parallel_shared_kernel_completes_without_error():
+    """LayoutInference must not crash on a Sunmmio kernel with T.Parallel + shared memory.
+
+    This is the exact scenario that triggered the ThreadBindingCollector bug:
+    - Only blockIdx.* bindings (no threadIdx on Sunmmio)
+    - T.Parallel for loops accessing shared memory → BufferUseDefCollector builds
+      ParallelOpNode entries, and in Run() retrieves thread_var for each
+
+    Before the fix: blockIdx collected → skip_thread_partition=False →
+    PartitionLoop called with unbound dummy v_thread → incorrect IR or crash.
+    After the fix: blockIdx ignored → skip_thread_partition=True →
+    PartitionLoop skipped → clean threadless IR.
+    """
+    target = determine_target("Sunmmio", return_object=True)
+
+    with tvm.target.Target(target):
+        mod = make_sunmmio_parallel_shared_kernel(64, 64)
+        mod = tvm.tir.transform.BindTarget(target)(mod)
+        mod = tl_transform.InferSramScope()(mod)
+        mod = tl_transform.LayoutInference()(mod)  # must not crash or raise
+
+
+def test_layout_inference_parallel_shared_kernel_has_no_threadidx_bindings():
+    """After LayoutInference a Sunmmio T.Parallel kernel must have no threadIdx bindings.
+
+    Sunmmio is unconditionally threadless; LayoutInference must not inject threadIdx
+    when processing T.Parallel loops. If blockIdx were still collected as a thread
+    binding the pass might introduce spurious threadIdx annotations.
+    """
+    target = determine_target("Sunmmio", return_object=True)
+
+    with tvm.target.Target(target):
+        mod = make_sunmmio_parallel_shared_kernel(64, 64)
+        mod = tvm.tir.transform.BindTarget(target)(mod)
+        mod = tl_transform.InferSramScope()(mod)
+        mod = tl_transform.LayoutInference()(mod)
+
+    thread_extents = collect_thread_extents(mod["main"])
+    threadidx_tags = [t for t in thread_extents if t.startswith("threadIdx")]
+
+    assert not threadidx_tags, (
+        f"Sunmmio kernel with T.Parallel must have no threadIdx bindings after "
+        f"LayoutInference (Sunmmio is fully threadless). Found: {thread_extents}\n"
+        f"IR:\n{mod['main'].script()}")
+
+
+def test_layout_inference_parallel_shared_kernel_has_no_v_thread_variable():
+    """After LayoutInference the IR must not contain a free v_thread variable.
+
+    v_thread is the dummy IterVar used by PartitionLoop when no real thread binding
+    exists. If it appears in the output IR it means PartitionLoop was called with
+    an unbound variable — the exact bug this fix addresses.
+
+    Trigger condition: T.Parallel loop + shared memory + no threadIdx binding.
+    Before fix: blockIdx collected → PartitionLoop(v_thread) → v_thread in IR.
+    After fix: skip_thread_partition=True → PartitionLoop not called → no v_thread.
+    """
+    target = determine_target("Sunmmio", return_object=True)
+
+    with tvm.target.Target(target):
+        mod = make_sunmmio_parallel_shared_kernel(64, 64)
+        mod = tvm.tir.transform.BindTarget(target)(mod)
+        mod = tl_transform.InferSramScope()(mod)
+        mod = tl_transform.LayoutInference()(mod)
+
+    var_names = collect_var_names(mod["main"])
+
+    assert "v_thread" not in var_names, (
+        "LayoutInference introduced a free v_thread variable for a Sunmmio kernel "
+        "with T.Parallel. This means ThreadBindingCollector incorrectly collected "
+        "blockIdx.* as a thread binding, causing PartitionLoop to run with an "
+        "unbound dummy thread variable.\n"
+        f"All vars found: {sorted(var_names)}\n"
+        f"IR:\n{mod['main'].script()}")
+
+
+if __name__ == "__main__":
+    test_layout_inference_threadless_kernel_completes_without_error()
+    test_layout_inference_threadless_kernel_has_no_threadidx_bindings()
+    test_layout_inference_threadless_kernel_preserves_blockidx_bindings()
+    test_layout_inference_parallel_shared_kernel_completes_without_error()
+    test_layout_inference_parallel_shared_kernel_has_no_threadidx_bindings()
+    test_layout_inference_parallel_shared_kernel_has_no_v_thread_variable()
+    print("All tests passed.")

--- a/testing/python/layout/test_tilelang_sunmmio_threadless_layout_inference.py
+++ b/testing/python/layout/test_tilelang_sunmmio_threadless_layout_inference.py
@@ -36,7 +36,6 @@ from tvm.tir.stmt_functor import post_order_visit
 
 tilelang.env.disable_cache()
 
-
 # ---------------------------------------------------------------------------
 # Kernel helpers
 # ---------------------------------------------------------------------------

--- a/testing/python/layout/test_tilelang_sunmmio_threadless_layout_inference.py
+++ b/testing/python/layout/test_tilelang_sunmmio_threadless_layout_inference.py
@@ -26,6 +26,7 @@ Regression coverage:
   2. Threadless kernel WITH T.Parallel + shared memory — the exact bug trigger,
      verifying that PartitionLoop is not called with the dummy v_thread variable.
 """
+
 import tilelang
 import tilelang.language as T
 import tilelang.transform as tl_transform
@@ -165,7 +166,8 @@ def test_layout_inference_threadless_kernel_has_no_threadidx_bindings():
     assert not threadidx_tags, (
         f"Threadless Sunmmio kernel must have no threadIdx bindings after LayoutInference. "
         f"Found: {thread_extents}\n"
-        f"IR:\n{mod['main'].script()}")
+        f"IR:\n{mod['main'].script()}"
+    )
 
 
 def test_layout_inference_threadless_kernel_preserves_blockidx_bindings():
@@ -188,7 +190,8 @@ def test_layout_inference_threadless_kernel_preserves_blockidx_bindings():
     assert blockidx_tags, (
         f"Threadless Sunmmio kernel must still have blockIdx bindings after LayoutInference. "
         f"Found extents: {thread_extents}\n"
-        f"IR:\n{mod['main'].script()}")
+        f"IR:\n{mod['main'].script()}"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -239,7 +242,8 @@ def test_layout_inference_parallel_shared_kernel_has_no_threadidx_bindings():
     assert not threadidx_tags, (
         f"Sunmmio kernel with T.Parallel must have no threadIdx bindings after "
         f"LayoutInference (Sunmmio is fully threadless). Found: {thread_extents}\n"
-        f"IR:\n{mod['main'].script()}")
+        f"IR:\n{mod['main'].script()}"
+    )
 
 
 def test_layout_inference_parallel_shared_kernel_has_no_v_thread_variable():
@@ -269,7 +273,8 @@ def test_layout_inference_parallel_shared_kernel_has_no_v_thread_variable():
         "blockIdx.* as a thread binding, causing PartitionLoop to run with an "
         "unbound dummy thread variable.\n"
         f"All vars found: {sorted(var_names)}\n"
-        f"IR:\n{mod['main'].script()}")
+        f"IR:\n{mod['main'].script()}"
+    )
 
 
 if __name__ == "__main__":

--- a/testing/python/transform/test_tilelang_transform_sunmmio_annotate_split.py
+++ b/testing/python/transform/test_tilelang_transform_sunmmio_annotate_split.py
@@ -44,8 +44,9 @@ def get_device_func(mod):
     is GPU-only). We identify it by kIsGlobalFunc + Sunmmio target.
     """
     candidates = [
-        f for f in mod.functions.values() if f.attrs.get("tir.is_global_func", False)
-        and "target" in f.attrs and target_is_sunmmio(f.attrs["target"])
+        f
+        for f in mod.functions.values()
+        if f.attrs.get("tir.is_global_func", False) and "target" in f.attrs and target_is_sunmmio(f.attrs["target"])
     ]
     return candidates
 
@@ -75,18 +76,18 @@ def test_annotate_device_regions_wraps_thread_extent_with_target():
     target_attrs = collect_attr_stmts(func.body, "target")
 
     assert len(target_attrs) >= 1, (
-        f"Expected at least one 'target' AttrStmt after AnnotateDeviceRegions, found none.\n"
-        f"Function body:\n{func.script()}")
+        f"Expected at least one 'target' AttrStmt after AnnotateDeviceRegions, found none.\nFunction body:\n{func.script()}"
+    )
 
     device_target_node = target_attrs[0].node
     assert target_is_sunmmio(device_target_node), (
-        f"Expected 'target' AttrStmt to annotate with the Sunmmio device target, "
-        f"got: {device_target_node}")
+        f"Expected 'target' AttrStmt to annotate with the Sunmmio device target, got: {device_target_node}"
+    )
 
     inner_stmt = target_attrs[0].body
     assert isinstance(inner_stmt, tir.AttrStmt) and inner_stmt.attr_key == "thread_extent", (
-        f"Expected the body of the 'target' AttrStmt to be a 'thread_extent' AttrStmt "
-        f"(the thread launch region), got: {type(inner_stmt)}")
+        f"Expected the body of the 'target' AttrStmt to be a 'thread_extent' AttrStmt (the thread launch region), got: {type(inner_stmt)}"
+    )
 
 
 def test_split_host_device_produces_two_functions():
@@ -101,8 +102,7 @@ def test_split_host_device_produces_two_functions():
     mod = tilelang.transform.SplitHostDevice()(mod)
 
     funcs = dict(mod.functions)
-    assert len(funcs) == 2, (
-        f"Expected 2 functions after SplitHostDevice, got {len(funcs)}: {list(funcs.keys())}")
+    assert len(funcs) == 2, f"Expected 2 functions after SplitHostDevice, got {len(funcs)}: {list(funcs.keys())}"
 
 
 def test_split_host_device_device_func_has_sunmmio_target():
@@ -123,9 +123,11 @@ def test_split_host_device_device_func_has_sunmmio_target():
     device_funcs = get_device_func(mod)
     assert len(device_funcs) == 1, (
         f"Expected exactly 1 Sunmmio device function, got {len(device_funcs)}.\n"
-        f"Functions: { {gv.name_hint: dict(f.attrs) for gv, f in mod.functions.items()} }")
+        f"Functions: { {gv.name_hint: dict(f.attrs) for gv, f in mod.functions.items()} }"
+    )
     assert target_is_sunmmio(device_funcs[0].attrs["target"]), (
-        f"Expected device function target to be Sunmmio, got: {device_funcs[0].attrs['target']}")
+        f"Expected device function target to be Sunmmio, got: {device_funcs[0].attrs['target']}"
+    )
 
 
 def test_split_host_device_device_func_has_no_thread_bindings():
@@ -142,7 +144,8 @@ def test_split_host_device_device_func_has_no_thread_bindings():
     device_funcs = get_device_func(mod)
     assert len(device_funcs) == 1, (
         "Expected a device function (Sunmmio target + kIsGlobalFunc) after SplitHostDevice, "
-        f"found none.\nFunctions in module: {[str(gv) for gv in mod.functions]}")
+        f"found none.\nFunctions in module: {[str(gv) for gv in mod.functions]}"
+    )
     device_func = device_funcs[0]
 
     thread_extents = {}
@@ -156,7 +159,8 @@ def test_split_host_device_device_func_has_no_thread_bindings():
     assert "threadIdx.x" not in thread_extents, (
         f"Sunmmio device function must have no threadIdx bindings (threadless). "
         f"Found thread extents: {thread_extents}\n"
-        f"Device function:\n{device_func.script()}")
+        f"Device function:\n{device_func.script()}"
+    )
 
 
 if __name__ == "__main__":

--- a/testing/python/transform/test_tilelang_transform_sunmmio_annotate_split.py
+++ b/testing/python/transform/test_tilelang_transform_sunmmio_annotate_split.py
@@ -4,16 +4,37 @@ import tilelang.transform
 from tilelang import tvm as tvm
 from tilelang.utils.target import determine_target, target_is_sunmmio
 from tilelang.engine.lower import canon_target_host
-from tvm.ir import CallingConv
 
 tilelang.env.disable_cache()
 
 
 def make_sunmmio_target_with_host():
-    """Build the Sunmmio target with an llvm host, matching what lower() does."""
+    """Build the Sunmmio target with a host, matching what lower() does."""
     target = determine_target("Sunmmio", return_object=True)
     target_host = tvm.target.Target.canon_target(canon_target_host(target, None))
     return tvm.target.Target(target, target_host)
+
+
+def run_pre_split_passes(mod, target):
+    """Run the passes required before AnnotateDeviceRegions, matching the real pipeline."""
+    mod = tvm.tir.transform.BindTarget(target)(mod)
+    mod = tilelang.transform.LowerOpaqueBlock()(mod)
+    return mod
+
+
+def get_device_func(mod):
+    """
+    Return the device function after SplitHostDevice.
+    For CPU-based targets (kDLCPU) like Sunmmio, SplitHostDevice marks the
+    device function with kIsGlobalFunc=True (not DEVICE_KERNEL_LAUNCH which
+    is GPU-only). We identify it by kIsGlobalFunc + Sunmmio target.
+    """
+    candidates = [
+        f for f in mod.functions.values()
+        if f.attrs.get("tir.is_global_func", False) and
+           "target" in f.attrs and target_is_sunmmio(f.attrs["target"])
+    ]
+    return candidates
 
 
 def simple_kernel(M, N, dtype=T.float32):
@@ -27,21 +48,20 @@ def simple_kernel(M, N, dtype=T.float32):
 
 
 def test_annotate_device_regions_runs_on_sunmmio():
-    """AnnotateDeviceRegions should not crash and should annotate thread_extent regions."""
+    """AnnotateDeviceRegions should annotate thread_extent regions with the Sunmmio target."""
     target = make_sunmmio_target_with_host()
 
     with tvm.target.Target(target):
         mod = simple_kernel(4, 4)
 
-    mod = tvm.tir.transform.BindTarget(target)(mod)
-    # Should not raise
+    mod = run_pre_split_passes(mod, target)
     mod = tilelang.transform.AnnotateDeviceRegions()(mod)
 
-    # The device target on the annotated region must be the Sunmmio target
     script = mod.script()
     assert "sunmmio" in script.lower(), (
         f"Expected Sunmmio target annotation in script, got:\n{script}"
     )
+    print("test_annotate_device_regions_runs_on_sunmmio passed.")
 
 
 def test_split_host_device_produces_two_functions():
@@ -51,7 +71,7 @@ def test_split_host_device_produces_two_functions():
     with tvm.target.Target(target):
         mod = simple_kernel(4, 4)
 
-    mod = tvm.tir.transform.BindTarget(target)(mod)
+    mod = run_pre_split_passes(mod, target)
     mod = tilelang.transform.AnnotateDeviceRegions()(mod)
     mod = tilelang.transform.SplitHostDevice()(mod)
 
@@ -59,6 +79,7 @@ def test_split_host_device_produces_two_functions():
     assert len(funcs) == 2, (
         f"Expected 2 functions after SplitHostDevice, got {len(funcs)}: {list(funcs.keys())}"
     )
+    print("test_split_host_device_produces_two_functions passed.")
 
 
 def test_split_host_device_device_func_has_sunmmio_target():
@@ -68,22 +89,16 @@ def test_split_host_device_device_func_has_sunmmio_target():
     with tvm.target.Target(target):
         mod = simple_kernel(4, 4)
 
-    mod = tvm.tir.transform.BindTarget(target)(mod)
+    mod = run_pre_split_passes(mod, target)
     mod = tilelang.transform.AnnotateDeviceRegions()(mod)
     mod = tilelang.transform.SplitHostDevice()(mod)
 
-    device_funcs = [
-        f for f in mod.functions.values()
-        if f.attrs.get("calling_conv", None) == CallingConv.DEVICE_KERNEL_LAUNCH
-    ]
+    device_funcs = get_device_func(mod)
     assert len(device_funcs) == 1, (
-        f"Expected exactly 1 device function, got {len(device_funcs)}"
+        f"Expected exactly 1 Sunmmio device function, got {len(device_funcs)}.\n"
+        f"Functions: { {gv.name_hint: dict(f.attrs) for gv, f in mod.functions.items()} }"
     )
-    device_func = device_funcs[0]
-    func_target = device_func.attrs["target"]
-    assert target_is_sunmmio(func_target), (
-        f"Expected device function target to be Sunmmio, got: {func_target}"
-    )
+    print("test_split_host_device_device_func_has_sunmmio_target passed.")
 
 
 def test_split_host_device_device_func_is_threadless():
@@ -93,19 +108,17 @@ def test_split_host_device_device_func_is_threadless():
     with tvm.target.Target(target):
         mod = simple_kernel(4, 4)
 
-    mod = tvm.tir.transform.BindTarget(target)(mod)
+    mod = run_pre_split_passes(mod, target)
     mod = tilelang.transform.AnnotateDeviceRegions()(mod)
     mod = tilelang.transform.SplitHostDevice()(mod)
 
-    device_funcs = [
-        f for f in mod.functions.values()
-        if f.attrs.get("calling_conv", None) == CallingConv.DEVICE_KERNEL_LAUNCH
-    ]
+    device_funcs = get_device_func(mod)
     assert len(device_funcs) == 1
     script = device_funcs[0].script()
     assert "threadIdx.x\", 1)" in script, (
         f"Expected threadIdx.x extent 1 in device function, got:\n{script}"
     )
+    print("test_split_host_device_device_func_is_threadless passed.")
 
 
 if __name__ == "__main__":

--- a/testing/python/transform/test_tilelang_transform_sunmmio_annotate_split.py
+++ b/testing/python/transform/test_tilelang_transform_sunmmio_annotate_split.py
@@ -52,7 +52,6 @@ def get_device_func(mod):
 
 
 def simple_kernel(M, N, dtype=T.float32):
-
     @T.prim_func
     def main(A: T.Tensor((M, N), dtype), B: T.Tensor((M, N), dtype)):
         with T.Kernel(M, N) as (bx, by):

--- a/testing/python/transform/test_tilelang_transform_sunmmio_annotate_split.py
+++ b/testing/python/transform/test_tilelang_transform_sunmmio_annotate_split.py
@@ -1,0 +1,116 @@
+import tilelang
+import tilelang.language as T
+import tilelang.transform
+from tilelang import tvm as tvm
+from tilelang.utils.target import determine_target, target_is_sunmmio
+from tilelang.engine.lower import canon_target_host
+from tvm.ir import CallingConv
+
+tilelang.env.disable_cache()
+
+
+def make_sunmmio_target_with_host():
+    """Build the Sunmmio target with an llvm host, matching what lower() does."""
+    target = determine_target("Sunmmio", return_object=True)
+    target_host = tvm.target.Target.canon_target(canon_target_host(target, None))
+    return tvm.target.Target(target, target_host)
+
+
+def simple_kernel(M, N, dtype=T.float32):
+
+    @T.prim_func
+    def main(A: T.Tensor((M, N), dtype), B: T.Tensor((M, N), dtype)):
+        with T.Kernel(M, N) as (bx, by):
+            B[bx, by] = A[bx, by]
+
+    return tvm.IRModule({"main": main})
+
+
+def test_annotate_device_regions_runs_on_sunmmio():
+    """AnnotateDeviceRegions should not crash and should annotate thread_extent regions."""
+    target = make_sunmmio_target_with_host()
+
+    with tvm.target.Target(target):
+        mod = simple_kernel(4, 4)
+
+    mod = tvm.tir.transform.BindTarget(target)(mod)
+    # Should not raise
+    mod = tilelang.transform.AnnotateDeviceRegions()(mod)
+
+    # The device target on the annotated region must be the Sunmmio target
+    script = mod.script()
+    assert "sunmmio" in script.lower(), (
+        f"Expected Sunmmio target annotation in script, got:\n{script}"
+    )
+
+
+def test_split_host_device_produces_two_functions():
+    """SplitHostDevice should split the module into a host and a device function."""
+    target = make_sunmmio_target_with_host()
+
+    with tvm.target.Target(target):
+        mod = simple_kernel(4, 4)
+
+    mod = tvm.tir.transform.BindTarget(target)(mod)
+    mod = tilelang.transform.AnnotateDeviceRegions()(mod)
+    mod = tilelang.transform.SplitHostDevice()(mod)
+
+    funcs = dict(mod.functions)
+    assert len(funcs) == 2, (
+        f"Expected 2 functions after SplitHostDevice, got {len(funcs)}: {list(funcs.keys())}"
+    )
+
+
+def test_split_host_device_device_func_has_sunmmio_target():
+    """The device function produced by SplitHostDevice should carry the Sunmmio target."""
+    target = make_sunmmio_target_with_host()
+
+    with tvm.target.Target(target):
+        mod = simple_kernel(4, 4)
+
+    mod = tvm.tir.transform.BindTarget(target)(mod)
+    mod = tilelang.transform.AnnotateDeviceRegions()(mod)
+    mod = tilelang.transform.SplitHostDevice()(mod)
+
+    device_funcs = [
+        f for f in mod.functions.values()
+        if f.attrs.get("calling_conv", None) == CallingConv.DEVICE_KERNEL_LAUNCH
+    ]
+    assert len(device_funcs) == 1, (
+        f"Expected exactly 1 device function, got {len(device_funcs)}"
+    )
+    device_func = device_funcs[0]
+    func_target = device_func.attrs["target"]
+    assert target_is_sunmmio(func_target), (
+        f"Expected device function target to be Sunmmio, got: {func_target}"
+    )
+
+
+def test_split_host_device_device_func_is_threadless():
+    """The device function should have threadIdx.x with extent 1 (threadless)."""
+    target = make_sunmmio_target_with_host()
+
+    with tvm.target.Target(target):
+        mod = simple_kernel(4, 4)
+
+    mod = tvm.tir.transform.BindTarget(target)(mod)
+    mod = tilelang.transform.AnnotateDeviceRegions()(mod)
+    mod = tilelang.transform.SplitHostDevice()(mod)
+
+    device_funcs = [
+        f for f in mod.functions.values()
+        if f.attrs.get("calling_conv", None) == CallingConv.DEVICE_KERNEL_LAUNCH
+    ]
+    assert len(device_funcs) == 1
+    script = device_funcs[0].script()
+    assert "threadIdx.x\", 1)" in script, (
+        f"Expected threadIdx.x extent 1 in device function, got:\n{script}"
+    )
+
+
+if __name__ == "__main__":
+    test_annotate_device_regions_runs_on_sunmmio()
+    test_split_host_device_produces_two_functions()
+    test_split_host_device_device_func_has_sunmmio_target()
+    test_split_host_device_device_func_is_threadless()
+    print("All tests passed.")

--- a/testing/python/transform/test_tilelang_transform_sunmmio_annotate_split.py
+++ b/testing/python/transform/test_tilelang_transform_sunmmio_annotate_split.py
@@ -2,6 +2,8 @@ import tilelang
 import tilelang.language as T
 import tilelang.transform
 from tilelang import tvm as tvm
+from tvm import tir
+from tvm.tir.stmt_functor import post_order_visit
 from tilelang.utils.target import determine_target, target_is_sunmmio
 from tilelang.engine.lower import canon_target_host
 
@@ -20,6 +22,18 @@ def run_pre_split_passes(mod, target):
     mod = tvm.tir.transform.BindTarget(target)(mod)
     mod = tilelang.transform.LowerOpaqueBlock()(mod)
     return mod
+
+
+def collect_attr_stmts(stmt, attr_key):
+    """Walk TIR and return all AttrStmt nodes with the given attr_key."""
+    found = []
+
+    def fvisit(node):
+        if isinstance(node, tir.AttrStmt) and node.attr_key == attr_key:
+            found.append(node)
+
+    post_order_visit(stmt, fvisit)
+    return found
 
 
 def get_device_func(mod):
@@ -47,8 +61,9 @@ def simple_kernel(M, N, dtype=T.float32):
     return tvm.IRModule({"main": main})
 
 
-def test_annotate_device_regions_runs_on_sunmmio():
-    """AnnotateDeviceRegions should annotate thread_extent regions with the Sunmmio target."""
+def test_annotate_device_regions_wraps_thread_extent_with_target():
+    """AnnotateDeviceRegions must wrap thread_extent regions with a 'target' AttrStmt
+    pointing to the Sunmmio device target (no host)."""
     target = make_sunmmio_target_with_host()
 
     with tvm.target.Target(target):
@@ -57,11 +72,22 @@ def test_annotate_device_regions_runs_on_sunmmio():
     mod = run_pre_split_passes(mod, target)
     mod = tilelang.transform.AnnotateDeviceRegions()(mod)
 
-    script = mod.script()
-    assert "sunmmio" in script.lower(), (
-        f"Expected Sunmmio target annotation in script, got:\n{script}"
-    )
-    print("test_annotate_device_regions_runs_on_sunmmio passed.")
+    func = mod["main"]
+    target_attrs = collect_attr_stmts(func.body, "target")
+
+    assert len(target_attrs) >= 1, (
+        f"Expected at least one 'target' AttrStmt after AnnotateDeviceRegions, found none.\n"
+        f"Function body:\n{func.script()}")
+
+    device_target_node = target_attrs[0].node
+    assert target_is_sunmmio(device_target_node), (
+        f"Expected 'target' AttrStmt to annotate with the Sunmmio device target, "
+        f"got: {device_target_node}")
+
+    inner_stmt = target_attrs[0].body
+    assert isinstance(inner_stmt, tir.AttrStmt) and inner_stmt.attr_key == "thread_extent", (
+        f"Expected the body of the 'target' AttrStmt to be a 'thread_extent' AttrStmt "
+        f"(the thread launch region), got: {type(inner_stmt)}")
 
 
 def test_split_host_device_produces_two_functions():
@@ -77,13 +103,15 @@ def test_split_host_device_produces_two_functions():
 
     funcs = dict(mod.functions)
     assert len(funcs) == 2, (
-        f"Expected 2 functions after SplitHostDevice, got {len(funcs)}: {list(funcs.keys())}"
-    )
-    print("test_split_host_device_produces_two_functions passed.")
+        f"Expected 2 functions after SplitHostDevice, got {len(funcs)}: {list(funcs.keys())}")
 
 
 def test_split_host_device_device_func_has_sunmmio_target():
-    """The device function produced by SplitHostDevice should carry the Sunmmio target."""
+    """The device function produced by SplitHostDevice should carry the Sunmmio device target.
+
+    SplitHostDevice does not set CallingConv.DEVICE_KERNEL_LAUNCH; the device function
+    is identified by its target attribute having no host.
+    """
     target = make_sunmmio_target_with_host()
 
     with tvm.target.Target(target):
@@ -96,13 +124,13 @@ def test_split_host_device_device_func_has_sunmmio_target():
     device_funcs = get_device_func(mod)
     assert len(device_funcs) == 1, (
         f"Expected exactly 1 Sunmmio device function, got {len(device_funcs)}.\n"
-        f"Functions: { {gv.name_hint: dict(f.attrs) for gv, f in mod.functions.items()} }"
-    )
-    print("test_split_host_device_device_func_has_sunmmio_target passed.")
+        f"Functions: { {gv.name_hint: dict(f.attrs) for gv, f in mod.functions.items()} }")
+    assert target_is_sunmmio(device_funcs[0].attrs["target"]), (
+        f"Expected device function target to be Sunmmio, got: {device_funcs[0].attrs['target']}")
 
 
 def test_split_host_device_device_func_is_threadless():
-    """The device function should have threadIdx.x with extent 1 (threadless)."""
+    """The device function body must contain threadIdx.x with extent 1 (Sunmmio is threadless)."""
     target = make_sunmmio_target_with_host()
 
     with tvm.target.Target(target):
@@ -113,16 +141,30 @@ def test_split_host_device_device_func_is_threadless():
     mod = tilelang.transform.SplitHostDevice()(mod)
 
     device_funcs = get_device_func(mod)
-    assert len(device_funcs) == 1
-    script = device_funcs[0].script()
-    assert "threadIdx.x\", 1)" in script, (
-        f"Expected threadIdx.x extent 1 in device function, got:\n{script}"
-    )
-    print("test_split_host_device_device_func_is_threadless passed.")
+    assert len(device_funcs) == 1, (
+        "Expected a device function (Sunmmio target + kIsGlobalFunc) after SplitHostDevice, "
+        f"found none.\nFunctions in module: {[str(gv) for gv in mod.functions]}")
+    device_func = device_funcs[0]
+
+    thread_extents = {}
+
+    def fvisit(node):
+        if isinstance(node, tir.AttrStmt) and node.attr_key == "thread_extent":
+            thread_extents[node.node.thread_tag] = int(node.value)
+
+    post_order_visit(device_func.body, fvisit)
+
+    assert "threadIdx.x" in thread_extents, (
+        f"Expected a 'thread_extent' AttrStmt for threadIdx.x in the device function body. "
+        f"Found thread extents: {thread_extents}\n"
+        f"Device function:\n{device_func.script()}")
+    assert thread_extents["threadIdx.x"] == 1, (
+        f"Expected threadIdx.x extent to be 1 (Sunmmio is threadless), "
+        f"got {thread_extents['threadIdx.x']}")
 
 
 if __name__ == "__main__":
-    test_annotate_device_regions_runs_on_sunmmio()
+    test_annotate_device_regions_wraps_thread_extent_with_target()
     test_split_host_device_produces_two_functions()
     test_split_host_device_device_func_has_sunmmio_target()
     test_split_host_device_device_func_is_threadless()

--- a/testing/python/transform/test_tilelang_transform_sunmmio_annotate_split.py
+++ b/testing/python/transform/test_tilelang_transform_sunmmio_annotate_split.py
@@ -129,8 +129,8 @@ def test_split_host_device_device_func_has_sunmmio_target():
         f"Expected device function target to be Sunmmio, got: {device_funcs[0].attrs['target']}")
 
 
-def test_split_host_device_device_func_is_threadless():
-    """The device function body must contain threadIdx.x with extent 1 (Sunmmio is threadless)."""
+def test_split_host_device_device_func_has_no_thread_bindings():
+    """The device function body must contain no threadIdx bindings (Sunmmio is fully threadless)."""
     target = make_sunmmio_target_with_host()
 
     with tvm.target.Target(target):
@@ -154,18 +154,15 @@ def test_split_host_device_device_func_is_threadless():
 
     post_order_visit(device_func.body, fvisit)
 
-    assert "threadIdx.x" in thread_extents, (
-        f"Expected a 'thread_extent' AttrStmt for threadIdx.x in the device function body. "
+    assert "threadIdx.x" not in thread_extents, (
+        f"Sunmmio device function must have no threadIdx bindings (threadless). "
         f"Found thread extents: {thread_extents}\n"
         f"Device function:\n{device_func.script()}")
-    assert thread_extents["threadIdx.x"] == 1, (
-        f"Expected threadIdx.x extent to be 1 (Sunmmio is threadless), "
-        f"got {thread_extents['threadIdx.x']}")
 
 
 if __name__ == "__main__":
     test_annotate_device_regions_wraps_thread_extent_with_target()
     test_split_host_device_produces_two_functions()
     test_split_host_device_device_func_has_sunmmio_target()
-    test_split_host_device_device_func_is_threadless()
+    test_split_host_device_device_func_has_no_thread_bindings()
     print("All tests passed.")

--- a/testing/python/transform/test_tilelang_transform_sunmmio_annotate_split.py
+++ b/testing/python/transform/test_tilelang_transform_sunmmio_annotate_split.py
@@ -44,9 +44,8 @@ def get_device_func(mod):
     is GPU-only). We identify it by kIsGlobalFunc + Sunmmio target.
     """
     candidates = [
-        f for f in mod.functions.values()
-        if f.attrs.get("tir.is_global_func", False) and
-           "target" in f.attrs and target_is_sunmmio(f.attrs["target"])
+        f for f in mod.functions.values() if f.attrs.get("tir.is_global_func", False)
+        and "target" in f.attrs and target_is_sunmmio(f.attrs["target"])
     ]
     return candidates
 

--- a/testing/python/transform/test_tilelang_transform_sunmmio_threadless_lower_and_legalize.py
+++ b/testing/python/transform/test_tilelang_transform_sunmmio_threadless_lower_and_legalize.py
@@ -1,0 +1,260 @@
+"""End-to-end cascaded tests for LowerAndLegalize on threadless Sunmmio kernels.
+
+Each test function runs the passes in LowerAndLegalize **in sequence**, asserting
+the threadless invariants (no threadIdx, no v_thread, blockIdx preserved) after
+every individual pass. When a pass breaks a threadless kernel, the assertion
+failure names exactly which pass is responsible.
+
+Passes run in order (mirroring phase.py LowerAndLegalize):
+    01  BindTarget
+    02  AddWrapperForSingleBufStore
+    03  LegalizeNegativeIndex
+    04  InjectAssumes
+    05  Simplify
+    06  InferSramScope
+    07  LayoutReducer
+    08  LayoutInference
+    09  LowerTileOp
+    10  LowerL2Persistent
+    11  LegalizeVectorizedLoop
+    12  LegalizeSafeMemoryAccess
+    13  Simplify (2nd)
+
+Kernel variants covered:
+    1. Simple element-wise copy    — no shared memory, no T.Parallel
+    2. T.Parallel + shared memory  — the original ThreadBindingCollector bug trigger
+    3. Multi-block element-wise    — 3-D grid (bx, by, bz) with arithmetic
+
+Note on target context: VectorizePlanner::Plan (called from ParallelOpNode::InferLayout
+inside LayoutInference) calls Target::Current() at runtime. For kernels that use
+T.Parallel, the target context must remain active for the duration of the pass
+cascade. All test functions therefore run entirely inside a with tvm.target.Target block.
+"""
+import tilelang
+import tilelang.language as T
+import tilelang.transform as tl_transform
+from tilelang import tvm as tvm
+from tilelang.utils.target import determine_target
+from tvm import tir
+from tvm.tir.stmt_functor import post_order_visit
+
+tilelang.env.disable_cache()
+
+# ---------------------------------------------------------------------------
+# Kernel helpers
+# ---------------------------------------------------------------------------
+
+
+def make_elementwise_copy_kernel(M, N, dtype=T.float32):
+    """Simplest threadless kernel: copy A → B element-by-element."""
+
+    @T.prim_func
+    def main(A: T.Tensor((M, N), dtype), B: T.Tensor((M, N), dtype)):
+        with T.Kernel(M, N) as (bx, by):
+            B[bx, by] = A[bx, by]
+
+    return tvm.IRModule({"main": main})
+
+
+def make_parallel_shared_kernel(M, N, dtype=T.float32):
+    """Threadless kernel with T.Parallel loops and shared memory.
+
+    This is the exact scenario that previously triggered the
+    ThreadBindingCollector bug in LayoutInference.
+    """
+
+    @T.prim_func
+    def main(A: T.Tensor((M, N), dtype), B: T.Tensor((M, N), dtype)):
+        with T.Kernel(T.ceildiv(M, 32), T.ceildiv(N, 32)) as (bx, by):
+            A_shared = T.alloc_shared((32, 32), dtype)
+            for i, j in T.Parallel(32, 32):
+                A_shared[i, j] = A[bx * 32 + i, by * 32 + j]
+            for i, j in T.Parallel(32, 32):
+                B[bx * 32 + i, by * 32 + j] = A_shared[i, j]
+
+    return tvm.IRModule({"main": main})
+
+
+def make_3d_grid_kernel(M, N, K, dtype=T.float32):
+    """Threadless kernel with a 3-D grid (bx, by, bz) and elementwise arithmetic."""
+
+    @T.prim_func
+    def main(A: T.Tensor((M, N, K), dtype), B: T.Tensor((M, N, K), dtype)):
+        with T.Kernel(M, N, K) as (bx, by, bz):
+            B[bx, by, bz] = A[bx, by, bz] + T.float32(1.0)
+
+    return tvm.IRModule({"main": main})
+
+
+# ---------------------------------------------------------------------------
+# IR inspection helpers
+# ---------------------------------------------------------------------------
+
+
+def collect_thread_extents(func):
+    extents = {}
+
+    def fvisit(node):
+        if isinstance(node, tir.AttrStmt) and node.attr_key == "thread_extent":
+            extents[node.node.thread_tag] = int(node.value)
+
+    post_order_visit(func.body, fvisit)
+    return extents
+
+
+def collect_var_names(func):
+    names = set()
+
+    def fvisit(node):
+        if isinstance(node, tir.Var):
+            names.add(node.name)
+
+    post_order_visit(func.body, fvisit)
+    return names
+
+
+def assert_threadless_invariants(mod, after_pass):
+    """Assert all three threadless invariants on mod["main"].
+
+    - No threadIdx.* bindings introduced
+    - No free v_thread variable
+    - blockIdx.* bindings still present
+    """
+    func = mod["main"]
+    extents = collect_thread_extents(func)
+    var_names = collect_var_names(func)
+
+    threadidx_tags = [t for t in extents if t.startswith("threadIdx")]
+    blockidx_tags = [t for t in extents if t.startswith("blockIdx")]
+
+    assert not threadidx_tags, (
+        f"After {after_pass}: threadIdx bindings must not exist in a threadless "
+        f"Sunmmio kernel. Found: {threadidx_tags}\nAll extents: {extents}\n"
+        f"IR:\n{func.script()}")
+
+    assert "v_thread" not in var_names, (
+        f"After {after_pass}: free v_thread variable found. A pass incorrectly "
+        f"treated blockIdx as a thread binding and called PartitionLoop with the "
+        f"unbound dummy thread variable.\nAll vars: {sorted(var_names)}\n"
+        f"IR:\n{func.script()}")
+
+    assert blockidx_tags, (
+        f"After {after_pass}: blockIdx bindings must be preserved in a threadless "
+        f"Sunmmio kernel. Found extents: {extents}\nIR:\n{func.script()}")
+
+
+# ---------------------------------------------------------------------------
+# Cascaded pipeline helper
+# ---------------------------------------------------------------------------
+
+
+def run_lower_and_legalize_cascade(mod, target):
+    """Run every pass in LowerAndLegalize in order, asserting threadless invariants
+    after each one. Returns the final transformed module.
+
+    Mirrors the pass sequence in tilelang/engine/phase.py LowerAndLegalize.
+    """
+    mod = tir.transform.BindTarget(target)(mod)
+    assert_threadless_invariants(mod, "BindTarget")
+
+    mod = tl_transform.AddWrapperForSingleBufStore()(mod)
+    assert_threadless_invariants(mod, "AddWrapperForSingleBufStore")
+
+    mod = tl_transform.LegalizeNegativeIndex()(mod)
+    assert_threadless_invariants(mod, "LegalizeNegativeIndex")
+
+    mod = tl_transform.InjectAssumes()(mod)
+    assert_threadless_invariants(mod, "InjectAssumes")
+
+    mod = tl_transform.Simplify()(mod)
+    assert_threadless_invariants(mod, "Simplify[1]")
+
+    mod = tl_transform.InferSramScope()(mod)
+    assert_threadless_invariants(mod, "InferSramScope")
+
+    mod = tl_transform.LayoutReducer()(mod)
+    assert_threadless_invariants(mod, "LayoutReducer")
+
+    mod = tl_transform.LayoutInference()(mod)
+    assert_threadless_invariants(mod, "LayoutInference")
+
+    mod = tl_transform.LowerTileOp()(mod)
+    assert_threadless_invariants(mod, "LowerTileOp")
+
+    mod = tl_transform.LowerL2Persistent()(mod)
+    assert_threadless_invariants(mod, "LowerL2Persistent")
+
+    mod = tl_transform.LegalizeVectorizedLoop()(mod)
+    assert_threadless_invariants(mod, "LegalizeVectorizedLoop")
+
+    mod = tl_transform.LegalizeSafeMemoryAccess()(mod)
+    assert_threadless_invariants(mod, "LegalizeSafeMemoryAccess")
+
+    mod = tl_transform.Simplify()(mod)
+    assert_threadless_invariants(mod, "Simplify[2]")
+
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_lower_and_legalize_cascade_elementwise_copy():
+    """All passes in LowerAndLegalize must preserve threadless invariants for a copy kernel.
+
+    Checks after every pass:
+      - no threadIdx bindings injected
+      - no free v_thread variable introduced
+      - blockIdx bindings preserved
+    """
+    target = determine_target("Sunmmio", return_object=True)
+
+    with tvm.target.Target(target):
+        mod = make_elementwise_copy_kernel(16, 16)
+
+    run_lower_and_legalize_cascade(mod, target)
+
+
+def test_lower_and_legalize_cascade_parallel_shared():
+    """All passes in LowerAndLegalize must preserve threadless invariants for a
+    T.Parallel + shared memory kernel — the original ThreadBindingCollector bug trigger.
+
+    Checks after every pass:
+      - no threadIdx bindings injected
+      - no free v_thread variable introduced
+      - blockIdx bindings preserved
+
+    Note: target context must stay active throughout because VectorizePlanner::Plan
+    (inside LayoutInference) calls Target::Current() at runtime.
+    """
+    target = determine_target("Sunmmio", return_object=True)
+
+    with tvm.target.Target(target):
+        mod = make_parallel_shared_kernel(64, 64)
+        run_lower_and_legalize_cascade(mod, target)
+
+
+def test_lower_and_legalize_cascade_3d_grid():
+    """All passes in LowerAndLegalize must preserve threadless invariants for a
+    3-D grid kernel.
+
+    Checks after every pass:
+      - no threadIdx bindings injected
+      - no free v_thread variable introduced
+      - blockIdx bindings preserved
+    """
+    target = determine_target("Sunmmio", return_object=True)
+
+    with tvm.target.Target(target):
+        mod = make_3d_grid_kernel(4, 4, 4)
+
+    run_lower_and_legalize_cascade(mod, target)
+
+
+if __name__ == "__main__":
+    test_lower_and_legalize_cascade_elementwise_copy()
+    test_lower_and_legalize_cascade_parallel_shared()
+    test_lower_and_legalize_cascade_3d_grid()
+    print("All tests passed.")

--- a/testing/python/transform/test_tilelang_transform_sunmmio_threadless_lower_and_legalize.py
+++ b/testing/python/transform/test_tilelang_transform_sunmmio_threadless_lower_and_legalize.py
@@ -30,6 +30,7 @@ inside LayoutInference) calls Target::Current() at runtime. For kernels that use
 T.Parallel, the target context must remain active for the duration of the pass
 cascade. All test functions therefore run entirely inside a with tvm.target.Target block.
 """
+
 import tilelang
 import tilelang.language as T
 import tilelang.transform as tl_transform
@@ -130,17 +131,20 @@ def assert_threadless_invariants(mod, after_pass):
     assert not threadidx_tags, (
         f"After {after_pass}: threadIdx bindings must not exist in a threadless "
         f"Sunmmio kernel. Found: {threadidx_tags}\nAll extents: {extents}\n"
-        f"IR:\n{func.script()}")
+        f"IR:\n{func.script()}"
+    )
 
     assert "v_thread" not in var_names, (
         f"After {after_pass}: free v_thread variable found. A pass incorrectly "
         f"treated blockIdx as a thread binding and called PartitionLoop with the "
         f"unbound dummy thread variable.\nAll vars: {sorted(var_names)}\n"
-        f"IR:\n{func.script()}")
+        f"IR:\n{func.script()}"
+    )
 
     assert blockidx_tags, (
         f"After {after_pass}: blockIdx bindings must be preserved in a threadless "
-        f"Sunmmio kernel. Found extents: {extents}\nIR:\n{func.script()}")
+        f"Sunmmio kernel. Found extents: {extents}\nIR:\n{func.script()}"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/testing/python/transform/test_tilelang_transform_sunmmio_threadless_optimize_for_target.py
+++ b/testing/python/transform/test_tilelang_transform_sunmmio_threadless_optimize_for_target.py
@@ -126,8 +126,8 @@ def collect_var_names(func):
 def get_device_func(mod):
     """Return the device PrimFunc: the one whose target attribute has no host."""
     for func in mod.functions.values():
-        if (isinstance(func, tir.PrimFunc) and func.attrs is not None and
-                "target" in func.attrs and not func.attrs["target"].host):
+        if (isinstance(func, tir.PrimFunc) and func.attrs is not None and "target" in func.attrs
+                and not func.attrs["target"].host):
             return func
     return None
 
@@ -234,17 +234,15 @@ def run_optimize_for_sunmmio_cascade(mod, target):
 
     mod = tl_transform.MakePackedAPI()(mod)
     device_func = get_device_func(mod)
-    assert device_func is not None, (
-        "After MakePackedAPI: device function lost. "
-        f"Functions: {[str(gv) for gv in mod.functions]}")
+    assert device_func is not None, ("After MakePackedAPI: device function lost. "
+                                     f"Functions: {[str(gv) for gv in mod.functions]}")
     assert_threadless_invariants(device_func, "MakePackedAPI")
 
     mod = tl_transform.LowerDeviceKernelLaunch()(mod)
     # LowerDeviceKernelLaunch rewrites the host launcher; device body is unchanged.
     device_func = get_device_func(mod)
-    assert device_func is not None, (
-        "After LowerDeviceKernelLaunch: device function lost. "
-        f"Functions: {[str(gv) for gv in mod.functions]}")
+    assert device_func is not None, ("After LowerDeviceKernelLaunch: device function lost. "
+                                     f"Functions: {[str(gv) for gv in mod.functions]}")
     assert_threadless_invariants(device_func, "LowerDeviceKernelLaunch")
 
     return mod

--- a/testing/python/transform/test_tilelang_transform_sunmmio_threadless_optimize_for_target.py
+++ b/testing/python/transform/test_tilelang_transform_sunmmio_threadless_optimize_for_target.py
@@ -39,6 +39,7 @@ Note on target context: VectorizePlanner::Plan inside LayoutInference calls
 Target::Current() at runtime. All test functions run entirely inside a
 `with tvm.target.Target(target):` block to keep the context active.
 """
+
 import tilelang
 import tilelang.language as T
 import tilelang.transform as tl_transform
@@ -126,8 +127,7 @@ def collect_var_names(func):
 def get_device_func(mod):
     """Return the device PrimFunc: the one whose target attribute has no host."""
     for func in mod.functions.values():
-        if (isinstance(func, tir.PrimFunc) and func.attrs is not None and "target" in func.attrs
-                and not func.attrs["target"].host):
+        if isinstance(func, tir.PrimFunc) and func.attrs is not None and "target" in func.attrs and not func.attrs["target"].host:
             return func
     return None
 
@@ -148,16 +148,19 @@ def assert_threadless_invariants(func, after_pass):
     assert not threadidx_tags, (
         f"After {after_pass}: threadIdx bindings must not exist in a threadless "
         f"Sunmmio kernel. Found: {threadidx_tags}\nAll extents: {extents}\n"
-        f"IR:\n{func.script()}")
+        f"IR:\n{func.script()}"
+    )
 
     assert "v_thread" not in var_names, (
         f"After {after_pass}: free v_thread variable found. A pass incorrectly "
         f"treated blockIdx as a thread binding and called PartitionLoop.\n"
-        f"All vars: {sorted(var_names)}\nIR:\n{func.script()}")
+        f"All vars: {sorted(var_names)}\nIR:\n{func.script()}"
+    )
 
     assert blockidx_tags, (
         f"After {after_pass}: blockIdx bindings must be preserved in a threadless "
-        f"Sunmmio kernel. Found extents: {extents}\nIR:\n{func.script()}")
+        f"Sunmmio kernel. Found extents: {extents}\nIR:\n{func.script()}"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -225,7 +228,8 @@ def run_optimize_for_sunmmio_cascade(mod, target):
     device_func = get_device_func(mod)
     assert device_func is not None, (
         "After SplitHostDevice: expected a device function (target attr with no host), "
-        f"found none. Functions: {[str(gv) for gv in mod.functions]}")
+        f"found none. Functions: {[str(gv) for gv in mod.functions]}"
+    )
     assert_threadless_invariants(device_func, "SplitHostDevice")
 
     # MergeSRAMAllocations  -- SKIPPED (under implementation)
@@ -234,15 +238,13 @@ def run_optimize_for_sunmmio_cascade(mod, target):
 
     mod = tl_transform.MakePackedAPI()(mod)
     device_func = get_device_func(mod)
-    assert device_func is not None, ("After MakePackedAPI: device function lost. "
-                                     f"Functions: {[str(gv) for gv in mod.functions]}")
+    assert device_func is not None, f"After MakePackedAPI: device function lost. Functions: {[str(gv) for gv in mod.functions]}"
     assert_threadless_invariants(device_func, "MakePackedAPI")
 
     mod = tl_transform.LowerDeviceKernelLaunch()(mod)
     # LowerDeviceKernelLaunch rewrites the host launcher; device body is unchanged.
     device_func = get_device_func(mod)
-    assert device_func is not None, ("After LowerDeviceKernelLaunch: device function lost. "
-                                     f"Functions: {[str(gv) for gv in mod.functions]}")
+    assert device_func is not None, f"After LowerDeviceKernelLaunch: device function lost. Functions: {[str(gv) for gv in mod.functions]}"
     assert_threadless_invariants(device_func, "LowerDeviceKernelLaunch")
 
     return mod

--- a/testing/python/transform/test_tilelang_transform_sunmmio_threadless_optimize_for_target.py
+++ b/testing/python/transform/test_tilelang_transform_sunmmio_threadless_optimize_for_target.py
@@ -1,0 +1,318 @@
+"""Cascaded tests for OptimizeForSunmmio passes on threadless Sunmmio kernels.
+
+Each test function first runs LowerAndLegalize (Phase 1) to produce a correctly
+lowered module, then cascades through every OptimizeForSunmmio pass (Phase 2) in
+order, asserting threadless invariants after each pass.
+
+Passes run in order (mirroring OptimizeForSunmmio in phase.py):
+    01  IfStmtBinding
+    --  InjectGreedyPipeline     SKIPPED (under implementation)
+    --  InjectAsyncToken         SKIPPED (under implementation)
+    02  MergeIfStmt
+    03  LowerOpaqueBlock
+    04  NarrowDataType
+    05  FlattenBuffer
+    06  ConfigIndexBitwidth
+    07  Simplify[1]
+    08  VectorizeLoop
+    09  UnrollLoop
+    10  Simplify[2]
+    11  RemoveNoOp
+    12  HoistIfThenElse
+    13  AnnotateDeviceRegions       ← splits the IR into host/device regions
+    14  SplitHostDevice             ← mod["main"] becomes host; device func extracted
+    --  MergeSRAMAllocations     SKIPPED (under implementation)
+    15  MakePackedAPI
+    16  LowerDeviceKernelLaunch
+
+Assertion strategy:
+    - Passes 01-13: assert on mod["main"] — no threadIdx, no v_thread, blockIdx present
+    - Pass 14 (SplitHostDevice) onward: assert on the device function (identified
+      by its target attribute having no host)
+
+Kernel variants covered:
+    1. Simple element-wise copy    — no shared memory, no T.Parallel
+    2. T.Parallel + shared memory  — original ThreadBindingCollector bug trigger
+    3. 3-D grid (bx, by, bz)       — multi-dimensional grid with arithmetic
+
+Note on target context: VectorizePlanner::Plan inside LayoutInference calls
+Target::Current() at runtime. All test functions run entirely inside a
+`with tvm.target.Target(target):` block to keep the context active.
+"""
+import tilelang
+import tilelang.language as T
+import tilelang.transform as tl_transform
+from tilelang import tvm as tvm
+from tilelang.engine.lower import canon_target_host
+from tilelang.engine.phase import LowerAndLegalize
+from tilelang.utils.target import determine_target
+from tvm import tir
+from tvm.tir.stmt_functor import post_order_visit
+
+tilelang.env.disable_cache()
+
+# ---------------------------------------------------------------------------
+# Kernel helpers
+# ---------------------------------------------------------------------------
+
+
+def make_elementwise_copy_kernel(M, N, dtype=T.float32):
+
+    @T.prim_func
+    def main(A: T.Tensor((M, N), dtype), B: T.Tensor((M, N), dtype)):
+        with T.Kernel(M, N) as (bx, by):
+            B[bx, by] = A[bx, by]
+
+    return tvm.IRModule({"main": main})
+
+
+def make_parallel_shared_kernel(M, N, dtype=T.float32):
+
+    @T.prim_func
+    def main(A: T.Tensor((M, N), dtype), B: T.Tensor((M, N), dtype)):
+        with T.Kernel(T.ceildiv(M, 32), T.ceildiv(N, 32)) as (bx, by):
+            A_shared = T.alloc_shared((32, 32), dtype)
+            for i, j in T.Parallel(32, 32):
+                A_shared[i, j] = A[bx * 32 + i, by * 32 + j]
+            for i, j in T.Parallel(32, 32):
+                B[bx * 32 + i, by * 32 + j] = A_shared[i, j]
+
+    return tvm.IRModule({"main": main})
+
+
+def make_3d_grid_kernel(M, N, K, dtype=T.float32):
+
+    @T.prim_func
+    def main(A: T.Tensor((M, N, K), dtype), B: T.Tensor((M, N, K), dtype)):
+        with T.Kernel(M, N, K) as (bx, by, bz):
+            B[bx, by, bz] = A[bx, by, bz] + T.float32(1.0)
+
+    return tvm.IRModule({"main": main})
+
+
+def make_sunmmio_target_with_host():
+    target = determine_target("Sunmmio", return_object=True)
+    target_host = tvm.target.Target.canon_target(canon_target_host(target, None))
+    return tvm.target.Target(target, target_host)
+
+
+# ---------------------------------------------------------------------------
+# IR inspection helpers
+# ---------------------------------------------------------------------------
+
+
+def collect_thread_extents(func):
+    extents = {}
+
+    def fvisit(node):
+        if isinstance(node, tir.AttrStmt) and node.attr_key == "thread_extent":
+            extents[node.node.thread_tag] = int(node.value)
+
+    post_order_visit(func.body, fvisit)
+    return extents
+
+
+def collect_var_names(func):
+    names = set()
+
+    def fvisit(node):
+        if isinstance(node, tir.Var):
+            names.add(node.name)
+
+    post_order_visit(func.body, fvisit)
+    return names
+
+
+def get_device_func(mod):
+    """Return the device PrimFunc: the one whose target attribute has no host."""
+    for func in mod.functions.values():
+        if (isinstance(func, tir.PrimFunc) and func.attrs is not None and
+                "target" in func.attrs and not func.attrs["target"].host):
+            return func
+    return None
+
+
+def assert_threadless_invariants(func, after_pass):
+    """Assert all three threadless invariants on a PrimFunc.
+
+    - No threadIdx.* bindings introduced
+    - No free v_thread variable
+    - blockIdx.* bindings still present
+    """
+    extents = collect_thread_extents(func)
+    var_names = collect_var_names(func)
+
+    threadidx_tags = [t for t in extents if t.startswith("threadIdx")]
+    blockidx_tags = [t for t in extents if t.startswith("blockIdx")]
+
+    assert not threadidx_tags, (
+        f"After {after_pass}: threadIdx bindings must not exist in a threadless "
+        f"Sunmmio kernel. Found: {threadidx_tags}\nAll extents: {extents}\n"
+        f"IR:\n{func.script()}")
+
+    assert "v_thread" not in var_names, (
+        f"After {after_pass}: free v_thread variable found. A pass incorrectly "
+        f"treated blockIdx as a thread binding and called PartitionLoop.\n"
+        f"All vars: {sorted(var_names)}\nIR:\n{func.script()}")
+
+    assert blockidx_tags, (
+        f"After {after_pass}: blockIdx bindings must be preserved in a threadless "
+        f"Sunmmio kernel. Found extents: {extents}\nIR:\n{func.script()}")
+
+
+# ---------------------------------------------------------------------------
+# Cascaded pipeline helper
+# ---------------------------------------------------------------------------
+
+
+def run_optimize_for_sunmmio_cascade(mod, target):
+    """Run every implemented pass in OptimizeForSunmmio in order, asserting
+    threadless invariants after each one.
+
+    Pre-split assertions target mod["main"].
+    Post-split assertions target the device function (target attr with no host).
+
+    Skipped passes (under implementation):
+        InjectGreedyPipeline, InjectAsyncToken, MergeSRAMAllocations
+    """
+    # --- Pre-split phase: assert on mod["main"] ---
+
+    mod = tl_transform.IfStmtBinding()(mod)
+    assert_threadless_invariants(mod["main"], "IfStmtBinding")
+
+    # InjectGreedyPipeline  -- SKIPPED (under implementation)
+    # InjectAsyncToken      -- SKIPPED (under implementation)
+
+    mod = tl_transform.MergeIfStmt()(mod)
+    assert_threadless_invariants(mod["main"], "MergeIfStmt")
+
+    mod = tl_transform.LowerOpaqueBlock()(mod)
+    assert_threadless_invariants(mod["main"], "LowerOpaqueBlock")
+
+    mod = tir.transform.NarrowDataType(32)(mod)
+    assert_threadless_invariants(mod["main"], "NarrowDataType")
+
+    mod = tl_transform.FlattenBuffer()(mod)
+    assert_threadless_invariants(mod["main"], "FlattenBuffer")
+
+    mod = tl_transform.ConfigIndexBitwidth()(mod)
+    assert_threadless_invariants(mod["main"], "ConfigIndexBitwidth")
+
+    mod = tir.transform.Simplify()(mod)
+    assert_threadless_invariants(mod["main"], "Simplify[1]")
+
+    mod = tl_transform.VectorizeLoop(enable_vectorize=True)(mod)
+    assert_threadless_invariants(mod["main"], "VectorizeLoop")
+
+    mod = tir.transform.UnrollLoop()(mod)
+    assert_threadless_invariants(mod["main"], "UnrollLoop")
+
+    mod = tir.transform.Simplify()(mod)
+    assert_threadless_invariants(mod["main"], "Simplify[2]")
+
+    mod = tir.transform.RemoveNoOp()(mod)
+    assert_threadless_invariants(mod["main"], "RemoveNoOp")
+
+    mod = tir.transform.HoistIfThenElse()(mod)
+    assert_threadless_invariants(mod["main"], "HoistIfThenElse")
+
+    mod = tl_transform.AnnotateDeviceRegions()(mod)
+    assert_threadless_invariants(mod["main"], "AnnotateDeviceRegions")
+
+    # --- Host/device split: mod["main"] becomes the host launcher ---
+
+    mod = tl_transform.SplitHostDevice()(mod)
+    device_func = get_device_func(mod)
+    assert device_func is not None, (
+        "After SplitHostDevice: expected a device function (target attr with no host), "
+        f"found none. Functions: {[str(gv) for gv in mod.functions]}")
+    assert_threadless_invariants(device_func, "SplitHostDevice")
+
+    # MergeSRAMAllocations  -- SKIPPED (under implementation)
+
+    # --- Post-split phase: assert on device function ---
+
+    mod = tl_transform.MakePackedAPI()(mod)
+    device_func = get_device_func(mod)
+    assert device_func is not None, (
+        "After MakePackedAPI: device function lost. "
+        f"Functions: {[str(gv) for gv in mod.functions]}")
+    assert_threadless_invariants(device_func, "MakePackedAPI")
+
+    mod = tl_transform.LowerDeviceKernelLaunch()(mod)
+    # LowerDeviceKernelLaunch rewrites the host launcher; device body is unchanged.
+    device_func = get_device_func(mod)
+    assert device_func is not None, (
+        "After LowerDeviceKernelLaunch: device function lost. "
+        f"Functions: {[str(gv) for gv in mod.functions]}")
+    assert_threadless_invariants(device_func, "LowerDeviceKernelLaunch")
+
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_optimize_for_sunmmio_cascade_elementwise_copy():
+    """All OptimizeForSunmmio passes must preserve threadless invariants for a copy kernel.
+
+    Runs LowerAndLegalize first (Phase 1), then cascades every implemented
+    OptimizeForSunmmio pass (Phase 2) asserting after each one:
+      - no threadIdx bindings injected
+      - no free v_thread variable introduced
+      - blockIdx bindings preserved (pre-split: main; post-split: device func)
+    """
+    target = make_sunmmio_target_with_host()
+    device_target = determine_target("Sunmmio", return_object=True)
+
+    with tvm.target.Target(target):
+        mod = make_elementwise_copy_kernel(16, 16)
+        mod = LowerAndLegalize(mod, device_target)
+        run_optimize_for_sunmmio_cascade(mod, target)
+
+
+def test_optimize_for_sunmmio_cascade_parallel_shared():
+    """All OptimizeForSunmmio passes must preserve threadless invariants for a
+    T.Parallel + shared memory kernel — the original ThreadBindingCollector bug trigger.
+
+    Runs LowerAndLegalize first (Phase 1), then cascades every implemented
+    OptimizeForSunmmio pass (Phase 2) asserting after each one:
+      - no threadIdx bindings injected
+      - no free v_thread variable introduced
+      - blockIdx bindings preserved (pre-split: main; post-split: device func)
+    """
+    target = make_sunmmio_target_with_host()
+    device_target = determine_target("Sunmmio", return_object=True)
+
+    with tvm.target.Target(target):
+        mod = make_parallel_shared_kernel(64, 64)
+        mod = LowerAndLegalize(mod, device_target)
+        run_optimize_for_sunmmio_cascade(mod, target)
+
+
+def test_optimize_for_sunmmio_cascade_3d_grid():
+    """All OptimizeForSunmmio passes must preserve threadless invariants for a
+    3-D grid kernel.
+
+    Runs LowerAndLegalize first (Phase 1), then cascades every implemented
+    OptimizeForSunmmio pass (Phase 2) asserting after each one:
+      - no threadIdx bindings injected
+      - no free v_thread variable introduced
+      - blockIdx bindings preserved (pre-split: main; post-split: device func)
+    """
+    target = make_sunmmio_target_with_host()
+    device_target = determine_target("Sunmmio", return_object=True)
+
+    with tvm.target.Target(target):
+        mod = make_3d_grid_kernel(4, 4, 4)
+        mod = LowerAndLegalize(mod, device_target)
+        run_optimize_for_sunmmio_cascade(mod, target)
+
+
+if __name__ == "__main__":
+    test_optimize_for_sunmmio_cascade_elementwise_copy()
+    test_optimize_for_sunmmio_cascade_parallel_shared()
+    test_optimize_for_sunmmio_cascade_3d_grid()
+    print("All tests passed.")

--- a/testing/python/transform/test_tilelang_transform_sunmmio_threadless_optimize_for_target.py
+++ b/testing/python/transform/test_tilelang_transform_sunmmio_threadless_optimize_for_target.py
@@ -58,7 +58,6 @@ tilelang.env.disable_cache()
 
 
 def make_elementwise_copy_kernel(M, N, dtype=T.float32):
-
     @T.prim_func
     def main(A: T.Tensor((M, N), dtype), B: T.Tensor((M, N), dtype)):
         with T.Kernel(M, N) as (bx, by):
@@ -68,7 +67,6 @@ def make_elementwise_copy_kernel(M, N, dtype=T.float32):
 
 
 def make_parallel_shared_kernel(M, N, dtype=T.float32):
-
     @T.prim_func
     def main(A: T.Tensor((M, N), dtype), B: T.Tensor((M, N), dtype)):
         with T.Kernel(T.ceildiv(M, 32), T.ceildiv(N, 32)) as (bx, by):
@@ -82,7 +80,6 @@ def make_parallel_shared_kernel(M, N, dtype=T.float32):
 
 
 def make_3d_grid_kernel(M, N, K, dtype=T.float32):
-
     @T.prim_func
     def main(A: T.Tensor((M, N, K), dtype), B: T.Tensor((M, N, K), dtype)):
         with T.Kernel(M, N, K) as (bx, by, bz):

--- a/tilelang/language/kernel.py
+++ b/tilelang/language/kernel.py
@@ -111,8 +111,7 @@ class KernelLaunchFrame(TIRFrame):
         _get_current_stack().push(self)
 
         last_block_frame = self.frames[-1]
-        assert isinstance(last_block_frame,
-                          BlockFrame), f"Last frame must be a block frame, got {last_block_frame}"
+        assert isinstance(last_block_frame, BlockFrame), f"Last frame must be a block frame, got {last_block_frame}"
 
         maybe_cpu = last_block_frame.annotations.get("tilelang.is_cpu_kernel_frame", False)
         maybe_sunmmio = last_block_frame.annotations.get("tilelang.is_sunmmio_kernel_frame", False)
@@ -294,9 +293,7 @@ def Kernel(
     from tilelang.language.eager.builder import Builder
 
     if Builder.current() is None:
-        raise JITNoBuilderError(
-            "T.Kernel() can only be used inside @tilelang.jit or @T.prim_func context. No Builder is available."
-        )
+        raise JITNoBuilderError("T.Kernel() can only be used inside @tilelang.jit or @T.prim_func context. No Builder is available.")
 
     attrs: dict = {}
 

--- a/tilelang/language/kernel.py
+++ b/tilelang/language/kernel.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 from collections import deque
 from tvm import tir
+from tvm.target import Target
 from tvm.tir import Var
 from tvm.script.ir_builder.tir.frame import TIRFrame, BlockFrame
 from tvm.ffi import register_object
 from tilelang import _ffi_api
 from tilelang.jit.exceptions import JITNoBuilderError
+from tilelang.utils.target import target_is_sunmmio
 import threading
 
 # Ensure single-dimension kernel bindings can be unpacked like iterables.
@@ -292,8 +294,8 @@ def Kernel(
 
     if not is_cpu:
         cur_target = Target.current(allow_none=True)
-        if cur_target is not None and target_is_sunmmio(cur_target):
-            #Overriding requested threads to 1 for Sunmmio target.
+        if cur_target is not None and (cur_target.kind.name == "npu" or
+                                       target_is_sunmmio(cur_target)):
             threads = 1
 
     if not is_cpu and threads is None:

--- a/tilelang/language/kernel.py
+++ b/tilelang/language/kernel.py
@@ -113,10 +113,14 @@ class KernelLaunchFrame(TIRFrame):
         assert isinstance(last_block_frame, BlockFrame), f"Last frame must be a block frame, got {last_block_frame}"
 
         maybe_cpu = last_block_frame.annotations.get("tilelang.is_cpu_kernel_frame", False)
+        maybe_sunmmio = last_block_frame.annotations.get("tilelang.is_sunmmio_kernel_frame", False)
 
         if maybe_cpu:
             # CPU kernel frame, return a list of for frame items.
             return _normalize_bindings([frame.vars[0] for frame in self.frames[0:-1]])
+        elif maybe_sunmmio:
+            # Only blockIdx frames; last frame is the Block frame (no threadIdx frames)
+            return _normalize_bindings([frame.iter_var.var for frame in self.frames[0:-1]])
         else:
             # Otherwise, return a list of iter_var.var objects (excluding the last 4 frames).
             # As 4 frames for threadIdx.x, threadIdx.y, threadIdx.z and block frame with attributes
@@ -294,11 +298,12 @@ def Kernel(
 
     if not is_cpu:
         cur_target = Target.current(allow_none=True)
-        if cur_target is not None and (cur_target.kind.name == "npu" or
-                                       target_is_sunmmio(cur_target)):
-            threads = 1
+        if cur_target is not None and target_is_sunmmio(cur_target):
+            attrs["tilelang.is_sunmmio_kernel_frame"] = True
+            threads = None
 
-    if not is_cpu and threads is None:
+    is_sunmmio = attrs.get("tilelang.is_sunmmio_kernel_frame", False)
+    if not is_cpu and not is_sunmmio and threads is None:
         threads = 128  # default thread number
 
     if isinstance(threads, int):
@@ -308,7 +313,7 @@ def Kernel(
     elif isinstance(threads, tuple):
         threads = list(threads) + [1] * (3 - len(threads))
     else:
-        assert is_cpu, "threads must be an integer or a list of integers"
+        assert is_cpu or is_sunmmio, "threads must be an integer or a list of integers"
 
     if is_cpu:
         attrs["tilelang.is_cpu_kernel_frame"] = True

--- a/tilelang/language/kernel.py
+++ b/tilelang/language/kernel.py
@@ -13,7 +13,6 @@ import threading
 # Ensure single-dimension kernel bindings can be unpacked like iterables.
 # especially for issue https://github.com/tile-ai/tilelang/issues/830
 if not hasattr(Var, "__iter__"):
-
     def _var_iter(self):
         yield self
 
@@ -290,6 +289,12 @@ def Kernel(
         raise JITNoBuilderError("T.Kernel() can only be used inside @tilelang.jit or @T.prim_func context. No Builder is available.")
 
     attrs: dict = {}
+
+    if not is_cpu:
+        cur_target = Target.current(allow_none=True)
+        if cur_target is not None and target_is_sunmmio(cur_target):
+            #Overriding requested threads to 1 for Sunmmio target.
+            threads = 1
 
     if not is_cpu and threads is None:
         threads = 128  # default thread number

--- a/tilelang/language/kernel.py
+++ b/tilelang/language/kernel.py
@@ -15,6 +15,7 @@ import threading
 # Ensure single-dimension kernel bindings can be unpacked like iterables.
 # especially for issue https://github.com/tile-ai/tilelang/issues/830
 if not hasattr(Var, "__iter__"):
+
     def _var_iter(self):
         yield self
 
@@ -110,7 +111,8 @@ class KernelLaunchFrame(TIRFrame):
         _get_current_stack().push(self)
 
         last_block_frame = self.frames[-1]
-        assert isinstance(last_block_frame, BlockFrame), f"Last frame must be a block frame, got {last_block_frame}"
+        assert isinstance(last_block_frame,
+                          BlockFrame), f"Last frame must be a block frame, got {last_block_frame}"
 
         maybe_cpu = last_block_frame.annotations.get("tilelang.is_cpu_kernel_frame", False)
         maybe_sunmmio = last_block_frame.annotations.get("tilelang.is_sunmmio_kernel_frame", False)
@@ -292,7 +294,9 @@ def Kernel(
     from tilelang.language.eager.builder import Builder
 
     if Builder.current() is None:
-        raise JITNoBuilderError("T.Kernel() can only be used inside @tilelang.jit or @T.prim_func context. No Builder is available.")
+        raise JITNoBuilderError(
+            "T.Kernel() can only be used inside @tilelang.jit or @T.prim_func context. No Builder is available."
+        )
 
     attrs: dict = {}
 


### PR DESCRIPTION
 Description:

  ## Background

  Sunmmio is a threadless NPU target (4×4 mesh of 16 cores). Each core executes instructions sequentially with no thread hierarchy — there is no `threadIdx`.   Forcing `threads=1` for Sunmmio kernels will cause `threadIdx.x` bindings (extent=1) to appear throughout the IR. Several passes then incorrectly treated these as real thread bindings, producing wrong IR.

  ## What this PR does

Establishes a clean threadless execution model for Sunmmio: no `threadIdx` bindings are emitted at any stage of the compilation pipeline.

  ### 1. `tilelang/language/kernel.py` — threadless frontend path

  `T.Kernel(...)` on a Sunmmio target now sets `threads=None` instead of `threads=1`. `KernelLaunchFrame.__enter__` returns only `blockIdx` variables to the user — no `threadIdx` frames are created at all.

  ### 2. `src/transform/layout_inference.cc` — ThreadBindingCollector fix

  `ThreadBindingCollector` previously collected all `thread_extent` AttrStmts, including `blockIdx.*`. On Sunmmio this caused `has_thread_binding=true`, so `skip_thread_partition=false`, so `PartitionLoop` was called with an unbound
  dummy `v_thread` variable — producing free variables in the output IR.

  Fix: only collect `threadIdx.*` bindings. A pure-blockIdx kernel now correctly  yields `has_thread_binding=false` → `skip_thread_partition=true` → `PartitionLoop` is never called.

  ### 3. `src/transform/lower_tile_op.cc` — IR-driven PartitionLoop guard

 `LowerTileOpPass` always called `PartitionLoop` with a dummy `v_thread` IterVar for `T.Parallel` loops accessing shared memory, regardless of whether the function had any real thread bindings. For GPU kernels this was previously masked by the Simplify pass proving the `v_thread < 1` guard always true, but an upstream TVM analyzer change (SideEffect Checking in ConstIntBound) made that simplification more conservative, exposing the bug for Sunmmio kernels.

Fix: add `has_thread_binding_` flag (default `false`), set to `true` in the existing `VisitStmt_(AttrStmtNode)` handler only when a real `threadIdx.x` AttrStmt is visited. `parallel_loop` is now gated on `has_thread_binding_`,
  so `PartitionLoop` is never called on threadless kernels. 

  ## Tests

Tests will checked after each pass (where applicable):
  - Passes do not crash when there is no threadbinding provided in the IR.
  - No `threadIdx.*` bindings injected
  - No free `v_thread` variable introduced
  - `blockIdx.*` bindings preserved

| File | Passes covered | Tests |
|---|---|---|
| `testing/python/transform/test_tilelang_transform_sunmmio_annotate_split.py` | `AnnotateDeviceRegions`, `SplitHostDevice` — device func carries Sunmmio target and no threadIdx bindings. Passes yield correct results | 4 |
| `testing/python/layout/test_tilelang_sunmmio_threadless_layout_inference.py` | `InferSramScope`, `LayoutInference` — threadless invariants, no v_thread free variable | 6 |
| `testing/python/transform/test_tilelang_transform_sunmmio_threadless_lower_and_legalize.py` | All 13 `LowerAndLegalize` passes in cascade | 3 |
| `testing/python/transform/test_tilelang_transform_sunmmio_threadless_optimize_for_target.py` | All implemented `OptimizeForSunmmio` passes in cascade | 3 |


  Kernel variants covered:
  - Element-wise copy (no shared memory, no `T.Parallel`)
  - `T.Parallel` + shared memory (original `ThreadBindingCollector` bug trigger)
  - 3-D grid (`bx`, `by`, `bz`) with elementwise arithmetic

  ## Out of scope (follow-up PRs)

  - `OptimizeForSunmmio` integration into `phase.py` / `lower.py`
  - `InjectGreedyPipeline`, `InjectAsyncToken`, `MergeSRAMAllocations` passes
  - End-to-end `tilelang.lower()` compilation test