### PR TITLE
[Feature] [Language] Implement Inter-core communication

### DIFF
--- a/src/op/comm.cc
+++ b/src/op/comm.cc
@@ -1,0 +1,980 @@
+/*!
+ * \file tl/op/comm.cc
+ * \brief Implementation of Inter-core Communication Operators
+ */
+
+#include "comm.h"
+
+#include <algorithm>
+#include <tvm/tir/op.h>
+#include <vector>
+
+#include "../target/utils.h"
+#include "copy.h"
+#include "reduce.h"
+#include "utils.h"
+
+namespace tvm {
+namespace tl {
+
+#define TIR_DEFINE_TL_BUILTIN(OpName)                                          \
+  const Op &OpName() {                                                         \
+    static const Op &op = Op::Get("tl." #OpName);                              \
+    return op;                                                                 \
+  }                                                                            \
+  TVM_REGISTER_OP("tl." #OpName)                                               \
+      .set_attr<TScriptPrinterName>("TScriptPrinterName", #OpName)
+TIR_DEFINE_TL_BUILTIN(comm_barrier)
+    .set_num_inputs(-1)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+TIR_DEFINE_TL_BUILTIN(comm_fence)
+    .set_num_inputs(0)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+TIR_DEFINE_TL_BUILTIN(CoreId).set_num_inputs(1).set_attr<TCallEffectKind>(
+    "TCallEffectKind", Integer(CallEffectKind::kOpaque));
+TIR_DEFINE_TL_BUILTIN(comm_current_core)
+    .set_num_inputs(0)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+TIR_DEFINE_TL_BUILTIN(comm_is_current_core)
+    .set_num_inputs(-1)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+TIR_DEFINE_TL_BUILTIN(broadcast_)
+    .set_num_inputs(-1)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+// src_buffer, dst_buffer, size(IntImm), src_core(IntImm)
+// direction(0: horizontal, 1: vertical),
+// *mask(optional: IntImm list of core ids to exclude)
+
+using namespace tir;
+
+BroadcastOp::BroadcastOp(Array<PrimExpr> args,
+                         Map<String, ObjectRef> annotations) {
+  ObjectPtr<BroadcastOpNode> node = tvm::ffi::make_object<BroadcastOpNode>();
+  node->src_expr = args[0];
+  node->dst_expr = args[1];
+  Array<Range> rgs[2];
+  Buffer bf[2];
+  for (int i = 0; i < 2; i++) {
+    auto region = NormalizeToBufferRegion(args[i]);
+
+    rgs[i] = region->region;
+    bf[i] = region->buffer;
+  }
+  std::tie(node->src, node->dst) = std::tie(bf[0], bf[1]);
+  std::tie(node->src_range, node->dst_range) = std::tie(rgs[0], rgs[1]);
+  node->size = Downcast<IntImm>(args[2]);
+  node->dst_offset = Downcast<IntImm>(args[3]);
+  node->src_core = Downcast<IntImm>(args[4]);
+  node->direction = Downcast<IntImm>(args[5])->value;
+  data_ = std::move(node);
+}
+
+TileOperator BroadcastOpNode::Clone() const {
+  auto op = tvm::ffi::make_object<BroadcastOpNode>(*this);
+  return BroadcastOp(op);
+}
+
+LayoutMap BroadcastOpNode::InferLayout(const LayoutInferArgs &T,
+                                       InferLevel level) const {
+  Array<PrimExpr> args;
+  args.push_back(src_expr);
+  args.push_back(dst_expr);
+  Copy copy_op = Copy(args);
+  LayoutMap out_layout = copy_op->InferLayout(T, level);
+  return out_layout;
+}
+
+int get_target_mesh(Target target, int axis) {
+  auto mattr = target->GetAttr<Array<String>>("mattr").value();
+  int x = 0;
+  std::string axis_str;
+  if (axis == 0) {
+    axis_str = "device_mesh_nrow_";
+  } else if (axis == 1) {
+    axis_str = "device_mesh_ncol_";
+  } else {
+    LOG(FATAL) << "Invalid axis " << axis << " for getting mesh dimension.";
+  }
+  for (size_t i = 0; i < mattr.size(); i++) {
+    std::string m = mattr[i];
+    if (m.find(axis_str) != std::string::npos) {
+      std::string s = m.substr(m.find_last_of('_') + 1);
+      ;
+      try {
+        x = std::stoi(s);
+      } catch (const std::invalid_argument &e) {
+        x = -1;
+      } catch (const std::out_of_range &e) {
+        x = -1;
+      }
+    }
+  }
+  ICHECK(x != 0) << axis_str << " not found.";
+  ICHECK(x > 0) << "Invalid " << axis_str;
+  return x;
+}
+
+Stmt BroadcastOpNode::Lower(const LowerArgs &T,
+                            arith::Analyzer *analyzer) const {
+  Target target = T.target;
+  ICHECK(TargetIsSunmmio(target)) << "Broadcast only supports SUNMMIO targets.";
+  int mesh_nrow = get_target_mesh(target, 0);
+  int mesh_ncol = get_target_mesh(target, 1);
+
+  // check for valid core id
+  ICHECK(src_core->value >= 0 and src_core->value < mesh_nrow * mesh_ncol)
+      << "Source core id " << src_core->value << " out of range [0, "
+      << mesh_nrow * mesh_ncol << ")";
+
+  // check for src and dst buffer sizes
+  PrimExpr src_elements = 1;
+  for (size_t i = 0; i < src_range.size(); i++) {
+    src_elements *= src_range[i]->extent;
+  }
+  src_elements = analyzer->Simplify(src_elements);
+  PrimExpr dst_elements = 1;
+  for (size_t i = 0; i < dst_range.size(); i++) {
+    dst_elements *= dst_range[i]->extent;
+  }
+  dst_elements = analyzer->Simplify(dst_elements);
+  ICHECK(Downcast<IntImm>(src_elements)->value <=
+         Downcast<IntImm>(dst_elements)->value)
+      << "Source buffer size larger than destination buffer size: "
+      << src_elements << " vs " << dst_elements;
+  ICHECK(size->value <= Downcast<IntImm>(src_elements)->value)
+      << "Broadcast size larger than data size: " << size->value << " vs "
+      << Downcast<IntImm>(src_elements)->value;
+
+  // check for size and dst_offset
+  PrimExpr broadcast_elements;
+  if (size->value < 0) {
+    broadcast_elements = src_elements;
+  } else {
+    broadcast_elements = size;
+  }
+  ICHECK((Downcast<IntImm>(broadcast_elements)->value) <=
+         Downcast<IntImm>(src_elements)->value)
+      << "Broadcast size Larger than source buffer size: "
+      << (Downcast<IntImm>(broadcast_elements)->value) << " vs "
+      << Downcast<IntImm>(src_elements)->value;
+  ICHECK((Downcast<IntImm>(broadcast_elements)->value + dst_offset->value) <=
+         Downcast<IntImm>(dst_elements)->value)
+      << "Broadcast size + dst_offset larger than destination buffer size: "
+      << (Downcast<IntImm>(broadcast_elements)->value + dst_offset->value)
+      << " vs " << Downcast<IntImm>(dst_elements)->value;
+
+  // check for valid direction
+  if (direction != 0 and direction != 1 and direction != 2) {
+    LOG(FATAL) << "Invalid broadcast direction " << direction
+               << ", must be 0 (horizontal) or 1 (vertical) or 2 (all).";
+  }
+
+  // all checks passed, generate the call
+  PrimExpr src_addr = src.access_ptr(1, DataType::Handle(), 1, 0, src_elements);
+  PrimExpr dst_addr =
+      dst.access_ptr(2, DataType::Handle(), 1,
+                     Downcast<IntImm>(dst_offset->value), src_elements);
+  int src_core_col = src_core->value % mesh_ncol;
+
+  if (direction == 0 or direction == 1) {
+    // 1D broadcast
+    Array<PrimExpr> args;
+    args.push_back(MakeRegionExpr(src, src_range, /*access_mask=*/1));
+    args.push_back(MakeRegionExpr(dst, dst_range, /*access_mask=*/2));
+    args.push_back(Downcast<IntImm>(broadcast_elements));
+    args.push_back(src_core);
+    args.push_back(direction);
+    Stmt broadcast = Evaluate(Call(DataType::Handle(), broadcast_(), args));
+    return broadcast;
+  } else {
+    // 2D broadcast
+    Array<Stmt> seq;
+    // vertical broadcast
+    Array<PrimExpr> args;
+    args.push_back(MakeRegionExpr(src, src_range, /*access_mask=*/1));
+    args.push_back(MakeRegionExpr(dst, dst_range, /*access_mask=*/2));
+    args.push_back(Downcast<IntImm>(broadcast_elements));
+    args.push_back(src_core);
+    args.push_back(1); // direction: vertical
+    Stmt broadcast = Evaluate(Call(DataType::Handle(), broadcast_(), args));
+    seq.push_back(broadcast);
+    // horizontal broadcast
+    for (int i = 0; i < mesh_nrow; i++) {
+      Array<PrimExpr> args;
+      args.push_back(MakeRegionExpr(dst, dst_range, /*access_mask=*/1));
+      args.push_back(MakeRegionExpr(dst, dst_range, /*access_mask=*/2));
+      args.push_back(Downcast<IntImm>(broadcast_elements));
+      args.push_back(int(i * mesh_ncol) + src_core_col);
+      args.push_back(0); // direction: horizontal
+      Stmt broadcast = Evaluate(Call(DataType::Handle(), broadcast_(), args));
+      seq.push_back(broadcast);
+    }
+    return SeqStmt::Flatten(seq);
+  }
+}
+
+TIR_REGISTER_TL_TILE_OP(BroadcastOp, comm_broadcast)
+    .set_num_inputs(6)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+PutOp::PutOp(Array<PrimExpr> args, Map<String, ObjectRef> annotations) {
+  ObjectPtr<PutOpNode> node = tvm::ffi::make_object<PutOpNode>();
+  node->src_expr = args[0];
+  node->dst_expr = args[1];
+  Array<Range> rgs[2];
+  Buffer bf[2];
+  for (int i = 0; i < 2; i++) {
+    auto region = NormalizeToBufferRegion(args[i]);
+    rgs[i] = region->region;
+    bf[i] = region->buffer;
+  }
+  std::tie(node->src, node->dst) = std::tie(bf[0], bf[1]);
+  std::tie(node->src_range, node->dst_range) = std::tie(rgs[0], rgs[1]);
+  node->size = Downcast<IntImm>(args[2]);
+  node->src_core = Downcast<IntImm>(args[3]);
+  node->dst_core = Downcast<IntImm>(args[4]);
+  data_ = std::move(node);
+}
+
+TileOperator PutOpNode::Clone() const {
+  auto op = tvm::ffi::make_object<PutOpNode>(*this);
+  return PutOp(op);
+}
+
+LayoutMap PutOpNode::InferLayout(const LayoutInferArgs &T,
+                                 InferLevel level) const {
+  Array<PrimExpr> args;
+  args.push_back(src_expr);
+  args.push_back(dst_expr);
+  Copy copy_op = Copy(args);
+  LayoutMap out_layout = copy_op->InferLayout(T, level);
+  return out_layout;
+}
+
+Stmt PutOpNode::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
+  Target target = T.target;
+  ICHECK(TargetIsSunmmio(target)) << "Put only supports SUNMMIO targets.";
+  int mesh_nrow = get_target_mesh(target, 0);
+  int mesh_ncol = get_target_mesh(target, 1);
+
+  // check for valid core id
+  ICHECK(src_core->value >= 0 and src_core->value < mesh_nrow * mesh_ncol)
+      << "Source core id " << src_core->value << " out of range [0, "
+      << mesh_nrow * mesh_ncol << ")";
+  ICHECK(dst_core->value >= 0 and dst_core->value < mesh_nrow * mesh_ncol)
+      << "Destination core id " << dst_core->value << " out of range [0, "
+      << mesh_nrow * mesh_ncol << ")";
+
+  // check for src and dst buffer sizes
+  PrimExpr src_elements = 1;
+  for (size_t i = 0; i < src_range.size(); i++) {
+    src_elements *= src_range[i]->extent;
+  }
+  src_elements = analyzer->Simplify(src_elements);
+  PrimExpr dst_elements = 1;
+  for (size_t i = 0; i < dst_range.size(); i++) {
+    dst_elements *= dst_range[i]->extent;
+  }
+  dst_elements = analyzer->Simplify(dst_elements);
+  ICHECK(Downcast<IntImm>(src_elements)->value <=
+         Downcast<IntImm>(dst_elements)->value)
+      << "Source buffer size larger than destination buffer size: "
+      << src_elements << " vs " << dst_elements;
+  ICHECK(size->value <= Downcast<IntImm>(src_elements)->value)
+      << "Put size larger than data size: " << size->value << " vs "
+      << Downcast<IntImm>(src_elements)->value;
+
+  // check for size
+  PrimExpr broadcast_elements;
+  if (size->value < 0) {
+    broadcast_elements = src_elements;
+  } else {
+    broadcast_elements = size;
+  }
+  ICHECK((Downcast<IntImm>(broadcast_elements)->value) <=
+         Downcast<IntImm>(src_elements)->value)
+      << "Put size Larger than source buffer size: "
+      << (Downcast<IntImm>(broadcast_elements)->value) << " vs "
+      << Downcast<IntImm>(src_elements)->value;
+  ICHECK((Downcast<IntImm>(broadcast_elements)->value) <=
+         Downcast<IntImm>(dst_elements)->value)
+      << "Put size larger than destination buffer size: "
+      << (Downcast<IntImm>(broadcast_elements)->value) << " vs "
+      << Downcast<IntImm>(dst_elements)->value;
+
+  // all checks passed, generate the call
+  PrimExpr src_addr = src.access_ptr(1, DataType::Handle(), 1, 0, src_elements);
+  PrimExpr dst_addr = dst.access_ptr(2, DataType::Handle(), 1, 0, dst_elements);
+  int src_core_row = src_core->value / mesh_ncol;
+  int src_core_col = src_core->value % mesh_ncol;
+  int dst_core_row = dst_core->value / mesh_ncol;
+  int dst_core_col = dst_core->value % mesh_ncol;
+
+  if (src_core_row == dst_core_row) {
+    // 1D put via horizontal communication
+    Array<PrimExpr> args;
+    args.push_back(MakeRegionExpr(src, src_range, /*access_mask=*/1));
+    args.push_back(MakeRegionExpr(dst, dst_range, /*access_mask=*/2));
+    args.push_back(Downcast<IntImm>(broadcast_elements));
+    args.push_back(src_core);
+    args.push_back(0); // direction: horizontal
+    for (int j = 0; j < mesh_ncol; j++) {
+      if (j != dst_core_col) {
+        args.push_back(IntImm(DataType::Int(32),
+                              j)); // mask: all cores except dst_core_col
+      }
+    }
+    Stmt put = Evaluate(Call(DataType::Handle(), broadcast_(), args));
+    return put;
+  } else if (src_core_col == dst_core_col) {
+    // 1D put via vertical communication
+    Array<PrimExpr> args;
+    args.push_back(MakeRegionExpr(src, src_range, /*access_mask=*/1));
+    args.push_back(MakeRegionExpr(dst, dst_range, /*access_mask=*/2));
+    args.push_back(Downcast<IntImm>(broadcast_elements));
+    args.push_back(src_core);
+    args.push_back(1); // direction: vertical
+    for (int i = 0; i < mesh_nrow; i++) {
+      if (i != dst_core_row) {
+        args.push_back(IntImm(DataType::Int(32),
+                              i)); // mask: all cores except dst_core_row
+      }
+    }
+    Stmt put = Evaluate(Call(DataType::Handle(), broadcast_(), args));
+    return put;
+  } else {
+    Array<Stmt> seq;
+    // vertical transfer from src core to intermediate core
+    int intermediate_core_id = dst_core_row * mesh_ncol + src_core_col;
+    Array<PrimExpr> args1;
+    args1.push_back(MakeRegionExpr(src, src_range, /*access_mask=*/1));
+    args1.push_back(MakeRegionExpr(dst, dst_range, /*access_mask=*/2));
+    args1.push_back(Downcast<IntImm>(broadcast_elements));
+    args1.push_back(src_core);
+    args1.push_back(1); // direction: vertical
+    for (int i = 0; i < mesh_nrow; i++) {
+      if (i != dst_core_row) {
+        args1.push_back(IntImm(DataType::Int(32),
+                               i)); // mask: all cores except dst_core_row
+      }
+    }
+    Stmt put1 = Evaluate(Call(DataType::Handle(), broadcast_(), args1));
+    seq.push_back(put1);
+    // horizontal transfer from intermediate core to dst core
+    Array<PrimExpr> args2;
+    args2.push_back(MakeRegionExpr(dst, dst_range, /*access_mask=*/1));
+    args2.push_back(MakeRegionExpr(dst, dst_range, /*access_mask=*/2));
+    args2.push_back(Downcast<IntImm>(broadcast_elements));
+    args2.push_back(IntImm(DataType::Int(32), intermediate_core_id));
+    args2.push_back(0); // direction: horizontal
+    for (int j = 0; j < mesh_ncol; j++) {
+      if (j != dst_core_col) {
+        args2.push_back(IntImm(DataType::Int(32),
+                               j)); // mask: all cores except dst_core_col
+      }
+    }
+    Stmt put2 = Evaluate(Call(DataType::Handle(), broadcast_(), args2));
+    seq.push_back(put2);
+    return SeqStmt::Flatten(seq);
+  }
+}
+
+TIR_REGISTER_TL_TILE_OP(PutOp, comm_put)
+    .set_num_inputs(5)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+AllgatherOp::AllgatherOp(Array<PrimExpr> args,
+                           Map<String, ObjectRef> annotations) {
+  ObjectPtr<AllgatherOpNode> node = tvm::ffi::make_object<AllgatherOpNode>();
+  node->send = args[0];
+  node->recv = args[1];
+  node->direction = Downcast<IntImm>(args[2])->value;
+  node->size = Downcast<IntImm>(args[3]);
+  data_ = std::move(node);
+}
+
+TileOperator AllgatherOpNode::Clone() const {
+  auto op = tvm::ffi::make_object<AllgatherOpNode>(*this);
+  return AllgatherOp(op);
+}
+
+// Not yet complete; it will be further refined later
+LayoutMap AllgatherOpNode::ComputeLayout(const LayoutInferArgs &T,
+                                         InferLevel level, Buffer src,
+                                         Buffer dst) const {
+  if (src.scope() == "local.fragment" && dst.scope() == "local.fragment" &&
+      T.layout_map.count(src)) {
+    auto src_layout = T.layout_map[src].as<Fragment>().value();
+
+    PrimExpr src_rep_extent = src_layout->ReplicateExtent();
+
+    Array<PrimExpr> fwd;
+    fwd.push_back(InputPlaceholder(0));
+    for (int i = 0; i < static_cast<int>(src->shape.size()); i++) {
+      fwd.push_back(InputPlaceholder(i + 1));
+    }
+    auto thd = src_layout->ForwardThread(fwd, std::nullopt);
+
+    Fragment dst_layout =
+        Fragment(dst->shape, {}, thd, src_rep_extent, std::nullopt)
+            ->CondenseReplicateVar()
+            ->BindThreadRange(T.thread_bounds);
+
+    if (!T.layout_map.count(dst))
+      return {{dst, dst_layout}};
+    else {
+      // Check if computed layout is compatible with existing: the existing one
+      // must strictly contains the computed layout
+      auto orig_dst_layout =
+          T.layout_map.Get(dst).value().as<Fragment>().value();
+      ICHECK(dst_layout->InputDim() == orig_dst_layout->InputDim());
+      Array<PrimExpr> indices;
+      indices.reserve(dst_layout->InputDim());
+      arith::Analyzer inner_analyzer;
+      for (int i = 0; i < dst_layout->InputDim(); ++i) {
+        auto x = InputPlaceholder(i);
+        indices.push_back(x);
+        // should be literal - literal = 0, any analyzer will work
+        ICHECK(is_zero(inner_analyzer.Simplify(
+            dst_layout->InputShape()[i] - orig_dst_layout->InputShape()[i])));
+        inner_analyzer.Bind(x, Range(0, dst_layout->InputShape()[i]));
+      }
+
+      ICHECK(as_const_int(dst_layout->ReplicateExtent()));
+      ICHECK(as_const_int(src_layout->ReplicateExtent()));
+      auto dst_rep = *as_const_int(dst_layout->ReplicateExtent());
+      auto src_rep = *as_const_int(src_layout->ReplicateExtent());
+      if (dst_rep < src_rep ||
+          !ProveFragmentContains(orig_dst_layout, dst_layout, indices, indices,
+                                 inner_analyzer)) {
+        std::ostringstream oss;
+        oss << "Layout may conflict with ReduceOp for buffer " << dst << " vs. "
+            << src << "\nLHS = " << src_layout->DebugOutput()
+            << "\nRHS = " << orig_dst_layout->DebugOutput()
+            << "\nYou may need to use a shared memory to transform the "
+               "layout";
+        throw LayoutConflictException(oss.str());
+      }
+
+      if (dst_rep > src_rep) {
+        return {{dst, dst_layout}};
+      }
+    }
+  }
+  return {};
+}
+
+LayoutMap AllgatherOpNode::InferLayout(const LayoutInferArgs &T,
+                                       InferLevel level) const {
+  Buffer src_buffer = NormalizeToBufferRegion(send)->buffer;
+  Buffer recv_buffer = NormalizeToBufferRegion(recv)->buffer;
+  return ComputeLayout(T, level, src_buffer, recv_buffer);
+}
+
+Stmt AllgatherOpNode::Lower(const LowerArgs &T,
+                            arith::Analyzer *analyzer) const {
+  Target target = T.target;
+  ICHECK(TargetIsSunmmio(target)) << "Allgather only supports SUNMMIO targets.";
+  int mesh_nrow = get_target_mesh(target, 0);
+  int mesh_ncol = get_target_mesh(target, 1);
+
+  Array<Range> send_range, recv_range;
+  auto send_region = NormalizeToBufferRegion(send);
+  auto recv_region = NormalizeToBufferRegion(recv);
+  send_range = send_region->region;
+  recv_range = recv_region->region;
+
+  int recv_num = 1;
+  if (direction == 0) { // horizontal
+    recv_num = mesh_ncol;
+  } else if (direction == 1) { // vertical
+    recv_num = mesh_nrow;
+  } else if (direction == 2) { // all
+    recv_num = mesh_nrow * mesh_ncol;
+  } else {
+    // invalid direction
+    ICHECK(false) << "Invalid direction value for allgather: " << direction;
+  }
+
+  PrimExpr send_elements = 1;
+  for (size_t i = 0; i < send_range.size(); i++) {
+    send_elements *= send_range[i]->extent;
+  }
+  send_elements = analyzer->Simplify(send_elements);
+  PrimExpr recv_elements = 1;
+  for (size_t i = 0; i < recv_range.size(); i++) {
+    recv_elements *= recv_range[i]->extent;
+  }
+  recv_elements = analyzer->Simplify(recv_elements);
+  // check for buffer sizes
+  ICHECK(Downcast<IntImm>(send_elements)->value * recv_num <=
+         Downcast<IntImm>(recv_elements)->value)
+      << "Receive buffer size not enough for allgather: required "
+      << (Downcast<IntImm>(send_elements)->value * recv_num) << ", but got "
+      << Downcast<IntImm>(recv_elements)->value;
+
+  // all checks passed, generate the calls
+  Array<Stmt> bcast_stmts;
+
+  if (direction == 0) { // horizontal
+    for (int i = 0; i < mesh_nrow; i++) {
+      for (size_t j = 0; j < mesh_ncol; j++) {
+        Array<PrimExpr> args;
+        args.push_back(send);
+        args.push_back(recv);
+        args.push_back(size);
+        args.push_back(IntImm(DataType::Int(32), j) * send_elements); // offset
+        args.push_back(
+            IntImm(DataType::Int(32), i * mesh_ncol + j)); // src_core
+        args.push_back(0); // direction: horizontal
+        BroadcastOp bcast = BroadcastOp(args);
+        Stmt bcast_stmt = bcast->Lower(T, analyzer);
+        bcast_stmts.push_back(bcast_stmt);
+      }
+    }
+  } else if (direction == 1) { // vertical
+    for (int j = 0; j < mesh_ncol; j++) {
+      for (size_t i = 0; i < mesh_nrow; i++) {
+        Array<PrimExpr> args;
+        args.push_back(send);
+        args.push_back(recv);
+        args.push_back(size);
+        args.push_back(IntImm(DataType::Int(32), i) * send_elements); // offset
+        args.push_back(
+            IntImm(DataType::Int(32), i * mesh_ncol + j)); // src_core
+        args.push_back(1); // direction: vertical
+        BroadcastOp bcast = BroadcastOp(args);
+        Stmt bcast_stmt = bcast->Lower(T, analyzer);
+        bcast_stmts.push_back(bcast_stmt);
+      }
+    }
+  } else if (direction == 2) { // all
+    // first do horizontal allgather
+    for (int i = 0; i < mesh_nrow; i++) {
+      for (size_t j = 0; j < mesh_ncol; j++) {
+        Array<PrimExpr> args;
+        args.push_back(send);
+        args.push_back(recv);
+        args.push_back(size);
+        args.push_back(IntImm(DataType::Int(32), i * mesh_ncol + j) *
+                       send_elements); // offset
+        args.push_back(
+            IntImm(DataType::Int(32), i * mesh_ncol + j)); // src_core
+        args.push_back(0); // direction: horizontal
+        BroadcastOp bcast = BroadcastOp(args);
+        Stmt bcast_stmt = bcast->Lower(T, analyzer);
+        bcast_stmts.push_back(bcast_stmt);
+      }
+    }
+    // then do vertical allgather
+    Buffer recv_buffer = recv_region->buffer;
+    int allgather_size =
+        (size->value < 0) ? Downcast<IntImm>(send_elements)->value * mesh_ncol
+                          : size->value * mesh_ncol;
+
+    // Try to slice along the first dimension to avoid flattening
+    // This produces cleaner TIR when the buffer shape is aligned with the mesh
+    bool use_flatten = true;
+    PrimExpr dim0_extent = 0;
+    PrimExpr stride0 = 1;
+
+    if (recv_buffer->shape.size() > 0) {
+      for (size_t k = 1; k < recv_buffer->shape.size(); k++) {
+        stride0 *= recv_buffer->shape[k];
+      }
+      stride0 = analyzer->Simplify(stride0);
+
+      PrimExpr row_size = IntImm(DataType::Int(32), mesh_ncol) * send_elements;
+      if (analyzer->CanProve(FloorMod(row_size, stride0) == 0)) {
+        dim0_extent = analyzer->Simplify(FloorDiv(row_size, stride0));
+        use_flatten = false;
+      }
+    }
+
+    Buffer target_buffer = recv_buffer;
+    if (use_flatten && recv_buffer->shape.size() > 1) {
+      target_buffer =
+          Buffer(recv_buffer->data, recv_buffer->dtype, {recv_elements}, {1},
+                 recv_buffer->elem_offset, recv_buffer->name + "_flat",
+                 recv_buffer->data_alignment, recv_buffer->offset_factor,
+                 recv_buffer->buffer_type);
+    }
+
+    for (int j = 0; j < mesh_ncol; j++) {
+      for (size_t i = 0; i < mesh_nrow; i++) {
+        Array<PrimExpr> args;
+        Array<Range> ranges;
+
+        if (use_flatten) {
+          PrimExpr offset =
+              IntImm(DataType::Int(32), i * mesh_ncol) * send_elements;
+          PrimExpr extent =
+              IntImm(DataType::Int(32), mesh_ncol) * send_elements;
+          ranges.push_back(Range::FromMinExtent(offset, extent));
+        } else {
+          // Slice along the first dimension
+          ranges.push_back(Range::FromMinExtent(
+              IntImm(DataType::Int(32), i) * dim0_extent, dim0_extent));
+          for (size_t k = 1; k < recv_buffer->shape.size(); k++) {
+            ranges.push_back(Range::FromMinExtent(0, recv_buffer->shape[k]));
+          }
+        }
+
+        args.push_back(MakeRegionExpr(target_buffer, ranges, 1));
+        args.push_back(MakeRegionExpr(target_buffer, ranges, 2));
+        args.push_back(IntImm(DataType::Int(32), allgather_size)); // size
+        args.push_back(
+            IntImm(DataType::Int(32), i * mesh_ncol + j)); // src_core
+        args.push_back(1); // direction: vertical
+        Stmt bcast_stmt =
+            Evaluate(Call(DataType::Handle(), broadcast_(), args));
+        bcast_stmts.push_back(bcast_stmt);
+      }
+    }
+  }
+  return SeqStmt::Flatten(bcast_stmts);
+}
+
+TIR_REGISTER_TL_TILE_OP(AllgatherOp, comm_allgather)
+    .set_num_inputs(4)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+AllreduceOp::AllreduceOp(Array<PrimExpr> args,
+                           Map<String, ObjectRef> annotations) {
+  ObjectPtr<AllreduceOpNode> node = tvm::ffi::make_object<AllreduceOpNode>();
+  node->src = args[0];
+  node->dst = args[1];
+  node->row_allgather = args[2];
+  node->col_allgather = args[3];
+
+  node->type = Downcast<StringImm>(args[4]);
+  node->direction = Downcast<IntImm>(args[5])->value;
+  node->dim = Downcast<IntImm>(args[6]);
+  node->clear = Downcast<IntImm>(args[7]);
+  if (args.size() > 8) {
+    node->dst_copy = args[8];
+  }
+  data_ = std::move(node);
+}
+
+TileOperator AllreduceOpNode::Clone() const {
+  auto op = tvm::ffi::make_object<AllreduceOpNode>(*this);
+  return AllreduceOp(op);
+}
+
+// Not yet complete; it will be further refined later
+LayoutMap AllreduceOpNode::ComputeLayout(const LayoutInferArgs &T,
+                                         InferLevel level, Buffer src,
+                                         Buffer dst, int dim) const {
+  if (level >= InferLevel::kStrict)
+    return {};
+
+  if (src.scope() == "local.fragment" && dst.scope() == "local.fragment" &&
+      T.layout_map.count(src)) {
+    auto src_layout = T.layout_map[src].as<Fragment>().value();
+
+    PrimExpr indice_rep_extent = src->shape[dim];
+    PrimExpr src_rep_extent = src_layout->ReplicateExtent();
+    PrimExpr dest_buffer_rep_extent = indice_rep_extent * src_rep_extent;
+
+    Array<PrimExpr> fwd;
+    fwd.push_back(InputPlaceholder(0));
+    for (int i = 0; i < static_cast<int>(src->shape.size()); i++) {
+      if (i == dim) {
+        ;
+      } else if (i < dim) {
+        fwd.push_back(InputPlaceholder(i + 1));
+      } else if (i > dim) {
+        fwd.push_back(InputPlaceholder(i - 1 + 1));
+      }
+    }
+    auto thd = src_layout->ForwardThread(
+        fwd, FloorDiv(ReplicationPlaceholder(), indice_rep_extent));
+
+    // Ensure the thread count is divisible by the replicate extent.
+    // Otherwise, we cannot infer a valid fragment<->fragment layout.
+    {
+      arith::Analyzer analyzer;
+      PrimExpr num_threads = T.thread_bounds->extent;
+      // Though the dest_buffer_rep_extent will be compressed at
+      // CondenseReplicateVar, we need to check the divisibility here to avoid
+      // the issue that the thread count is not divisible by the replicate
+      // extent.
+      if (!analyzer.CanProve(FloorMod(num_threads, dest_buffer_rep_extent) ==
+                             0) &&
+          !analyzer.CanProve(FloorMod(dest_buffer_rep_extent, num_threads) ==
+                             0)) {
+        ICHECK(false) << "ReduceOp fragment layout inference failed: "
+                         "num_threads % replicate_extent != 0. "
+                      << "This mapping requires the block's thread count to be "
+                         "divisible by the "
+                      << "replicate extent. "
+                      << "Try one of: (1) choose a thread block size divisible "
+                         "by replicate_extent; "
+                      << "(2) pick a different reduce dimension or adjust the "
+                         "source fragment layout; "
+                      << "Details: num_threads=" << num_threads
+                      << ", replicate_extent=" << indice_rep_extent
+                      << ", src=" << src << ", dst=" << dst;
+      }
+    }
+
+    Fragment dst_layout =
+        Fragment(dst->shape, {}, thd, dest_buffer_rep_extent, std::nullopt)
+            ->CondenseReplicateVar()
+            ->BindThreadRange(T.thread_bounds);
+
+    if (!T.layout_map.count(dst))
+      return {{dst, dst_layout}};
+    else {
+      // Check if computed layout is compatible with existing: the existing one
+      // must strictly contains the computed layout
+      auto orig_dst_layout =
+          T.layout_map.Get(dst).value().as<Fragment>().value();
+      ICHECK(dst_layout->InputDim() == orig_dst_layout->InputDim());
+      Array<PrimExpr> indices;
+      indices.reserve(dst_layout->InputDim());
+      arith::Analyzer inner_analyzer;
+      for (int i = 0; i < dst_layout->InputDim(); ++i) {
+        auto x = InputPlaceholder(i);
+        indices.push_back(x);
+        // should be literal - literal = 0, any analyzer will work
+        ICHECK(is_zero(inner_analyzer.Simplify(
+            dst_layout->InputShape()[i] - orig_dst_layout->InputShape()[i])));
+        inner_analyzer.Bind(x, Range(0, dst_layout->InputShape()[i]));
+      }
+
+      ICHECK(as_const_int(dst_layout->ReplicateExtent()));
+      ICHECK(as_const_int(src_layout->ReplicateExtent()));
+      auto dst_rep = *as_const_int(dst_layout->ReplicateExtent());
+      auto src_rep = *as_const_int(src_layout->ReplicateExtent());
+      if (dst_rep < src_rep ||
+          !ProveFragmentContains(orig_dst_layout, dst_layout, indices, indices,
+                                 inner_analyzer)) {
+        std::ostringstream oss;
+        oss << "Layout may conflict with ReduceOp for buffer " << dst << " vs. "
+            << src << "\nLHS = " << src_layout->DebugOutput()
+            << "\nRHS = " << orig_dst_layout->DebugOutput()
+            << "\nYou may need to use a shared memory to transform the "
+               "layout";
+        throw LayoutConflictException(oss.str());
+      }
+
+      if (dst_rep > src_rep) {
+        return {{dst, dst_layout}};
+      }
+    }
+  }
+  return {};
+}
+
+LayoutMap AllreduceOpNode::InferLayout(const LayoutInferArgs &T,
+                                       InferLevel level) const {
+  LayoutMap lm;
+
+  Array<PrimExpr> dst_layout_args;
+  dst_layout_args.push_back(src);
+  dst_layout_args.push_back(dst);
+  dst_layout_args.push_back(type);
+  dst_layout_args.push_back(dim);
+  dst_layout_args.push_back(clear);
+  ReduceOp dst_layout_op = ReduceOp(dst_layout_args);
+  LayoutMap dst_layout_map = dst_layout_op->InferLayout(T, InferLevel::kFree);
+  for (const auto &kv : dst_layout_map) {
+    lm.Set(kv.first, kv.second);
+  }
+
+  if (dst_copy.defined()) {
+    Array<PrimExpr> dst_copy_layout_args;
+    dst_copy_layout_args.push_back(src);
+    dst_copy_layout_args.push_back(dst_copy);
+    dst_copy_layout_args.push_back(type);
+    dst_copy_layout_args.push_back(dim);
+    dst_copy_layout_args.push_back(clear);
+    ReduceOp dst_copy_layout_op = ReduceOp(dst_copy_layout_args);
+    LayoutMap dst_copy_layout_map =
+        dst_copy_layout_op->InferLayout(T, InferLevel::kFree);
+    for (const auto &kv : dst_copy_layout_map) {
+      lm.Set(kv.first, kv.second);
+    }
+  }
+
+  Buffer row_allgather_buffer = NormalizeToBufferRegion(row_allgather)->buffer;
+  LayoutMap row_allgather_layout =
+      ComputeLayout(T, InferLevel::kFree, NormalizeToBufferRegion(src)->buffer,
+                    row_allgather_buffer, dim->value);
+  for (const auto &kv : row_allgather_layout) {
+    lm.Set(kv.first, kv.second);
+  }
+
+  Buffer col_allgather_buffer = NormalizeToBufferRegion(col_allgather)->buffer;
+  LayoutMap col_allgather_layout =
+      ComputeLayout(T, InferLevel::kFree, NormalizeToBufferRegion(src)->buffer,
+                    col_allgather_buffer, dim->value);
+  for (const auto &kv : col_allgather_layout) {
+    lm.Set(kv.first, kv.second);
+  }
+
+  return lm;
+}
+
+Stmt AllreduceOpNode::Lower(const LowerArgs &T,
+                            arith::Analyzer *analyzer) const {
+  Target target = T.target;
+  ICHECK(TargetIsSunmmio(target)) << "Allreduce only supports SUNMMIO targets.";
+  int mesh_nrow = get_target_mesh(target, 0);
+  int mesh_ncol = get_target_mesh(target, 1);
+
+  ICHECK(direction == 0 || direction == 1 || direction == 2)
+      << "Invalid allreduce direction " << direction
+      << ", must be 0 (row-wise) or 1 (column-wise) or 2 (all).";
+
+  Array<Stmt> stmts;
+
+  if (clear.as<Bool>().value() == true) {
+    // Local reduce to dst
+    Array<PrimExpr> local_reduce_args;
+    local_reduce_args.push_back(src);
+    local_reduce_args.push_back(dst);
+    local_reduce_args.push_back(type);
+    local_reduce_args.push_back(dim);
+    local_reduce_args.push_back(IntImm(DataType::Int(32), 1)); // clear = true
+    ReduceOp local_reduce_op = ReduceOp(local_reduce_args);
+    Stmt local_reduce_stmt = local_reduce_op->Lower(T, analyzer);
+    stmts.push_back(local_reduce_stmt);
+
+    if (direction == 0 or direction == 2) { // row-wise
+      // Allgather dst in rows to row_allgather
+      Array<PrimExpr> row_allgather_args;
+      row_allgather_args.push_back(dst);
+      row_allgather_args.push_back(row_allgather);
+      row_allgather_args.push_back(
+          IntImm(DataType::Int(32), 0)); // direction = horizontal
+      row_allgather_args.push_back(IntImm(DataType::Int(32), -1)); // size
+      AllgatherOp row_allgather_op = AllgatherOp(row_allgather_args);
+      Stmt row_allgather_stmt = row_allgather_op->Lower(T, analyzer);
+      stmts.push_back(row_allgather_stmt);
+
+      // Local reduce from row_allgather to dst
+      Array<PrimExpr> row_reduce_args;
+      row_reduce_args.push_back(row_allgather);
+      row_reduce_args.push_back(dst);
+      row_reduce_args.push_back(type);
+      row_reduce_args.push_back(IntImm(DataType::Int(32), 0)); // dim
+      row_reduce_args.push_back(IntImm(DataType::Int(32), 1)); // clear = true
+      ReduceOp row_reduce_op = ReduceOp(row_reduce_args);
+      Stmt row_reduce_stmt = row_reduce_op->Lower(T, analyzer);
+      stmts.push_back(row_reduce_stmt);
+    }
+
+    if (direction == 1 or direction == 2) { // column-wise
+      // Allgather dst in columns to col_allgather
+      Array<PrimExpr> col_allgather_args;
+      col_allgather_args.push_back(dst);
+      col_allgather_args.push_back(col_allgather);
+      col_allgather_args.push_back(
+          IntImm(DataType::Int(32), 1)); // direction = vertical
+      col_allgather_args.push_back(IntImm(DataType::Int(32), -1)); // size
+      AllgatherOp col_allgather_op = AllgatherOp(col_allgather_args);
+      Stmt col_allgather_stmt = col_allgather_op->Lower(T, analyzer);
+      stmts.push_back(col_allgather_stmt);
+
+      // Local reduce from col_allgather to dst
+      Array<PrimExpr> col_reduce_args;
+      col_reduce_args.push_back(col_allgather);
+      col_reduce_args.push_back(dst);
+      col_reduce_args.push_back(type);
+      col_reduce_args.push_back(IntImm(DataType::Int(32), 0)); // dim
+      col_reduce_args.push_back(IntImm(DataType::Int(32), 1)); // clear = true
+      ReduceOp col_reduce_op = ReduceOp(col_reduce_args);
+      Stmt col_reduce_stmt = col_reduce_op->Lower(T, analyzer);
+      stmts.push_back(col_reduce_stmt);
+    }
+  } else {
+    // Local reduce to dst_copy
+    Array<PrimExpr> local_reduce_args;
+    local_reduce_args.push_back(src);
+    local_reduce_args.push_back(dst_copy);
+    local_reduce_args.push_back(type);
+    local_reduce_args.push_back(dim);
+    local_reduce_args.push_back(IntImm(DataType::Int(32), 1)); // clear = true
+    ReduceOp local_reduce_op = ReduceOp(local_reduce_args);
+    Stmt local_reduce_stmt = local_reduce_op->Lower(T, analyzer);
+    stmts.push_back(local_reduce_stmt);
+
+    if (direction == 0 or direction == 2) { // row-wise
+      // Allgather dst in rows to row_allgather
+      Array<PrimExpr> row_allgather_args;
+      row_allgather_args.push_back(dst_copy);
+      row_allgather_args.push_back(row_allgather);
+      row_allgather_args.push_back(
+          IntImm(DataType::Int(32), 0)); // direction = horizontal
+      row_allgather_args.push_back(IntImm(DataType::Int(32), -1)); // size
+      AllgatherOp row_allgather_op = AllgatherOp(row_allgather_args);
+      Stmt row_allgather_stmt = row_allgather_op->Lower(T, analyzer);
+      stmts.push_back(row_allgather_stmt);
+
+      // Local reduce from row_allgather to dst
+      Array<PrimExpr> row_reduce_args;
+      row_reduce_args.push_back(row_allgather);
+      row_reduce_args.push_back(direction == 0 ? dst : dst_copy);
+      row_reduce_args.push_back(type);
+      row_reduce_args.push_back(IntImm(DataType::Int(32), 0)); // dim
+      row_reduce_args.push_back(IntImm(
+          DataType::Int(32),
+          direction == 0 ? 0 : 1)); // clear = direction == 0 ? false : true
+      ReduceOp row_reduce_op = ReduceOp(row_reduce_args);
+      Stmt row_reduce_stmt = row_reduce_op->Lower(T, analyzer);
+      stmts.push_back(row_reduce_stmt);
+    }
+
+    if (direction == 1 or direction == 2) { // column-wise
+      // Allgather dst in columns to col_allgather
+      Array<PrimExpr> col_allgather_args;
+      col_allgather_args.push_back(dst_copy);
+      col_allgather_args.push_back(col_allgather);
+      col_allgather_args.push_back(
+          IntImm(DataType::Int(32), 1)); // direction = vertical
+      col_allgather_args.push_back(IntImm(DataType::Int(32), -1)); // size
+      AllgatherOp col_allgather_op = AllgatherOp(col_allgather_args);
+      Stmt col_allgather_stmt = col_allgather_op->Lower(T, analyzer);
+      stmts.push_back(col_allgather_stmt);
+
+      // Local reduce from col_allgather to dst
+      Array<PrimExpr> col_reduce_args;
+      col_reduce_args.push_back(col_allgather);
+      col_reduce_args.push_back(dst);
+      col_reduce_args.push_back(type);
+      col_reduce_args.push_back(IntImm(DataType::Int(32), 0)); // dim
+      col_reduce_args.push_back(IntImm(DataType::Int(32), 0)); // clear = false
+      ReduceOp col_reduce_op = ReduceOp(col_reduce_args);
+      Stmt col_reduce_stmt = col_reduce_op->Lower(T, analyzer);
+      stmts.push_back(col_reduce_stmt);
+    }
+  }
+
+  return SeqStmt::Flatten(stmts);
+}
+
+TIR_REGISTER_TL_TILE_OP(AllreduceOp, comm_allreduce)
+    .set_num_inputs(-1)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TVM_FFI_STATIC_INIT_BLOCK() {
+  PutOpNode::RegisterReflection();
+  BroadcastOpNode::RegisterReflection();
+  AllgatherOpNode::RegisterReflection();
+  AllreduceOpNode::RegisterReflection();
+}
+
+} // namespace tl
+} // namespace tvm

--- a/src/op/comm.cc
+++ b/src/op/comm.cc
@@ -391,7 +391,7 @@ TIR_REGISTER_TL_TILE_OP(PutOp, comm_put)
                                Integer(CallEffectKind::kOpaque));
 
 AllgatherOp::AllgatherOp(Array<PrimExpr> args,
-                           Map<String, ObjectRef> annotations) {
+                         Map<String, ObjectRef> annotations) {
   ObjectPtr<AllgatherOpNode> node = tvm::ffi::make_object<AllgatherOpNode>();
   node->send = args[0];
   node->recv = args[1];
@@ -648,7 +648,7 @@ TIR_REGISTER_TL_TILE_OP(AllgatherOp, comm_allgather)
                                Integer(CallEffectKind::kOpaque));
 
 AllreduceOp::AllreduceOp(Array<PrimExpr> args,
-                           Map<String, ObjectRef> annotations) {
+                         Map<String, ObjectRef> annotations) {
   ObjectPtr<AllreduceOpNode> node = tvm::ffi::make_object<AllreduceOpNode>();
   node->src = args[0];
   node->dst = args[1];

--- a/src/op/comm.h
+++ b/src/op/comm.h
@@ -1,0 +1,188 @@
+/*!
+ * \file tl/op/comm.h
+ * \brief Implementation of Inter-core Communication Operators
+ */
+
+#ifndef TVM_TL_OP_COMM_H_
+#define TVM_TL_OP_COMM_H_
+
+#include "operator.h"
+
+namespace tvm {
+namespace tl {
+
+TVM_DLL const Op &CoreId();
+TVM_DLL const Op &comm_current_core();
+TVM_DLL const Op &comm_is_current_core();
+TVM_DLL const Op &comm_barrier();
+TVM_DLL const Op &broadcast_();
+
+TVM_DLL const Op &barrier_id();
+TVM_DLL const Op &barrier_init();
+TVM_DLL const Op &barrier_arrive_and_wait();
+TVM_DLL const Op &sync_token_id();
+TVM_DLL const Op &wait_token();
+
+using namespace tir;
+
+int get_target_mesh(Target target, int axis);
+
+class BroadcastOpNode : public TileOperatorNode {
+public:
+  Buffer src, dst;
+  Array<Range> src_range, dst_range;
+  PrimExpr src_expr, dst_expr;
+  IntImm size;
+  IntImm dst_offset;
+  IntImm src_core;
+  int direction;
+
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tl.comm_broadcast", BroadcastOpNode,
+                                    TileOperatorNode);
+
+  static void RegisterReflection() {
+    namespace refl = tvm::ffi::reflection;
+    refl::ObjectDef<BroadcastOpNode>()
+        .def_ro("src", &BroadcastOpNode::src)
+        .def_ro("dst", &BroadcastOpNode::dst)
+        .def_ro("src_range", &BroadcastOpNode::src_range)
+        .def_ro("dst_range", &BroadcastOpNode::dst_range)
+        .def_ro("src_core", &BroadcastOpNode::src_core)
+        // .def_ro("direction", &BroadcastOpNode::direction)
+        // .def_ro("size", &BroadcastOpNode::size)
+        .def_ro("dst_offset", &BroadcastOpNode::dst_offset);
+  }
+
+  TileOperator Clone() const;
+  LayoutMap InferLayout(const LayoutInferArgs &T,
+                        InferLevel level) const override;
+  Stmt Lower(const LowerArgs &T, arith::Analyzer *analyzer) const override;
+};
+
+class BroadcastOp : public TileOperator {
+public:
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(BroadcastOp, TileOperator,
+                                             BroadcastOpNode);
+  TVM_DLL BroadcastOp(Array<PrimExpr> args,
+                      Map<String, ObjectRef> annotations = {});
+  static const Op &Get();
+};
+
+class PutOpNode : public TileOperatorNode {
+public:
+  Buffer src, dst;
+  Array<Range> src_range, dst_range;
+  PrimExpr src_expr, dst_expr;
+  IntImm src_core, dst_core;
+  IntImm size;
+
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tl.comm_put", PutOpNode, TileOperatorNode);
+
+  static void RegisterReflection() {
+    namespace refl = tvm::ffi::reflection;
+    refl::ObjectDef<PutOpNode>()
+        .def_ro("src", &PutOpNode::src)
+        .def_ro("dst", &PutOpNode::dst)
+        .def_ro("src_range", &PutOpNode::src_range)
+        .def_ro("dst_range", &PutOpNode::dst_range)
+        .def_ro("src_core", &PutOpNode::src_core)
+        .def_ro("dst_core", &PutOpNode::dst_core)
+        .def_ro("size", &PutOpNode::size);
+  }
+
+  TileOperator Clone() const;
+  LayoutMap InferLayout(const LayoutInferArgs &T,
+                        InferLevel level) const override;
+  Stmt Lower(const LowerArgs &T, arith::Analyzer *analyzer) const override;
+};
+
+class PutOp : public TileOperator {
+public:
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(PutOp, TileOperator, PutOpNode);
+  TVM_DLL PutOp(Array<PrimExpr> args, Map<String, ObjectRef> annotations = {});
+  static const Op &Get();
+};
+
+class AllgatherOpNode : public TileOperatorNode {
+public:
+  PrimExpr send, recv;
+  int direction;
+  IntImm size;
+
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tl.comm_allgather", AllgatherOpNode,
+                                    TileOperatorNode);
+
+  static void RegisterReflection() {
+    namespace refl = tvm::ffi::reflection;
+    refl::ObjectDef<AllgatherOpNode>()
+        .def_ro("send", &AllgatherOpNode::send)
+        .def_ro("recv", &AllgatherOpNode::recv)
+        .def_ro("direction", &AllgatherOpNode::direction)
+        .def_ro("size", &AllgatherOpNode::size);
+  }
+
+  TileOperator Clone() const;
+  LayoutMap ComputeLayout(const LayoutInferArgs &T, InferLevel level,
+                          Buffer src, Buffer dst) const;
+  LayoutMap InferLayout(const LayoutInferArgs &T,
+                        InferLevel level) const override;
+  Stmt Lower(const LowerArgs &T, arith::Analyzer *analyzer) const override;
+};
+
+class AllgatherOp : public TileOperator {
+public:
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(AllgatherOp, TileOperator,
+                                             AllgatherOpNode);
+  TVM_DLL AllgatherOp(Array<PrimExpr> args,
+                      Map<String, ObjectRef> annotations = {});
+  static const Op &Get();
+};
+
+class AllreduceOpNode : public TileOperatorNode {
+public:
+  PrimExpr src, dst;
+  PrimExpr row_allgather, col_allgather;
+  PrimExpr dst_copy;
+  StringImm type;
+  int direction;
+  IntImm dim;
+  IntImm clear;
+
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tl.comm_allreduce", AllreduceOpNode,
+                                    TileOperatorNode);
+
+  static void RegisterReflection() {
+    namespace refl = tvm::ffi::reflection;
+    refl::ObjectDef<AllreduceOpNode>()
+        .def_ro("src", &AllreduceOpNode::src)
+        .def_ro("dst", &AllreduceOpNode::dst)
+        .def_ro("row_allgather", &AllreduceOpNode::row_allgather)
+        .def_ro("col_allgather", &AllreduceOpNode::col_allgather)
+        .def_ro("type", &AllreduceOpNode::type)
+        .def_ro("dim", &AllreduceOpNode::dim)
+        .def_ro("clear", &AllreduceOpNode::clear)
+        .def_ro("direction", &AllreduceOpNode::direction)
+        .def_ro("dst_copy", &AllreduceOpNode::dst_copy);
+  }
+
+  TileOperator Clone() const;
+  LayoutMap ComputeLayout(const LayoutInferArgs &T, InferLevel level,
+                          Buffer src, Buffer dst, int dim) const;
+  LayoutMap InferLayout(const LayoutInferArgs &T,
+                        InferLevel level) const override;
+  Stmt Lower(const LowerArgs &T, arith::Analyzer *analyzer) const override;
+};
+
+class AllreduceOp : public TileOperator {
+public:
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(AllreduceOp, TileOperator,
+                                             AllreduceOpNode);
+  TVM_DLL AllreduceOp(Array<PrimExpr> args,
+                      Map<String, ObjectRef> annotations = {});
+  static const Op &Get();
+};
+
+} // namespace tl
+} // namespace tvm
+
+#endif // TVM_TL_OP_COMM_H_

--- a/testing/python/language/test_tilelang_language_comm.py
+++ b/testing/python/language/test_tilelang_language_comm.py
@@ -33,7 +33,7 @@ def test_comm_python_api(M, N, block_M, block_N, dtype, accum_dtype):
             T.comm.put(A_shared, B_shared, (1, 2), (2, 3))
             T.comm.all_gather(A_shared, C_shared, direction="all")
 
-    assert main.script()[-len(func_str):] == func_str, "The generated script does not match the expected output."
+    assert main.script()[-len(func_str) :] == func_str, "The generated script does not match the expected output."
 
 
 @pytest.mark.parametrize(
@@ -66,7 +66,7 @@ def test_comm_broadcast_lower(M, N, block_M, block_N, dtype, accum_dtype):
     with tvm.target.Target(target):
         mod = tvm.tir.transform.BindTarget(target)(mod)
         mod = tilelang.transform.LowerTileOp()(mod)
-        assert mod.script()[-len(func_str):] == func_str, "The generated script does not match the expected output."
+        assert mod.script()[-len(func_str) :] == func_str, "The generated script does not match the expected output."
 
 
 @pytest.mark.parametrize(
@@ -96,7 +96,7 @@ def test_comm_put_lower(M, N, block_M, block_N, dtype, accum_dtype):
     with tvm.target.Target(target):
         mod = tvm.tir.transform.BindTarget(target)(mod)
         mod = tilelang.transform.LowerTileOp()(mod)
-        assert mod.script()[-len(func_str):] == func_str, "The generated script does not match the expected output."
+        assert mod.script()[-len(func_str) :] == func_str, "The generated script does not match the expected output."
 
 
 @pytest.mark.parametrize(
@@ -156,7 +156,8 @@ def test_comm_all_gather_lower(M, N, block_M, block_N, dtype, accum_dtype):
     with tvm.target.Target(target):
         mod = tvm.tir.transform.BindTarget(target)(mod)
         mod = tilelang.transform.LowerTileOp()(mod)
-        assert mod.script()[-len(func_str):] == func_str, "The generated script does not match the expected output."
+        assert mod.script()[-len(func_str) :] == func_str, "The generated script does not match the expected output."
+
 
 '''
 @pytest.mark.parametrize(

--- a/testing/python/language/test_tilelang_language_comm.py
+++ b/testing/python/language/test_tilelang_language_comm.py
@@ -1,0 +1,250 @@
+import pytest
+
+import tilelang
+import tilelang.language as T
+
+from tilelang import tvm as tvm
+from tilelang.utils.target import determine_target
+
+
+@pytest.mark.parametrize(
+    "M, N, block_M, block_N, dtype, accum_dtype",
+    [
+        (1024, 1024, 128, 128, "float16", "float"),
+    ],
+)
+def test_comm_python_api(M, N, block_M, block_N, dtype, accum_dtype):
+    func_str = """
+        T.comm_broadcast(A_shared[0:128, 0:128], B_shared[0:128, 0:128], -1, 0, 6, 2)
+        T.comm_put(A_shared[0:128, 0:128], B_shared[0:128, 0:128], -1, 6, 11)
+        T.comm_allgather(A_shared[0:128, 0:128], C_shared[0:16, 0:128, 0:128], 2, -1)""".strip()
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, N), dtype),
+    ):
+        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=128) as (bx, by):
+            A_shared = T.alloc_shared([block_M, block_N], dtype, scope="shared.rsram")
+            B_shared = T.alloc_shared([block_M, block_N], dtype, scope="shared.rsram")
+            C_shared = T.alloc_shared([16, block_M, block_N], dtype, scope="shared.rsram")
+            T.copy(A[by * block_M, bx * block_N], A_shared)
+
+            T.comm.broadcast(A_shared, B_shared, (1, 2), direction="all")
+            T.comm.put(A_shared, B_shared, (1, 2), (2, 3))
+            T.comm.all_gather(A_shared, C_shared, direction="all")
+
+    assert main.script()[-len(func_str):] == func_str, "The generated script does not match the expected output."
+
+
+@pytest.mark.parametrize(
+    "M, N, block_M, block_N, dtype, accum_dtype",
+    [
+        (1024, 1024, 128, 128, "float16", "float"),
+    ],
+)
+def test_comm_broadcast_lower(M, N, block_M, block_N, dtype, accum_dtype):
+    func_str = """
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(B_shared[0, 0], 2, 128, 128), 16384, 6, 1)
+            T.broadcast_(T.region(B_shared[0, 0], 1, 128, 128), T.region(B_shared[0, 0], 2, 128, 128), 16384, 2, 0)
+            T.broadcast_(T.region(B_shared[0, 0], 1, 128, 128), T.region(B_shared[0, 0], 2, 128, 128), 16384, 6, 0)
+            T.broadcast_(T.region(B_shared[0, 0], 1, 128, 128), T.region(B_shared[0, 0], 2, 128, 128), 16384, 10, 0)
+            T.broadcast_(T.region(B_shared[0, 0], 1, 128, 128), T.region(B_shared[0, 0], 2, 128, 128), 16384, 14, 0)""".strip()
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, N), dtype),
+    ):
+        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=128) as (bx, by):
+            A_shared = T.alloc_shared([block_M, block_N], dtype, scope="shared.rsram")
+            B_shared = T.alloc_shared([block_M, block_N], dtype, scope="shared.rsram")
+            T.copy(A[by * block_M, bx * block_N], A_shared)
+
+            T.comm.broadcast(A_shared, B_shared, (1, 2), direction="all")
+
+    mod = tvm.IRModule({"main": main})
+    target = determine_target("Sunmmio", return_object=True)
+    with tvm.target.Target(target):
+        mod = tvm.tir.transform.BindTarget(target)(mod)
+        mod = tilelang.transform.LowerTileOp()(mod)
+        assert mod.script()[-len(func_str):] == func_str, "The generated script does not match the expected output."
+
+
+@pytest.mark.parametrize(
+    "M, N, block_M, block_N, dtype, accum_dtype",
+    [
+        (1024, 1024, 128, 128, "float16", "float"),
+    ],
+)
+def test_comm_put_lower(M, N, block_M, block_N, dtype, accum_dtype):
+    func_str = """
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(B_shared[0, 0], 2, 128, 128), 16384, 6, 1, 0, 1, 3)
+            T.broadcast_(T.region(B_shared[0, 0], 1, 128, 128), T.region(B_shared[0, 0], 2, 128, 128), 16384, 10, 0, 0, 1, 2)""".strip()
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, N), dtype),
+    ):
+        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=128) as (bx, by):
+            A_shared = T.alloc_shared([block_M, block_N], dtype, scope="shared.rsram")
+            B_shared = T.alloc_shared([block_M, block_N], dtype, scope="shared.rsram")
+            T.copy(A[by * block_M, bx * block_N], A_shared)
+
+            T.comm.put(A_shared, B_shared, (1, 2), (2, 3))
+
+    mod = tvm.IRModule({"main": main})
+    target = determine_target("Sunmmio", return_object=True)
+    with tvm.target.Target(target):
+        mod = tvm.tir.transform.BindTarget(target)(mod)
+        mod = tilelang.transform.LowerTileOp()(mod)
+        assert mod.script()[-len(func_str):] == func_str, "The generated script does not match the expected output."
+
+
+@pytest.mark.parametrize(
+    "M, N, block_M, block_N, dtype, accum_dtype",
+    [
+        (1024, 1024, 128, 128, "float16", "float"),
+    ],
+)
+def test_comm_all_gather_lower(M, N, block_M, block_N, dtype, accum_dtype):
+    func_str = """
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(C_shared[0, 0, 0], 2, 16, 128, 128), 16384, 0, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(C_shared[0, 0, 0], 2, 16, 128, 128), 16384, 1, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(C_shared[0, 0, 0], 2, 16, 128, 128), 16384, 2, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(C_shared[0, 0, 0], 2, 16, 128, 128), 16384, 3, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(C_shared[0, 0, 0], 2, 16, 128, 128), 16384, 4, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(C_shared[0, 0, 0], 2, 16, 128, 128), 16384, 5, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(C_shared[0, 0, 0], 2, 16, 128, 128), 16384, 6, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(C_shared[0, 0, 0], 2, 16, 128, 128), 16384, 7, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(C_shared[0, 0, 0], 2, 16, 128, 128), 16384, 8, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(C_shared[0, 0, 0], 2, 16, 128, 128), 16384, 9, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(C_shared[0, 0, 0], 2, 16, 128, 128), 16384, 10, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(C_shared[0, 0, 0], 2, 16, 128, 128), 16384, 11, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(C_shared[0, 0, 0], 2, 16, 128, 128), 16384, 12, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(C_shared[0, 0, 0], 2, 16, 128, 128), 16384, 13, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(C_shared[0, 0, 0], 2, 16, 128, 128), 16384, 14, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(C_shared[0, 0, 0], 2, 16, 128, 128), 16384, 15, 0)
+            T.broadcast_(T.region(C_shared[0, 0, 0], 1, 4, 128, 128), T.region(C_shared[0, 0, 0], 2, 4, 128, 128), 65536, 0, 1)
+            T.broadcast_(T.region(C_shared[4, 0, 0], 1, 4, 128, 128), T.region(C_shared[4, 0, 0], 2, 4, 128, 128), 65536, 4, 1)
+            T.broadcast_(T.region(C_shared[8, 0, 0], 1, 4, 128, 128), T.region(C_shared[8, 0, 0], 2, 4, 128, 128), 65536, 8, 1)
+            T.broadcast_(T.region(C_shared[12, 0, 0], 1, 4, 128, 128), T.region(C_shared[12, 0, 0], 2, 4, 128, 128), 65536, 12, 1)
+            T.broadcast_(T.region(C_shared[0, 0, 0], 1, 4, 128, 128), T.region(C_shared[0, 0, 0], 2, 4, 128, 128), 65536, 1, 1)
+            T.broadcast_(T.region(C_shared[4, 0, 0], 1, 4, 128, 128), T.region(C_shared[4, 0, 0], 2, 4, 128, 128), 65536, 5, 1)
+            T.broadcast_(T.region(C_shared[8, 0, 0], 1, 4, 128, 128), T.region(C_shared[8, 0, 0], 2, 4, 128, 128), 65536, 9, 1)
+            T.broadcast_(T.region(C_shared[12, 0, 0], 1, 4, 128, 128), T.region(C_shared[12, 0, 0], 2, 4, 128, 128), 65536, 13, 1)
+            T.broadcast_(T.region(C_shared[0, 0, 0], 1, 4, 128, 128), T.region(C_shared[0, 0, 0], 2, 4, 128, 128), 65536, 2, 1)
+            T.broadcast_(T.region(C_shared[4, 0, 0], 1, 4, 128, 128), T.region(C_shared[4, 0, 0], 2, 4, 128, 128), 65536, 6, 1)
+            T.broadcast_(T.region(C_shared[8, 0, 0], 1, 4, 128, 128), T.region(C_shared[8, 0, 0], 2, 4, 128, 128), 65536, 10, 1)
+            T.broadcast_(T.region(C_shared[12, 0, 0], 1, 4, 128, 128), T.region(C_shared[12, 0, 0], 2, 4, 128, 128), 65536, 14, 1)
+            T.broadcast_(T.region(C_shared[0, 0, 0], 1, 4, 128, 128), T.region(C_shared[0, 0, 0], 2, 4, 128, 128), 65536, 3, 1)
+            T.broadcast_(T.region(C_shared[4, 0, 0], 1, 4, 128, 128), T.region(C_shared[4, 0, 0], 2, 4, 128, 128), 65536, 7, 1)
+            T.broadcast_(T.region(C_shared[8, 0, 0], 1, 4, 128, 128), T.region(C_shared[8, 0, 0], 2, 4, 128, 128), 65536, 11, 1)
+            T.broadcast_(T.region(C_shared[12, 0, 0], 1, 4, 128, 128), T.region(C_shared[12, 0, 0], 2, 4, 128, 128), 65536, 15, 1)""".strip()
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, N), dtype),
+    ):
+        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=128) as (bx, by):
+            A_shared = T.alloc_shared([block_M, block_N], dtype, scope="shared.rsram")
+            C_shared = T.alloc_shared([16, block_M, block_N], dtype, scope="shared.rsram")
+            T.copy(A[by * block_M, bx * block_N], A_shared)
+
+            T.comm.all_gather(A_shared, C_shared, direction="all")
+
+    mod = tvm.IRModule({"main": main})
+    target = determine_target("Sunmmio", return_object=True)
+    with tvm.target.Target(target):
+        mod = tvm.tir.transform.BindTarget(target)(mod)
+        mod = tilelang.transform.LowerTileOp()(mod)
+        assert mod.script()[-len(func_str):] == func_str, "The generated script does not match the expected output."
+
+'''
+@pytest.mark.parametrize(
+    "M, N, block_M, block_N, dtype, accum_dtype",
+    [
+        (1024 * 128, 1024 * 128, 1024, 1024, "float16", "float"),
+    ],
+)
+def test_comm_all_reduce_lower(M, N, block_M, block_N, dtype, accum_dtype):
+    func_str = """
+                for i in T.parallel(1024):
+                    for j in T.parallel(256):
+                        for vec in T.vectorized(4):
+                            A_shared[i * 8 + (j * 4 + vec) // 512 * 4 + (j * 4 + vec) % 4] = T.Cast("float32", A[by * 1024 + i, bx * 1024 + (j * 4 + vec)])
+                for i in T.unroll(1024, annotations={"pragma_unroll_explicit": T.bool(False)}):
+                    buffer_2[i] = T.float32(0.0)
+                    for rv in T.unroll(8, annotations={"pragma_unroll_explicit": T.bool(False)}):
+                        buffer_2[i] = buffer_2[i] + A_shared[i * 8 + rv % 2 * 4 + rv // 2]
+                    buffer_2[i] = T.call_extern("float32", "tl::AllReduce<tl::SumOp, 128, 1, 0>::run", buffer_2[i], T.tvm_access_ptr(T.type_annotation("float32"), workspace.data, 0, 128, 2))
+                T.broadcast_(T.tvm_access_ptr(T.type_annotation("float32"), buffer_2.data, 0, 1024, 1), T.tvm_access_ptr(T.type_annotation("float32"), buffer.data, 0, 1024, 2), 1024, 0, 0)
+                T.broadcast_(T.tvm_access_ptr(T.type_annotation("float32"), buffer_2.data, 0, 1024, 1), T.tvm_access_ptr(T.type_annotation("float32"), buffer.data, 1024, 1024, 2), 1024, 1, 0)
+                T.broadcast_(T.tvm_access_ptr(T.type_annotation("float32"), buffer_2.data, 0, 1024, 1), T.tvm_access_ptr(T.type_annotation("float32"), buffer.data, 2048, 1024, 2), 1024, 2, 0)
+                T.broadcast_(T.tvm_access_ptr(T.type_annotation("float32"), buffer_2.data, 0, 1024, 1), T.tvm_access_ptr(T.type_annotation("float32"), buffer.data, 3072, 1024, 2), 1024, 3, 0)
+                T.broadcast_(T.tvm_access_ptr(T.type_annotation("float32"), buffer_2.data, 0, 1024, 1), T.tvm_access_ptr(T.type_annotation("float32"), buffer.data, 0, 1024, 2), 1024, 4, 0)
+                T.broadcast_(T.tvm_access_ptr(T.type_annotation("float32"), buffer_2.data, 0, 1024, 1), T.tvm_access_ptr(T.type_annotation("float32"), buffer.data, 1024, 1024, 2), 1024, 5, 0)
+                T.broadcast_(T.tvm_access_ptr(T.type_annotation("float32"), buffer_2.data, 0, 1024, 1), T.tvm_access_ptr(T.type_annotation("float32"), buffer.data, 2048, 1024, 2), 1024, 6, 0)
+                T.broadcast_(T.tvm_access_ptr(T.type_annotation("float32"), buffer_2.data, 0, 1024, 1), T.tvm_access_ptr(T.type_annotation("float32"), buffer.data, 3072, 1024, 2), 1024, 7, 0)
+                T.broadcast_(T.tvm_access_ptr(T.type_annotation("float32"), buffer_2.data, 0, 1024, 1), T.tvm_access_ptr(T.type_annotation("float32"), buffer.data, 0, 1024, 2), 1024, 8, 0)
+                T.broadcast_(T.tvm_access_ptr(T.type_annotation("float32"), buffer_2.data, 0, 1024, 1), T.tvm_access_ptr(T.type_annotation("float32"), buffer.data, 1024, 1024, 2), 1024, 9, 0)
+                T.broadcast_(T.tvm_access_ptr(T.type_annotation("float32"), buffer_2.data, 0, 1024, 1), T.tvm_access_ptr(T.type_annotation("float32"), buffer.data, 2048, 1024, 2), 1024, 10, 0)
+                T.broadcast_(T.tvm_access_ptr(T.type_annotation("float32"), buffer_2.data, 0, 1024, 1), T.tvm_access_ptr(T.type_annotation("float32"), buffer.data, 3072, 1024, 2), 1024, 11, 0)
+                T.broadcast_(T.tvm_access_ptr(T.type_annotation("float32"), buffer_2.data, 0, 1024, 1), T.tvm_access_ptr(T.type_annotation("float32"), buffer.data, 0, 1024, 2), 1024, 12, 0)
+                T.broadcast_(T.tvm_access_ptr(T.type_annotation("float32"), buffer_2.data, 0, 1024, 1), T.tvm_access_ptr(T.type_annotation("float32"), buffer.data, 1024, 1024, 2), 1024, 13, 0)
+                T.broadcast_(T.tvm_access_ptr(T.type_annotation("float32"), buffer_2.data, 0, 1024, 1), T.tvm_access_ptr(T.type_annotation("float32"), buffer.data, 2048, 1024, 2), 1024, 14, 0)
+                T.broadcast_(T.tvm_access_ptr(T.type_annotation("float32"), buffer_2.data, 0, 1024, 1), T.tvm_access_ptr(T.type_annotation("float32"), buffer.data, 3072, 1024, 2), 1024, 15, 0)
+                for i in T.unroll(1024, annotations={"pragma_unroll_explicit": T.bool(False)}):
+                    buffer_2[i] = T.float32(0.0)
+                    for rv in T.unroll(4, annotations={"pragma_unroll_explicit": T.bool(False)}):
+                        buffer_2[i] = buffer_2[i] + buffer[rv * 8 + i // 512 * 4 + i % 4]
+                T.broadcast_(T.tvm_access_ptr(T.type_annotation("float32"), buffer_2.data, 0, 1024, 1), T.tvm_access_ptr(T.type_annotation("float32"), buffer_1.data, 0, 1024, 2), 1024, 0, 1)
+                T.broadcast_(T.tvm_access_ptr(T.type_annotation("float32"), buffer_2.data, 0, 1024, 1), T.tvm_access_ptr(T.type_annotation("float32"), buffer_1.data, 1024, 1024, 2), 1024, 4, 1)
+                T.broadcast_(T.tvm_access_ptr(T.type_annotation("float32"), buffer_2.data, 0, 1024, 1), T.tvm_access_ptr(T.type_annotation("float32"), buffer_1.data, 2048, 1024, 2), 1024, 8, 1)
+                T.broadcast_(T.tvm_access_ptr(T.type_annotation("float32"), buffer_2.data, 0, 1024, 1), T.tvm_access_ptr(T.type_annotation("float32"), buffer_1.data, 3072, 1024, 2), 1024, 12, 1)
+                T.broadcast_(T.tvm_access_ptr(T.type_annotation("float32"), buffer_2.data, 0, 1024, 1), T.tvm_access_ptr(T.type_annotation("float32"), buffer_1.data, 0, 1024, 2), 1024, 1, 1)
+                T.broadcast_(T.tvm_access_ptr(T.type_annotation("float32"), buffer_2.data, 0, 1024, 1), T.tvm_access_ptr(T.type_annotation("float32"), buffer_1.data, 1024, 1024, 2), 1024, 5, 1)
+                T.broadcast_(T.tvm_access_ptr(T.type_annotation("float32"), buffer_2.data, 0, 1024, 1), T.tvm_access_ptr(T.type_annotation("float32"), buffer_1.data, 2048, 1024, 2), 1024, 9, 1)
+                T.broadcast_(T.tvm_access_ptr(T.type_annotation("float32"), buffer_2.data, 0, 1024, 1), T.tvm_access_ptr(T.type_annotation("float32"), buffer_1.data, 3072, 1024, 2), 1024, 13, 1)
+                T.broadcast_(T.tvm_access_ptr(T.type_annotation("float32"), buffer_2.data, 0, 1024, 1), T.tvm_access_ptr(T.type_annotation("float32"), buffer_1.data, 0, 1024, 2), 1024, 2, 1)
+                T.broadcast_(T.tvm_access_ptr(T.type_annotation("float32"), buffer_2.data, 0, 1024, 1), T.tvm_access_ptr(T.type_annotation("float32"), buffer_1.data, 1024, 1024, 2), 1024, 6, 1)
+                T.broadcast_(T.tvm_access_ptr(T.type_annotation("float32"), buffer_2.data, 0, 1024, 1), T.tvm_access_ptr(T.type_annotation("float32"), buffer_1.data, 2048, 1024, 2), 1024, 10, 1)
+                T.broadcast_(T.tvm_access_ptr(T.type_annotation("float32"), buffer_2.data, 0, 1024, 1), T.tvm_access_ptr(T.type_annotation("float32"), buffer_1.data, 3072, 1024, 2), 1024, 14, 1)
+                T.broadcast_(T.tvm_access_ptr(T.type_annotation("float32"), buffer_2.data, 0, 1024, 1), T.tvm_access_ptr(T.type_annotation("float32"), buffer_1.data, 0, 1024, 2), 1024, 3, 1)
+                T.broadcast_(T.tvm_access_ptr(T.type_annotation("float32"), buffer_2.data, 0, 1024, 1), T.tvm_access_ptr(T.type_annotation("float32"), buffer_1.data, 1024, 1024, 2), 1024, 7, 1)
+                T.broadcast_(T.tvm_access_ptr(T.type_annotation("float32"), buffer_2.data, 0, 1024, 1), T.tvm_access_ptr(T.type_annotation("float32"), buffer_1.data, 2048, 1024, 2), 1024, 11, 1)
+                T.broadcast_(T.tvm_access_ptr(T.type_annotation("float32"), buffer_2.data, 0, 1024, 1), T.tvm_access_ptr(T.type_annotation("float32"), buffer_1.data, 3072, 1024, 2), 1024, 15, 1)
+                E_shared_clear = T.allocate([1024], "float32", "local")
+                for i in T.unroll(1024, annotations={"pragma_unroll_explicit": T.bool(False)}):
+                    E_shared_clear_1 = T.Buffer((1024,), data=E_shared_clear, scope="local")
+                    E_shared_clear_1[i] = T.float32(0.0)
+                    for rv in T.unroll(4, annotations={"pragma_unroll_explicit": T.bool(False)}):
+                        E_shared_clear_1[i] = E_shared_clear_1[i] + buffer_1[rv * 8 + i // 512 * 4 + i % 4]
+                    E_shared[i] = E_shared[i] + E_shared_clear_1[i]
+
+# Metadata omitted. Use show_meta=True in script() method to show it.""".strip()
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, N), dtype),
+    ):
+        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=128) as (bx, by):
+            A_shared = T.alloc_shared([block_M, block_N], dtype, scope="shared.rsram")
+            E_shared = T.alloc_shared([block_M], dtype, scope="shared.rsram")
+            T.copy(A[by * block_M, bx * block_N], A_shared)
+
+            T.comm.all_reduce(A_shared, E_shared, "sum", "all", dim=-1, clear=False)
+
+    mod = tvm.IRModule({"main": main})
+    target = determine_target("Sunmmio", return_object=True)
+    with tvm.target.Target(target):
+        mod = tvm.tir.transform.BindTarget(target)(mod)
+        mod = tilelang.transform.LayoutInference()(mod)
+        mod = tilelang.transform.LowerTileOp()(mod)
+        assert mod.script()[-len(func_str):] == func_str, "The generated script does not match the expected output."
+'''
+
+if __name__ == "__main__":
+    test_comm_python_api(1024, 1024, 128, 128, "float16", "float")
+    test_comm_broadcast_lower(1024, 1024, 128, 128, "float16", "float")
+    test_comm_put_lower(1024, 1024, 128, 128, "float16", "float")
+    test_comm_all_gather_lower(1024, 1024, 128, 128, "float16", "float")
+    # test_comm_all_reduce_lower(1024 * 128, 1024 * 128, 1024, 1024, "float16", "float")

--- a/tilelang/language/__init__.py
+++ b/tilelang/language/__init__.py
@@ -108,6 +108,8 @@ from .builtin import stg64 as stg64  # noqa: F401
 from .builtin import stg128 as stg128  # noqa: F401
 from .builtin import stg256 as stg256  # noqa: F401
 
+from . import comm  # noqa: F401
+
 from .utils import index_to_coordinates  # noqa: F401
 
 from .symbolics import dynamic, symbolic  # noqa: F401

--- a/tilelang/language/comm.py
+++ b/tilelang/language/comm.py
@@ -1,0 +1,471 @@
+"""Communication intrinsics wrappers for TileLang.
+
+This module provides small helper functions that prepare arguments and
+emit TIR intrinsics for inter-core communication on a target mesh.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+from collections.abc import Iterable
+
+from tvm import tir
+import tilelang.language as T
+from tilelang.utils.language import (
+    to_buffer_region,
+)
+
+from tilelang.carver.arch.driver import get_sunmmio_device_mesh_config
+
+DIRECTION_MAP = {"horizontal": 0, "h": 0, "vertical": 1, "v": 1, "all": 2, "a": 2}
+REDUCE_TYPE_LIST = (
+    "sum",
+    "abssum",
+    "max",
+    "min",
+    "absmax",
+    "bitand",
+    "bitor",
+    "bitxor",
+)
+
+
+def get_target_mesh_shape() -> dict[str, int]:
+    """Get the target mesh shape as a dictionary with 'nrow' and 'ncol' keys."""
+    nrow, ncol = get_sunmmio_device_mesh_config()
+    return {"nrow": nrow, "ncol": ncol}
+
+
+def core_tuple_to_id(core_id: tuple[int, int]) -> int:
+    """Convert 2D (row, col) coordinates on the mesh into a linear core id.
+
+    Parameters
+    ----------
+    core_id : tuple[int, int]
+        A tuple specifying the (row, col) coordinates of the core on the mesh.
+
+    Returns
+    -------
+    int
+        The linear core id corresponding to the provided coordinates.
+
+    Notes
+    -----
+    The conversion uses the current target mesh shape obtained via
+    get_target_mesh_shape().
+    """
+    mesh_shape = get_target_mesh_shape()
+    row, col = core_id
+    assert 0 <= row < mesh_shape["nrow"], f"Row {row} out of bounds for mesh shape {mesh_shape}."
+    assert 0 <= col < mesh_shape["ncol"], f"Col {col} out of bounds for mesh shape {mesh_shape}."
+    core_id_value = row * mesh_shape["ncol"] + col
+    return core_id_value
+
+
+def core_id_to_tuple(core_id: tir.Call) -> tuple[int, int]:
+    """Convert a linear core id into 2D (row, col) coordinates on the mesh.
+
+    Parameters
+    ----------
+    core_id : tir.Call
+        A linear core identifier (or a TIR expression that yields one).
+
+    Returns
+    -------
+    tuple[int, int]
+        The (row, col) coordinates corresponding to the linear core id.
+
+    Notes
+    -----
+    The conversion uses the current target mesh shape obtained via
+    get_target_mesh_shape().
+    """
+    mesh_shape = get_target_mesh_shape()
+    core_id_value = core_id
+    row = core_id_value // mesh_shape["ncol"]
+    col = core_id_value % mesh_shape["ncol"]
+    return (row, col)
+
+
+def CoreId(core_id: int | tuple[int, int]):
+    """Convert a core identifier to a linear core ID for the target mesh.
+
+    Parameters
+    ----------
+    core_id : int or tuple[int, int]
+        Either a linear core id (int) or a 2-tuple (row, col) specifying the
+        core coordinates on the target mesh.
+
+    Returns
+    -------
+    int
+        The linear core id mapped into [0, mesh_nrow * mesh_ncol).
+
+    Raises
+    ------
+    AssertionError, ValueError
+        If the provided coordinates are out of bounds or the type is invalid.
+    """
+    mesh_shape = get_target_mesh_shape()
+    if isinstance(core_id, tuple):
+        core_id_value = core_tuple_to_id(core_id)
+    elif isinstance(core_id, int):
+        core_id_value = core_id
+        assert 0 <= core_id_value < mesh_shape["nrow"] * mesh_shape["ncol"], (
+            f"Core ID {core_id_value} out of bounds for mesh shape {mesh_shape}"
+        )
+    else:
+        raise ValueError("core_id must be either a tuple[int, int] or an int.")
+    return tir.call_intrin("handle", tir.op.Op.get("tl.CoreId"), core_id_value)
+
+
+def current_core():
+    """Get the current core's identifier.
+
+    Returns
+    -------
+    tir.Call
+        The TIR intrinsic call handle for `tl.comm_current_core`.
+
+    Examples
+    --------
+    >>> current_core()
+    """
+    return tir.call_intrin("handle", tir.op.Op.get("tl.comm_current_core"))
+
+
+def _get_buffer_info(buf):
+    if isinstance(buf, tir.BufferRegion):
+        return buf.buffer.dtype, [r.extent for r in buf.region]
+    return buf.dtype, buf.shape
+
+
+def broadcast(
+    src: T.Buffer,
+    dst: T.Buffer,
+    src_core: tuple[int, int],
+    direction: Literal["horizontal", "h", "vertical", "v", "all", "a"] = "all",
+    size: int = -1,
+):
+    """Broadcast data from a source buffer on a specific source core to a destination buffer
+    on all cores in the specified direction by emitting the TIR intrinsic tl.tileop.comm_broadcast.
+    Parameters
+    ----------
+    src : T.Buffer
+        Source buffer containing data to broadcast.
+    dst : T.Buffer
+        Destination buffer to receive the broadcasted data.
+    src_core : tuple[int, int]
+        (row, col) coordinates of the source core on the target mesh.
+    direction : Literal["horizontal", "h", "vertical", "v", "all", "a"]
+        Direction of broadcast: "horizontal" (or "h") for row-wise, "vertical" (or "v") for column-wise,
+        and "all" (or "a") for all cores.
+    size : int
+        Number of elements to broadcast. If -1, the entire source buffer is used.
+    Returns
+    -------
+    tir.Call
+        The TIR intrinsic call handle for `tl.tileop.comm_broadcast`.
+    Examples
+    --------
+    >>> broadcast(A, B, (1, 2), direction="horizontal")
+    """
+    src_dtype, src_shape = _get_buffer_info(src)
+    dst_dtype, dst_shape = _get_buffer_info(dst)
+
+    assert src_dtype == dst_dtype, f"Source and destination buffer dtypes must match for broadcast. Got {src_dtype} vs {dst_dtype}."
+    if len(src_shape) != len(dst_shape):
+        raise ValueError("Source and destination buffer must have the same number of dimensions for broadcast.")
+    for i in range(len(src_shape)):
+        assert src_shape[i] == dst_shape[i] or src_shape[i] == 1 or dst_shape[i] == 1, (
+            f"Source buffer shape  and destination buffer shape must match for broadcast. Got {src_shape} vs {dst_shape}."
+        )
+
+    mesh_shape = get_target_mesh_shape()
+    assert isinstance(src_core, tuple) and len(src_core) == 2, "src_core must be a tuple of (row, col)."
+    assert 0 <= src_core[0] < mesh_shape["nrow"], f"src_core row {src_core[0]} out of bounds for mesh shape {mesh_shape}."
+    assert 0 <= src_core[1] < mesh_shape["ncol"], f"src_core col {src_core[1]} out of bounds for mesh shape {mesh_shape}."
+
+    src_elements = 1
+    for dim in src_shape:
+        src_elements *= dim
+    assert isinstance(size, int) and size >= -1, "size must be an integer >= -1."
+    assert size <= src_elements, f"size {size} exceeds source buffer size {src_elements}."
+
+    assert direction.lower() in DIRECTION_MAP, f"Invalid direction string: {direction}"
+
+    src_region = to_buffer_region(src)
+    dst_region = to_buffer_region(dst)
+    src_core_id = core_tuple_to_id(src_core)
+    dst_offset = 0  # Always 0 for now
+
+    args = (
+        src_region,
+        dst_region,
+        size,
+        dst_offset,
+        src_core_id,
+        DIRECTION_MAP[direction.lower()],
+    )
+    return tir.call_intrin("handle", tir.op.Op.get("tl.tileop.comm_broadcast"), *args)
+
+
+def put(
+    src: T.Buffer,
+    dst: T.Buffer,
+    src_core: tuple[int, int],
+    dst_core: tuple[int, int],
+    size: int = -1,
+):
+    """Put data from a source buffer on a specific source core to a destination buffer on a specific destination core
+    by emitting the TIR intrinsic tl.tileop.comm_put.
+    Parameters
+    ----------
+    src : T.Buffer
+        Source buffer containing data to put.
+    dst : T.Buffer
+        Destination buffer to receive the data.
+    src_core : tuple[int, int]
+        (row, col) coordinates of the source core on the target mesh.
+    dst_core : tuple[int, int]
+        (row, col) coordinates of the destination core on the target mesh.
+    size : int
+        Number of elements to put. If -1, the entire source buffer is used.
+    Returns
+    -------
+    tir.Call
+        The TIR intrinsic call handle for `tl.tileop.comm_put`.
+    Examples
+    --------
+    >>> put(A, B, (1, 2), (2, 3))
+    """
+    assert src.dtype == dst.dtype, f"Source and destination buffer dtypes must match for put. Got {src.dtype} vs {dst.dtype}."
+    if len(src.shape) != len(dst.shape):
+        raise ValueError("Source and destination buffer must have the same number of dimensions for put.")
+    for i in range(len(src.shape)):
+        assert src.shape[i] == dst.shape[i] or src.shape[i] == 1 or dst.shape[i] == 1, (
+            f"Source buffer shape and destination buffer shape must be compatible for put. Got {src.shape} vs {dst.shape}."
+        )
+
+    mesh_shape = get_target_mesh_shape()
+    assert isinstance(src_core, tuple) and len(src_core) == 2, "src_core must be a tuple of (row, col)."
+    assert 0 <= src_core[0] < mesh_shape["nrow"], f"src_core row {src_core[0]} out of bounds for mesh shape {mesh_shape}."
+    assert 0 <= src_core[1] < mesh_shape["ncol"], f"src_core col {src_core[1]} out of bounds for mesh shape {mesh_shape}."
+    assert isinstance(dst_core, tuple) and len(dst_core) == 2, "dst_core must be a tuple of (row, col)."
+    assert 0 <= dst_core[0] < mesh_shape["nrow"], f"dst_core row {dst_core[0]} out of bounds for mesh shape {mesh_shape}."
+    assert 0 <= dst_core[1] < mesh_shape["ncol"], f"dst_core col {dst_core[1]} out of bounds for mesh shape {mesh_shape}."
+    src_elements = 1
+    for dim in src.shape:
+        src_elements *= dim
+    assert isinstance(size, int) and size >= -1, "size must be an integer >= -1."
+    assert size <= src_elements, f"size {size} exceeds source buffer size {src_elements}."
+
+    src_region = to_buffer_region(src)
+    dst_region = to_buffer_region(dst)
+    src_core_id = core_tuple_to_id(src_core)
+    dst_core_id = core_tuple_to_id(dst_core)
+    args = (src_region, dst_region, size, src_core_id, dst_core_id)
+    return tir.call_intrin("handle", tir.op.Op.get("tl.tileop.comm_put"), *args)
+
+
+def all_gather(
+    send_buffer: T.Buffer,
+    recv_buffer: T.Buffer,
+    direction: Literal["horizontal", "h", "vertical", "v", "all", "a"] = "all",
+    size: int = -1,
+):
+    """Perform an all-gather operation from a send buffer to a receive buffer
+    by emitting the TIR intrinsic tl.tileop.comm_allgather.
+    Parameters
+    ----------
+    send_buffer : T.Buffer
+        Buffer containing data to send.
+    recv_buffer : T.Buffer
+        Buffer to receive gathered data.
+    direction : Literal["horizontal", "h", "vertical", "v", "all", "a"]
+        Direction of all-gather: "horizontal" (or "h") for row-wise, "vertical" (or "v") for column-wise,
+        and "all" (or "a") for all cores.
+    size : int
+        Number of elements to send from each core. If -1, the entire send buffer is used.
+    Returns
+    -------
+    tir.Call
+        The TIR intrinsic call handle for `tl.tileop.comm_allgather`.
+    Examples
+    --------
+    >>> all_gather(A_local, C_local, direction="horizontal")
+    """
+    assert direction.lower() in DIRECTION_MAP, f"Invalid direction string: {direction}"
+
+    assert send_buffer.dtype == recv_buffer.dtype, (
+        f"Source and destination buffer dtypes must match for all_gather. Got {send_buffer.dtype} vs {recv_buffer.dtype}."
+    )
+    mesh_shape = get_target_mesh_shape()
+
+    recv_num = 1
+    if direction.lower() in ["horizontal", "h"]:
+        recv_num = mesh_shape["ncol"]
+    elif direction.lower() in ["vertical", "v"]:
+        recv_num = mesh_shape["nrow"]
+    elif direction.lower() in ["all", "a"]:
+        recv_num = mesh_shape["nrow"] * mesh_shape["ncol"]
+
+    expected_recv_shape = [recv_num] + list(send_buffer.shape)
+    assert list(recv_buffer.shape) == expected_recv_shape, (
+        f"Receive buffer shape must be {expected_recv_shape} to hold gathered data from {recv_num} cores, but got {recv_buffer.shape}."
+    )
+
+    assert isinstance(size, int) and size >= -1, "size must be an integer >= -1."
+    send_elements = 1
+    for dim in send_buffer.shape:
+        send_elements *= dim
+    assert size <= send_elements, f"size {size} exceeds send buffer size {send_elements}."
+
+    send_buffer_region = to_buffer_region(send_buffer)
+    recv_buffer_region = to_buffer_region(recv_buffer)
+
+    args = (
+        send_buffer_region,
+        recv_buffer_region,
+        DIRECTION_MAP[direction.lower()],
+        size,
+    )
+    return tir.call_intrin("handle", tir.op.Op.get("tl.tileop.comm_allgather"), *args)
+
+
+def all_reduce(
+    buffer: T.Buffer,
+    out: T.Buffer,
+    reduce_type: str,
+    direction: Literal["horizontal", "h", "vertical", "v", "all", "a"],
+    dim: int = -1,
+    clear: bool = True,
+):
+    """Perform an all-reduce operation on a buffer and store the result in an output buffer
+    by emitting the TIR intrinsic tl.tileop.comm_allreduce.
+    Parameters
+    ----------
+    buffer : T.Buffer
+        Input buffer containing data to reduce.
+    out : T.Buffer
+        Output buffer to store the reduced result.
+    reduce_type : str
+        Type of reduction operation (e.g., "sum", "max", etc.).
+    direction : Literal["horizontal", "h", "vertical", "v", "all", "a"]
+        Direction of all-reduce: "horizontal" (or "h") for row-wise, "vertical" (or "v") for column-wise,
+        and "all" (or "a") for all cores.
+    dim : int
+        Dimension along which to perform the reduction. Default is -1 (last dimension).
+    clear : bool
+        Whether to clear the output buffer before reduction. Default is True.
+    Returns
+    -------
+    tir.Call
+        The TIR intrinsic call handle for `tl.tileop.comm_allreduce`.
+    Examples
+    --------
+    >>> all_reduce(A_local, E_local, "sum", "all", dim=-1, clear=False)
+    """
+    assert isinstance(dim, int) and dim >= -1 and dim < len(buffer.shape), (
+        f"dim {dim} out of bounds for buffer with {len(buffer.shape)} dimensions."
+    )
+    if dim == -1:
+        dim = len(buffer.shape) - 1
+
+    expected_shapes = [
+        buffer.shape[:dim] + buffer.shape[dim + 1 :],
+        buffer.shape[:dim] + [1] + buffer.shape[dim + 1 :],
+    ]
+    if list(out.shape) not in expected_shapes:
+        expected_shapes_str = " or ".join(map(str, expected_shapes))
+        raise ValueError(
+            f"Invalid reduce output shape, buffer shape is {buffer.shape}, dim is {dim}, "
+            f"output shape is {out.shape}, expected shapes are {expected_shapes_str}"
+        )
+
+    reduce_type = reduce_type.lower()
+    assert reduce_type in REDUCE_TYPE_LIST, f"Reduction op must be one of {REDUCE_TYPE_LIST}, but got {reduce_type}."
+
+    assert direction.lower() in DIRECTION_MAP, f"Invalid direction string: {direction}"
+    assert clear in [True, False], "clear must be a boolean value."
+
+    mesh_shape = get_target_mesh_shape()
+
+    # Create temporary buffers for row and column allgather results
+    row_allgather = T.alloc_fragment(list([mesh_shape["nrow"]] + out.shape), out.dtype)
+    col_allgather = T.alloc_fragment(list([mesh_shape["ncol"]] + out.shape), out.dtype)
+
+    buffer_region = to_buffer_region(buffer)
+    out_region = to_buffer_region(out)
+    row_allgather_region = to_buffer_region(row_allgather)
+    col_allgather_region = to_buffer_region(col_allgather)
+
+    args = (
+        buffer_region,
+        out_region,
+        row_allgather_region,
+        col_allgather_region,
+        reduce_type,
+        DIRECTION_MAP[direction.lower()],
+        dim,
+        clear,
+    )
+
+    # If not clearing, allocate an output copy buffer to hold intermediate results
+    if not clear:
+        out_copy = T.alloc_fragment(list(out.shape), out.dtype)
+        out_copy_region = to_buffer_region(out_copy)
+        args = (
+            buffer_region,
+            out_region,
+            row_allgather_region,
+            col_allgather_region,
+            reduce_type,
+            DIRECTION_MAP[direction.lower()],
+            dim,
+            clear,
+            out_copy_region,
+        )
+
+    return tir.call_intrin("handle", tir.op.Op.get("tl.tileop.comm_allreduce"), *args)
+
+
+def barrier(group: Iterable[tuple[int, int]] | None = None):
+    """Insert a synchronization barrier among a group of cores.
+
+    Parameters
+    ----------
+    group : iterable of tuple[int, int] | None
+        Optional set of core coordinates to synchronize. If omitted, the
+        runtime's default participant set is used.
+
+    Returns
+    -------
+    tir.Call
+        The TIR intrinsic call handle for `tl.comm_barrier`.
+
+    Examples
+    --------
+    >>> barrier()
+    >>> barrier(group=[(0,0),(0,1)])
+    """
+    if group is None:
+        return tir.call_intrin("handle", tir.op.Op.get("tl.comm_barrier"))
+    else:
+        group = [core_tuple_to_id(core_id) for core_id in group]
+        return tir.call_intrin("handle", tir.op.Op.get("tl.comm_barrier"), *group)
+
+
+def fence():
+    """Emit a memory/communication fence intrinsic.
+
+    Returns
+    -------
+    tir.Call
+        The TIR intrinsic call handle for `tl.comm_fence`.
+
+    Examples
+    --------
+    >>> fence()
+    """
+    return tir.call_intrin("handle", tir.op.Op.get("tl.comm_fence"))


### PR DESCRIPTION
# Inter Core Communication Operators

## 1. Overall Structure

The communication capabilities are organized in two layers:

- **Python Language Layer**: `tilelang/language/comm.py`
  - Provides user-friendly APIs: `broadcast`, `put`, `all_gather`, `all_reduce`, `barrier`, `fence`, `CoreId`.
  - Handles parameter validation, direction string mapping, conversion between core coordinates and linear core IDs, and BufferRegion normalization.
  - Ultimately emits `tir.call_intrin("handle", Op.get("tl.tileop.xxx"), ...)`.
- **C++ TileOp Layer**: `src/op/comm.h` + `src/op/comm.cc`
  - Defines `BroadcastOp`, `PutOp`, `AllgatherOp`, `AllreduceOp`.
  - Performs target checking, range checking, layout inference, and statement lowering during the `Lower` phase.
  - Key built-in primitive is `tl.broadcast_`, upon which `put/allgather/allreduce` are composed.

**Core Philosophy**: **Python handles semantics and usability, while C++ handles legality validation and specific communication scheduling lowering.**

## 2. Mesh and Core ID Conventions

### 2.1 Mesh Dimensions Source

- Python side reads `(nrow, ncol)` via `get_sunmmio_device_mesh_config()`.
- C++ side parses `device_mesh_nrow_*` and `device_mesh_ncol_*` via `Target`'s `mattr`.

### 2.2 Core ID Representation

- Conversion between 2D coordinates `(row, col)` and linear ID:
  - `id = row * ncol + col`
  - `row = id // ncol, col = id % ncol`
- Python API asserts boundaries for both input core coordinates and IDs.
- C++ Lower performs boundary checks again to prevent illegal cores from entering backend calls.

### 2.3 Direction Encoding

- Mapping from direction strings to integers:
  - `horizontal/h -> 0`
  - `vertical/v -> 1`
  - `all/a -> 2`

This encoding is consistent across both Python and C++.

## 3. Communication Operators Detail

### 3.1 Broadcast

#### Python Interface Semantics

```python
T.comm.broadcast(src, dst, src_core=(r, c), direction="all", size=-1)
```

- **Constraints**:
  - `src/dst dtype` must match.
  - Number of shape dimensions must match; each dimension must be equal or broadcastable (one side is 1).
  - `size >= -1`, and must not exceed `src` element count.
  - `src_core` must be within mesh boundaries.
- **Emitted Arguments**:
  - `(src_region, dst_region, size, dst_offset=0, src_core_id, direction_code)`.

#### C++ Lower Logic

- Only supports Sunmmio targets.
- Validates source/destination buffer element counts, `size`, and `dst_offset` legality.
- Lowers based on direction:
  - `direction in {0,1}`: Directly emits a single `tl.broadcast_`.
  - `direction == 2`: First performs a vertical broadcast, then performs a horizontal broadcast for each row, forming a 2D diffusion.

### 3.2 Put

#### Python Interface Semantics

```python
T.comm.put(src, dst, src_core=(r1, c1), dst_core=(r2, c2), size=-1)
```

- **Constraints**: Similar to `broadcast`, with additional checks for `dst_core`.
- **Emitted Arguments**:
  - `(src_region, dst_region, size, src_core_id, dst_core_id)`.

#### C++ Lower Logic

`put` is implemented by composing `tl.broadcast_`, handling three cases:

- Same Row (`src_row == dst_row`): One horizontal broadcast + mask to exclude non-target columns.
- Same Column (`src_col == dst_col`): One vertical broadcast + mask to exclude non-target rows.
- Cross Row and Column: Two-hop transfer
  1. Vertical transfer from `src` to an intermediate core (target row, source column);
  2. Horizontal transfer from the intermediate core to `dst`.

Thus, `put` is essentially a **controlled broadcast path**, not a standalone hardware primitive.

### 3.3 AllGather

#### Python Interface Semantics

```python
T.comm.all_gather(send_buffer, recv_buffer, direction="all", size=-1)
```

- **Constraints**:
  - dtypes must match.
  - `recv_buffer.shape` must equal `[recv_num] + send_buffer.shape`.
  - `recv_num` depends on direction: `ncol` for horizontal, `nrow` for vertical, `nrow*ncol` for all.

#### C++ Lower Logic

- Checks if `recv` capacity is sufficient to hold `send_elements * recv_num`.
- Direction lowering:
  - Horizontal: Iterates through every row and column, executing a horizontal broadcast with each core as the source.
  - Vertical: Iterates through every column and row, executing a vertical broadcast with each core as the source.
  - All-Gather:
    1. First performs a round of horizontal all-gather;
    2. Then performs a round of vertical broadcast to diffuse "aggregated blocks per row".
- To generate cleaner TIR, the second phase of `direction=all` attempts to slice along the 0-th dimension; if divisibility conditions are not met, it falls back to flattened interval processing.

### 3.4 AllReduce

#### Python Interface Semantics

```python
T.comm.all_reduce(buffer, out, reduce_type, direction, dim=-1, clear=True)
```

- `dim=-1` is normalized to the last dimension.
- `out.shape` must satisfy one of the following:
  - The reduced dimension is removed (actual dimensionality reduction);
  - The reduced dimension has length 1 (kept dimension).
- `reduce_type` allows: `sum/abssum/max/min/absmax/bitand/bitor/bitxor`.
- Internally allocates temporary fragments:
  - `row_allgather`, `col_allgather`;
  - When `clear=False`, additionally allocates `out_copy`.

#### C++ Lower Logic

AllReduce is a composite operator relying on `ReduceOp + AllgatherOp`:

- `clear=True`:
  1. Local `Reduce(src -> dst, clear=true)`;
  2. If row reduction is needed: `Allgather(dst -> row_allgather, horizontal)` then `Reduce(row_allgather -> dst)`;
  3. If column reduction is needed: `Allgather(dst -> col_allgather, vertical)` then `Reduce(col_allgather -> dst)`.
- `clear=False`:
  1. First `Reduce(src -> dst_copy, clear=true)`;
  2. In row/column paths, uses different `clear` combinations to accumulate results into `dst`, avoiding overwriting the original output.

`direction` supports `0/1/2` (row/col/all); invalid values trigger check failures.

## 4. Python API to C++ TileOp Mapping

| Python API | Emitted Op Name | C++ Class |
| --- | --- | --- |
| `T.comm.broadcast(...)` | `tl.tileop.comm_broadcast` | `BroadcastOpNode` |
| `T.comm.put(...)` | `tl.tileop.comm_put` | `PutOpNode` |
| `T.comm.all_gather(...)` | `tl.tileop.comm_allgather` | `AllgatherOpNode` |
| `T.comm.all_reduce(...)` | `tl.tileop.comm_allreduce` | `AllreduceOpNode` |
| `T.comm.barrier(...)` | `tl.comm_barrier` | Built-in Op (Not TileOpNode) |
| `T.comm.fence()` | `tl.comm_fence` | Built-in Op (Not TileOpNode) |
| `T.comm.CoreId(...)` | `tl.CoreId` | Built-in Op (Not TileOpNode) |

Where `comm_barrier/comm_fence/CoreId` are registered as TIR built-in calls, while `comm_broadcast/put/allgather/allreduce` are registered as TileOps and expanded during `LowerTileOp`.

## 5. Test Coverage and Observable Behavior

`testing/python/language/test_tilelang_language_comm.py` primarily verifies two things:

- Correctness of frontend emission from Python API to TIR text.
- Consistency of expanded results after `LowerTileOp` with expected scripts.

Currently enabled test points:

- `test_comm_python_api`:
  - Validates `T.comm.broadcast/put/all_gather` generated `T.comm_*` call text.
- `test_comm_broadcast_lower`:
  - Validates that `direction="all"` lowers to a sequence of "1 vertical + multiple horizontal" `broadcast_` calls.
- `test_comm_put_lower`:
  - Validates that cross-row/cross-column `put` is decomposed into two `broadcast_` segments (with masks).
- `test_comm_all_gather_lower`:
  - Validates that `direction="all"` all-gather generates a large number of `broadcast_` calls, reflecting staged diffusion.

The long script comparison test for `all_reduce` is currently commented out in the file, indicating that this path has examples but is not included in regular regression execution by default.

## 6. Key Design Features Summary

- **Unified Communication Abstraction**: High-level APIs are unified as `T.comm.*`, while the bottom layer is composed of a few built-in primitives.
- **Safety First**: Double parameter validation in both Python and C++, especially for mesh boundaries and buffer capacities.
- **Clear Extensibility Path**: Layout inference logic for `Allgather/Allreduce` has reserved space for further refinement (marked with "Not yet complete" in source code).
- **Compositional Implementation Strategy**: `put` and `allreduce` are not independent hardware paths but are built by reusing `broadcast_` and `reduce`, facilitating maintenance and unified backend optimization.
