### PR TITLE
[Features] Infer TileView in T.Tiles & Support 1D tiling

### DIFF
--- a/src/op/copy.cc
+++ b/src/op/copy.cc
@@ -456,14 +456,14 @@ LayoutMap CopyNode::InferLayout(const LayoutInferArgs &T,
     auto result = Map<Buffer, Layout>();
 
     if (level == InferLevel::kFree && !T.layout_map.count(src)) {
-      if (src.scope() != "global") {
+      if (src.scope() != "global" && src->shape.size() > 1) {
         auto layout = Downcast<Layout>((*f)(src));
         result.Set(src, layout);
       }
     }
 
     if (level == InferLevel::kFree && !T.layout_map.count(dst)) {
-      if (dst.scope() != "global") {
+      if (dst.scope() != "global" && dst->shape.size() > 1) {
         auto layout = Downcast<Layout>((*f)(dst));
         result.Set(dst, layout);
       }

--- a/src/transform/common/attr.h
+++ b/src/transform/common/attr.h
@@ -33,6 +33,15 @@ constexpr const char *tile_new_shape = "tile.buffer_new_shape";
 constexpr const char *tile_tile_size = "tile.tile_size";
 constexpr const char *tile_dim_map = "tile.dim_map";
 
+// ---- these attrs are added by the tiles_loop pass ----
+// Marks the outermost tile.execution loop — codegen entry point for a tile
+// scope
+constexpr const char *tile_scope_entry = "tile.scope_entry";
+// Marks generated inner loops (ki, kj) that iterate within a single tile
+constexpr const char *tile_interior = "tile.interior";
+// Which axis of the tile shape this interior loop corresponds to (0, 1, ...)
+constexpr const char *tile_interior_axis = "tile.interior_axis";
+
 } // namespace attr
 
 enum class TileLoopStage : int {

--- a/src/transform/legalize_tiles_loop.cc
+++ b/src/transform/legalize_tiles_loop.cc
@@ -6,6 +6,7 @@
 #include <tvm/tir/stmt_functor.h>
 #include <tvm/tir/transform.h>
 
+#include "../layout/layout.h"
 #include "../support/ffi_aliases.h"
 #include "../tileview/tileview.h"
 #include "common/attr.h"
@@ -96,13 +97,16 @@ class LegalizeTilesLoopRewriter : public StmtExprMutator {
 public:
   using TileViewMap =
       std::unordered_map<Var, TileView, ObjectPtrHash, ObjectPtrEqual>;
+  using BufferDataMap =
+      std::unordered_map<Var, Buffer, ObjectPtrHash, ObjectPtrEqual>;
 
   static PrimFunc Rewrite(PrimFunc f) {
     LegalizeTilesLoopRewriter rewriter;
     rewriter.tileviews_ = TileViewCollector::Collect(f);
 
-    if (rewriter.tileviews_.empty()) {
-      return f;
+    // Collect buffer info from PrimFunc params
+    for (const auto &[_, buffer] : f->buffer_map) {
+      rewriter.buffer_data_to_buffer_[buffer->data] = buffer;
     }
 
     f.CopyOnWrite()->body = rewriter(f->body);
@@ -110,6 +114,91 @@ public:
   }
 
 private:
+  /* ---- Collect buffer and layout info from Block nodes ---- */
+  Stmt VisitStmt_(const BlockNode *block) final {
+    // Collect buffer data -> Buffer mapping from alloc_buffers and
+    // match_buffers
+    for (const auto &buffer : block->alloc_buffers) {
+      buffer_data_to_buffer_[buffer->data] = buffer;
+    }
+    for (const auto &match_buffer : block->match_buffers) {
+      buffer_data_to_buffer_[match_buffer->buffer->data] = match_buffer->buffer;
+    }
+
+    // Collect layout_map from block annotation
+    if (block->annotations.count(attr::kLayoutMap)) {
+      auto layout_map = Downcast<Map<Buffer, Layout>>(
+          block->annotations.at(attr::kLayoutMap));
+      for (const auto &[buffer, layout] : layout_map) {
+        layout_map_.Set(buffer, layout);
+      }
+    }
+
+    return StmtExprMutator::VisitStmt_(block);
+  }
+
+  /* ---- Check if buffer has a layout in layout_map_ ---- */
+  bool HasLayout(const Buffer &buffer) const {
+    return layout_map_.count(buffer) > 0;
+  }
+
+  /* ---- Infer TileView for a buffer when no manual annotation exists ----
+   *
+   * All buffers inside T.Tiles are on-chip SRAM, so scope is not a
+   * distinguishing factor.  The only question is whether the buffer has
+   * a layout in layout_map_ (set by LayoutInference), which indicates
+   * that the tile unit processes it in 2-D blocks rather than row-by-row.
+   *
+   * Rules:
+   *   1D buffer                → tile_shape=(32,),    index_map=(-1,)
+   *   2D+ buffer WITH layout   → tile_shape=(H, 32),  index_map=(-2,-1)
+   *       where H = largest of {32,16,8,1} dividing dim[-2]
+   *   2D+ buffer WITHOUT layout→ tile_shape=(1, 32),   index_map=(-2,-1)
+   * ------------------------------------------------------------------ */
+  TileView InferTileView(const Var &buffer_data) {
+    auto buf_it = buffer_data_to_buffer_.find(buffer_data);
+    ICHECK(buf_it != buffer_data_to_buffer_.end())
+        << "Cannot find buffer for data var " << buffer_data
+        << " during TileView inference.";
+
+    const Buffer &buffer = buf_it->second;
+    int ndim = static_cast<int>(buffer->shape.size());
+
+    if (ndim == 1) {
+      // 1D buffer: tile_shape={32}, index_map={-1}
+      Array<PrimExpr> buffer_shape = buffer->shape;
+      Array<PrimExpr> tile_shape = {Integer(32)};
+      Array<PrimExpr> index_map = {Integer(-1)};
+      return makeTileView(buffer_shape, tile_shape, index_map);
+    }
+
+    // 2D+ buffer
+    Array<PrimExpr> buffer_shape = buffer->shape;
+
+    int tile_h = 1;
+    if (HasLayout(buffer)) {
+      // TODO: Further verify the layout (blockwise)
+      // Buffer has a layout from LayoutInference — tile unit processes
+      // it in 2-D blocks.  Pick the largest tile height that evenly
+      // divides the second-to-last dimension.
+      const auto *dim_val = buffer->shape[ndim - 2].as<IntImmNode>();
+      if (dim_val) {
+        int64_t dim_size = dim_val->value;
+        for (int candidate : {32, 16, 8, 1}) {
+          if (dim_size % candidate == 0) {
+            tile_h = candidate;
+            break;
+          }
+        }
+      }
+      // Dynamic dim: tile_h stays 1
+    }
+
+    Array<PrimExpr> tile_shape = {Integer(tile_h), Integer(32)};
+    Array<PrimExpr> index_map = {Integer(-2), Integer(-1)};
+    return makeTileView(buffer_shape, tile_shape, index_map);
+  }
+
   Stmt VisitStmt_(const ForNode *loop) final {
     // Only rewrite tile-level loops
     if (!loop->annotations.count(attr::tile_level_loop)) {
@@ -125,7 +214,7 @@ private:
     }
 
     if (stage >= static_cast<int>(TileLoopStage::kLegalized)) {
-      // Already legalized → skip
+      // Already legalized -> skip
       LOG(INFO) << "[Legalize tiles loop] tile loop stage is: " << stage
                 << ", so skip. ";
       return StmtExprMutator::VisitStmt_(loop);
@@ -139,24 +228,22 @@ private:
 
     Var buffer_data = Downcast<Var>((*buf_it).second);
 
-    auto tv_it = tileviews_.find(buffer_data);
-    if (tv_it == tileviews_.end()) {
-      // for debugging, it is helpful to print the buffer_data and the keys in
-      // tileviews_ to see why the lookup fails. It is possible that the
-      // buffer_data is not exactly the same as the key in tileviews_ even they
-      // represent the same buffer, due to some transformation before this pass.
-      // We can check their names and shapes to see if they match.
-      LOG(INFO) << "Looking for buffer: " << buffer_data;
-      for (auto &kv : tileviews_) {
-        LOG(INFO) << "Have tileview for: " << kv.first;
-      }
+    // ---- Local tileview map for this tile loop scope ----
+    TileViewMap local_tileviews;
 
-      LOG(INFO) << "Looking for buffer: " << buffer_data.get();
-      for (auto &kv : tileviews_) {
-        LOG(INFO) << "Have tileview for: " << kv.first.get();
-      }
-      return StmtExprMutator::VisitStmt_(loop);
+    // Look up primary buffer's TileView: manual annotation first, then infer
+    auto tv_it = tileviews_.find(buffer_data);
+    TileView primary_tv;
+    if (tv_it != tileviews_.end()) {
+      primary_tv = tv_it->second;
+    } else {
+      // Auto-infer TileView for the primary buffer
+      primary_tv = InferTileView(buffer_data);
+      LOG(INFO) << "[Legalize tiles loop] Auto-inferred TileView for primary "
+                   "buffer: "
+                << buffer_data;
     }
+    local_tileviews[buffer_data] = primary_tv;
 
     // ---- Collect all used buffers inside loop body ----
     auto used_buffers = SharedBufferCollector::Collect(loop->body);
@@ -165,28 +252,60 @@ private:
       return StmtExprMutator::VisitStmt_(loop);
     }
 
-    // ---- Validate TileViews ----
-    const TileView *ref_tv = nullptr;
-
+    // ---- Resolve TileViews for all used buffers ----
     for (const Var &buf : used_buffers) {
+      if (local_tileviews.count(buf))
+        continue;
+
       auto it = tileviews_.find(buf);
-
-      if (it == tileviews_.end()) {
-        LOG(FATAL) << "Buffer " << buf
-                   << " used inside tile loop but has no TileView.";
-      }
-
-      if (!ref_tv) {
-        ref_tv = &(it->second);
+      if (it != tileviews_.end()) {
+        // Manual annotation exists
+        local_tileviews[buf] = it->second;
       } else {
-        ICHECK(ref_tv->get()->IsEqual(it->second.get()))
-            << "Inconsistent TileView inside tile loop.";
+        // Auto-infer
+        local_tileviews[buf] = InferTileView(buf);
+        LOG(INFO) << "[Legalize tiles loop] Auto-inferred TileView for "
+                     "buffer: "
+                  << buf;
       }
     }
 
-    ICHECK(ref_tv) << "Internal error: ref_tv should not be null.";
+    // ---- Validate TileView compatibility across buffers ----
+    // 1) Same-rank buffers must have equal TileViews.
+    // 2) Cross-rank buffers must share the same tile width (last dim of
+    //    tile_shape) so that broadcast is straightforward.
+    {
+      size_t primary_rank = primary_tv->TileDim();
+      Array<PrimExpr> primary_tile = primary_tv->TileShape();
+      PrimExpr primary_width = primary_tile[primary_tile.size() - 1];
 
-    const TileView &tv = *ref_tv;
+      for (const auto &[buf, tv] : local_tileviews) {
+        size_t rank = tv->TileDim();
+        Array<PrimExpr> tile = tv->TileShape();
+        PrimExpr width = tile[tile.size() - 1];
+
+        if (rank == primary_rank) {
+          // Same rank: full equality check
+          ICHECK(primary_tv->IsEqual(tv.get()))
+              << "Inconsistent TileView inside tile loop: buffer " << buf
+              << " has same tile rank (" << rank
+              << ") as primary buffer but different TileView.";
+        } else {
+          // Cross rank: tile width must match for broadcast
+          const auto *pw = primary_width.as<IntImmNode>();
+          const auto *w = width.as<IntImmNode>();
+          ICHECK(pw && w && pw->value == w->value)
+              << "Tile width mismatch inside tile loop: primary buffer has "
+                 "tile width "
+              << primary_width << " but buffer " << buf << " has tile width "
+              << width << ". Cross-rank buffers must share tile width for "
+              << "broadcast.";
+        }
+      }
+    }
+
+    // Use the primary buffer's TileView for loop structure
+    const TileView &tv = primary_tv;
 
     // Enter tile loop (depth == tile dimension)
     int dim = tile_loop_depth_++;
@@ -237,6 +356,8 @@ private:
 
 private:
   TileViewMap tileviews_;
+  BufferDataMap buffer_data_to_buffer_;
+  Map<Buffer, Layout> layout_map_;
   int tile_loop_depth_{0};
 };
 

--- a/src/transform/legalize_tiles_loop.cc
+++ b/src/transform/legalize_tiles_loop.cc
@@ -228,6 +228,19 @@ private:
 
     Var buffer_data = Downcast<Var>((*buf_it).second);
 
+    // ---- Reject nested T.Tiles from different buffers ----
+    // Nesting separate T.Tiles calls (e.g., T.Tiles(A) inside T.Tiles(B))
+    // is not supported.  Loops from a single T.Tiles call share the same
+    // tiled_buffer and nest naturally; only cross-buffer nesting is banned.
+    if (tile_loop_depth_ > 0 && active_tiled_buffer_.defined() &&
+        !buffer_data.same_as(active_tiled_buffer_)) {
+      LOG(FATAL) << "Nested T.Tiles from different buffers is not supported. "
+                 << "Outer T.Tiles uses buffer " << active_tiled_buffer_
+                 << ", but inner T.Tiles uses buffer " << buffer_data << ". "
+                 << "Access multiple buffers within a single T.Tiles scope "
+                 << "instead.";
+    }
+
     // ---- Local tileview map for this tile loop scope ----
     TileViewMap local_tileviews;
 
@@ -309,7 +322,10 @@ private:
 
     // Enter tile loop (depth == tile dimension)
     int dim = tile_loop_depth_++;
+    Var prev_active_buffer = active_tiled_buffer_;
+    active_tiled_buffer_ = buffer_data;
     Stmt new_body = VisitStmt(loop->body);
+    active_tiled_buffer_ = prev_active_buffer;
     tile_loop_depth_--;
 
     Array<PrimExpr> tiled_shape = tv->TiledBufferShape();
@@ -359,6 +375,8 @@ private:
   BufferDataMap buffer_data_to_buffer_;
   Map<Buffer, Layout> layout_map_;
   int tile_loop_depth_{0};
+  Var active_tiled_buffer_; // tracks the tiled_buffer of the innermost T.Tiles
+                            // scope
 };
 
 /* ============================================================

--- a/src/transform/tiles_loop.cc
+++ b/src/transform/tiles_loop.cc
@@ -138,7 +138,45 @@ private:
       return UpdateBody(loop, new_body);
     }
 
-    // ---- Structural match ----
+    auto tile_size_opt = GetTileSize(loop);
+    if (!tile_size_opt.defined()) {
+      return UpdateBody(loop, new_body);
+    }
+
+    Array<PrimExpr> tile_size = tile_size_opt.value();
+    ICHECK(tile_size.size() == 1 || tile_size.size() == 2)
+        << "TilesLoop expects 1D or 2D tile_size, got " << tile_size.size();
+
+    // ---- Record modified tile buffer (semantic grouping anchor) ----
+    auto buf_it = loop->annotations.find(attr::tiled_buffer);
+    ICHECK(buf_it != loop->annotations.end());
+    Var tiled_buf = Downcast<Var>((*buf_it).second);
+    modified_tile_buffers_.insert(tiled_buf);
+
+    if (tile_size.size() == 1) {
+      // ---- 1D lowering ----
+      // for ti  →  for ti { for ki (vectorized) { body[ti → ti*ts+ki] } }
+      if (!IsSerialFor(loop)) {
+        return UpdateBody(loop, new_body);
+      }
+
+      Var ti = loop->loop_var;
+      Var ki("ki");
+
+      Map<Var, PrimExpr> vmap;
+      vmap.Set(ti, ti * tile_size[0] + ki);
+
+      Stmt tiled_body = Substitute(new_body, vmap);
+      tiled_body = For(ki, 0, tile_size[0], ForKind::kVectorized, tiled_body);
+
+      For new_outer = ffi::GetRef<For>(loop);
+      new_outer.CopyOnWrite()->body = tiled_body;
+      return new_outer;
+    }
+
+    // ---- 2D lowering ----
+    // for ti { for tj }  →  for ti { for tj { for ki { for kj (vec) { ... } } }
+    // }
     const ForNode *inner = new_body.as<ForNode>();
     if (!inner) {
       return UpdateBody(loop, new_body);
@@ -152,15 +190,6 @@ private:
       return UpdateBody(loop, new_body);
     }
 
-    auto tile_size_opt = GetTileSize(loop);
-    if (!tile_size_opt.defined()) {
-      return UpdateBody(loop, new_body);
-    }
-
-    Array<PrimExpr> tile_size = tile_size_opt.value();
-    ICHECK_EQ(tile_size.size(), 2) << "TilesLoop expects exactly 2D tile_size";
-
-    // ---- Perform lowering ----
     Var ti = loop->loop_var;
     Var tj = inner->loop_var;
 
@@ -181,13 +210,6 @@ private:
 
     For new_outer = ffi::GetRef<For>(loop);
     new_outer.CopyOnWrite()->body = new_inner;
-
-    // ---- Record modified tile buffer (semantic grouping anchor) ----
-    auto buf_it = loop->annotations.find(attr::tiled_buffer);
-    ICHECK(buf_it != loop->annotations.end());
-    Var tiled_buf = Downcast<Var>((*buf_it).second);
-
-    modified_tile_buffers_.insert(tiled_buf);
 
     return new_outer;
   }

--- a/src/transform/tiles_loop.cc
+++ b/src/transform/tiles_loop.cc
@@ -65,14 +65,18 @@ private:
  *       body
  *
  * Into:
- *   for i
+ *   for i        (tile.scope_entry=1)
  *     for j
- *       for ki
- *         for kj (vectorized)
+ *       for ki   (tile.interior, axis=0)
+ *         for kj (tile.interior, axis=1, vectorized)
  *           body
  *
  * Only for stage == kLegalized.
  * After rewrite, stage → kTiled (by buffer-group update).
+ *
+ * The 2D path is tolerant of non-trivial nesting between the
+ * outer and inner tile.execution loops (LetStmt, AttrStmt, etc.
+ * may appear in between).
  * ------------------------------------------------------------
  */
 class TilesLoopRewriter : public StmtExprMutator {
@@ -82,7 +86,7 @@ public:
     f.CopyOnWrite()->body = rewriter(f->body);
 
     // If any tiles loop was modified, update stage by semantic grouping
-    // When visiting tiles for node, wo collect all tiled_buffers and
+    // When visiting tiles for node, we collect all tiled_buffers and
     // update stage based on these buffers.
     if (!rewriter.modified_tile_buffers_.empty()) {
       StageUpdateRewriter updater(rewriter.modified_tile_buffers_);
@@ -93,15 +97,17 @@ public:
   }
 
 private:
-  bool IsTilesScope(const ForNode *loop) const {
+  // ---- Predicates ----
+
+  static bool IsTilesScope(const ForNode *loop) {
     return loop->annotations.count(attr::tile_execution_loop);
   }
 
-  bool IsSerialFor(const ForNode *loop) const {
+  static bool IsSerialFor(const ForNode *loop) {
     return loop->kind == ForKind::kSerial;
   }
 
-  Optional<Array<PrimExpr>> GetTileSize(const ForNode *loop) const {
+  static Optional<Array<PrimExpr>> GetTileSize(const ForNode *loop) {
     auto it = loop->annotations.find(attr::tile_tile_size);
     if (it == loop->annotations.end()) {
       return std::nullopt;
@@ -117,6 +123,90 @@ private:
     f.CopyOnWrite()->body = new_body;
     return f;
   }
+
+  // ---- Helpers for tolerant nesting ----
+
+  /*!
+   * \brief Search for the inner tile.execution ForNode by peeling through
+   *        transparent wrapper statements (LetStmt, AttrStmt, AssertStmt).
+   *
+   * This makes the 2D lowering path tolerant of intermediate IR that
+   * earlier passes may have inserted between the outer and inner tile
+   * execution loops.
+   *
+   * \param body The statement to search within.
+   * \param tiled_buf Only match loops tied to this buffer.
+   * \return The inner ForNode if found, nullptr otherwise.
+   */
+  static const ForNode *PeelToInnerTileExecLoop(const Stmt &body,
+                                                const Var &tiled_buf) {
+    if (const auto *f = body.as<ForNode>()) {
+      if (f->annotations.count(attr::tile_execution_loop)) {
+        auto buf_it = f->annotations.find(attr::tiled_buffer);
+        if (buf_it != f->annotations.end() &&
+            Downcast<Var>((*buf_it).second).same_as(tiled_buf)) {
+          return f;
+        }
+      }
+      // A ForNode that isn't the right tile.execution — stop peeling
+      return nullptr;
+    }
+    // Peel through transparent single-child wrappers
+    if (const auto *let = body.as<LetStmtNode>()) {
+      return PeelToInnerTileExecLoop(let->body, tiled_buf);
+    }
+    if (const auto *attr_stmt = body.as<AttrStmtNode>()) {
+      return PeelToInnerTileExecLoop(attr_stmt->body, tiled_buf);
+    }
+    if (const auto *assert_stmt = body.as<AssertStmtNode>()) {
+      return PeelToInnerTileExecLoop(assert_stmt->body, tiled_buf);
+    }
+    // SeqStmt, IfThenElse, etc. — don't descend
+    return nullptr;
+  }
+
+  /*!
+   * \brief Replace a specific ForNode within a statement tree.
+   *
+   * Used to swap the inner tile.execution loop with its rewritten
+   * version, preserving any wrapper statements in between.
+   */
+  class InnerLoopReplacer : public StmtExprMutator {
+  public:
+    InnerLoopReplacer(const ForNode *target, Stmt replacement)
+        : target_(target), replacement_(std::move(replacement)) {}
+
+    Stmt VisitStmt_(const ForNode *loop) final {
+      if (loop == target_)
+        return replacement_;
+      return StmtExprMutator::VisitStmt_(loop);
+    }
+
+  private:
+    const ForNode *target_;
+    Stmt replacement_;
+  };
+
+  /*!
+   * \brief Build a For loop annotated as a tile interior loop.
+   * \param loop_var  The intra-tile iteration variable (ki or kj).
+   * \param extent    tile_size along this axis.
+   * \param kind      kSerial for non-last axes, kVectorized for last axis.
+   * \param body      The loop body.
+   * \param axis      Which axis of the tile shape (0, 1, ...).
+   * \param tiled_buf The tiled buffer this loop belongs to.
+   */
+  static For MakeTileInteriorLoop(Var loop_var, PrimExpr extent, ForKind kind,
+                                  Stmt body, int axis, const Var &tiled_buf) {
+    For loop(loop_var, Integer(0), extent, kind, body);
+    auto *n = loop.CopyOnWrite();
+    n->annotations.Set(attr::tile_interior, Integer(1));
+    n->annotations.Set(attr::tile_interior_axis, Integer(axis));
+    n->annotations.Set(attr::tiled_buffer, tiled_buf);
+    return loop;
+  }
+
+  // ---- Main rewrite ----
 
   Stmt VisitStmt_(const ForNode *loop) final {
     // Post-order traversal
@@ -154,39 +244,61 @@ private:
     modified_tile_buffers_.insert(tiled_buf);
 
     if (tile_size.size() == 1) {
-      // ---- 1D lowering ----
-      // for ti  →  for ti { for ki (vectorized) { body[ti → ti*ts+ki] } }
-      if (!IsSerialFor(loop)) {
-        return UpdateBody(loop, new_body);
-      }
+      return Rewrite1D(loop, new_body, tile_size, tiled_buf);
+    }
+    return Rewrite2D(loop, new_body, tile_size, tiled_buf);
+  }
 
-      Var ti = loop->loop_var;
-      Var ki("ki");
-
-      Map<Var, PrimExpr> vmap;
-      vmap.Set(ti, ti * tile_size[0] + ki);
-
-      Stmt tiled_body = Substitute(new_body, vmap);
-      tiled_body = For(ki, 0, tile_size[0], ForKind::kVectorized, tiled_body);
-
-      For new_outer = ffi::GetRef<For>(loop);
-      new_outer.CopyOnWrite()->body = tiled_body;
-      return new_outer;
+  /*!
+   * \brief 1D lowering:
+   *   for ti → for ti (scope_entry) { for ki (interior, vec) { body } }
+   */
+  Stmt Rewrite1D(const ForNode *loop, Stmt new_body,
+                 const Array<PrimExpr> &tile_size, const Var &tiled_buf) {
+    if (!IsSerialFor(loop)) {
+      return UpdateBody(loop, new_body);
     }
 
-    // ---- 2D lowering ----
-    // for ti { for tj }  →  for ti { for tj { for ki { for kj (vec) { ... } } }
-    // }
-    const ForNode *inner = new_body.as<ForNode>();
+    Var ti = loop->loop_var;
+    Var ki("ki");
+
+    Map<Var, PrimExpr> vmap;
+    vmap.Set(ti, ti * tile_size[0] + ki);
+
+    Stmt tiled_body = Substitute(new_body, vmap);
+
+    // Create annotated interior loop
+    For ki_loop =
+        MakeTileInteriorLoop(ki, tile_size[0], ForKind::kVectorized, tiled_body,
+                             /*axis=*/0, tiled_buf);
+
+    // Update outer loop: set scope_entry
+    For new_outer = ffi::GetRef<For>(loop);
+    auto *n = new_outer.CopyOnWrite();
+    n->body = ki_loop;
+    n->annotations.Set(attr::tile_scope_entry, Integer(1));
+    return new_outer;
+  }
+
+  /*!
+   * \brief 2D lowering:
+   *   for ti { [wrappers...] for tj { body } }
+   *   →
+   *   for ti (scope_entry) { [wrappers...] for tj {
+   *       for ki (interior, axis=0) { for kj (interior, axis=1, vec) { body } }
+   *   } }
+   *
+   * Tolerant of LetStmt/AttrStmt/AssertStmt between ti and tj.
+   */
+  Stmt Rewrite2D(const ForNode *loop, Stmt new_body,
+                 const Array<PrimExpr> &tile_size, const Var &tiled_buf) {
+    // Find inner tile.execution loop, peeling through wrappers
+    const ForNode *inner = PeelToInnerTileExecLoop(new_body, tiled_buf);
     if (!inner) {
       return UpdateBody(loop, new_body);
     }
 
     if (!IsSerialFor(loop) || !IsSerialFor(inner)) {
-      return UpdateBody(loop, new_body);
-    }
-
-    if (!IsTilesScope(inner)) {
       return UpdateBody(loop, new_body);
     }
 
@@ -202,15 +314,33 @@ private:
 
     Stmt tiled_body = Substitute(inner->body, vmap);
 
-    tiled_body = For(kj, 0, tile_size[1], ForKind::kVectorized, tiled_body);
-    tiled_body = For(ki, 0, tile_size[0], ForKind::kSerial, tiled_body);
+    // Create annotated interior loops
+    For kj_loop =
+        MakeTileInteriorLoop(kj, tile_size[1], ForKind::kVectorized, tiled_body,
+                             /*axis=*/1, tiled_buf);
+    For ki_loop =
+        MakeTileInteriorLoop(ki, tile_size[0], ForKind::kSerial, kj_loop,
+                             /*axis=*/0, tiled_buf);
 
+    // Replace inner loop's body with the tiled loops
     For new_inner = ffi::GetRef<For>(inner);
-    new_inner.CopyOnWrite()->body = tiled_body;
+    new_inner.CopyOnWrite()->body = ki_loop;
 
+    // Replace inner loop in the body tree (tolerant of wrapper stmts)
+    Stmt replaced_body;
+    if (new_body.as<ForNode>() == inner) {
+      // Fast path: inner loop is the direct body
+      replaced_body = new_inner;
+    } else {
+      // General path: inner loop is behind wrapper stmts
+      replaced_body = InnerLoopReplacer(inner, new_inner)(new_body);
+    }
+
+    // Update outer loop: set scope_entry
     For new_outer = ffi::GetRef<For>(loop);
-    new_outer.CopyOnWrite()->body = new_inner;
-
+    auto *n = new_outer.CopyOnWrite();
+    n->body = replaced_body;
+    n->annotations.Set(attr::tile_scope_entry, Integer(1));
     return new_outer;
   }
 

--- a/testing/python/transform/test_tilelang_mesh_transform_tiles_loop.py
+++ b/testing/python/transform/test_tilelang_mesh_transform_tiles_loop.py
@@ -224,3 +224,110 @@ def test_tiles_loop_insert_and_index_rewrite(prim_func_builder):
     assert any(contains_mul(e, tile_size[0]) for e in index_exprs), "Expected i * tile_size[0] in rewritten indices"
 
     assert any(contains_mul(e, tile_size[1]) for e in index_exprs), "Expected j * tile_size[1] in rewritten indices"
+
+
+# =========================================================
+# 1D test
+# =========================================================
+
+
+def dot_mul_tiled_parallel_1d(M, block_M, tile_size, index_map, dtype="float16"):
+    @T.prim_func
+    def main(
+        A: T.Tensor((M,), dtype),
+        B: T.Tensor((M,), dtype),
+        C: T.Tensor((M,), dtype),
+    ):
+        with T.Kernel(T.ceildiv(M, block_M), threads=128) as (bx,):
+            A_shared = T.alloc_shared((block_M,), dtype)
+            B_shared = T.alloc_shared((block_M,), dtype)
+            C_shared = T.alloc_fragment((block_M,), dtype)
+
+            T.annotate_tileview(
+                {
+                    A_shared: make_tileview(A_shared, tile_size, index_map),
+                    B_shared: make_tileview(B_shared, tile_size, index_map),
+                    C_shared: make_tileview(C_shared, tile_size, index_map),
+                }
+            )
+
+            T.clear(C_shared)
+            T.copy(A[bx * block_M], A_shared)
+            T.copy(B[bx * block_M], B_shared)
+
+            for i in T.Tiles(A_shared, parallel=True):
+                C_shared[i] = A_shared[i] * B_shared[i]
+
+            T.copy(C_shared, C[bx * block_M])
+
+    return main
+
+
+def test_tiles_loop_1d():
+    """
+    TilesLoop pass contract test for 1D tile_size.
+
+    Verifies:
+    1) A single tile.execution loop is present
+    2) A vectorized(tile_size) loop is inserted inside it
+    3) Index is rewritten as: i * tile_size + ki
+    """
+    tile_size = (32,)
+
+    mod = IRModule.from_expr(
+        dot_mul_tiled_parallel_1d(
+            M=1024,
+            block_M=256,
+            tile_size=tile_size,
+            index_map=(-1,),
+        ).with_attr("global_symbol", "main")
+    )
+
+    mod = tl.transform.LegalizeTilesLoop()(mod)
+    mod = tl.transform.TilesLoop()(mod)
+
+    main_func = mod["main"]
+
+    # 1. Collect tile.execution loops
+    tile_exec_loops = []
+
+    def collect_tile_exec(stmt, tile_exec_loops=tile_exec_loops):
+        if isinstance(stmt, tir.For):
+            ann = stmt.annotations
+            if ann and ann.get("tile.execution", 0) == 1:
+                tile_exec_loops.append(stmt)
+
+    tvm.tir.stmt_functor.post_order_visit(main_func.body, collect_tile_exec)
+
+    assert len(tile_exec_loops) == 1, f"Expected 1 tile.execution loop, got {len(tile_exec_loops)}"
+
+    # 2. Vectorized(tile_size) loop is inside the execution loop
+    exec_loop = tile_exec_loops[0]
+    found_vectorized = []
+
+    def visit_subtree(stmt, found_vectorized=found_vectorized):
+        if (
+            isinstance(stmt, tir.For)
+            and stmt.kind == tir.ForKind.VECTORIZED
+            and isinstance(stmt.extent, tir.IntImm)
+            and stmt.extent.value == tile_size[0]
+        ):
+            found_vectorized.append(stmt)
+
+    tvm.tir.stmt_functor.post_order_visit(exec_loop.body, visit_subtree)
+    assert found_vectorized, "Expected vectorized(tile_size) loop inside tile.execution subtree"
+
+    # 3. Index rewrite: i * tile_size + ki
+    index_exprs = []
+
+    def collect_indices(stmt, index_exprs=index_exprs):
+        if isinstance(stmt, tir.BufferStore):
+            index_exprs.extend(stmt.indices)
+
+    tvm.tir.stmt_functor.post_order_visit(main_func.body, collect_indices)
+
+    def contains_mul(expr, factor):
+        s = str(expr)
+        return f"* {factor}" in s or f"*{factor}" in s
+
+    assert any(contains_mul(e, tile_size[0]) for e in index_exprs), "Expected i * tile_size in rewritten indices"

--- a/testing/python/transform/test_tilelang_mesh_transform_tiles_loop.py
+++ b/testing/python/transform/test_tilelang_mesh_transform_tiles_loop.py
@@ -331,3 +331,191 @@ def test_tiles_loop_1d():
         return f"* {factor}" in s or f"*{factor}" in s
 
     assert any(contains_mul(e, tile_size[0]) for e in index_exprs), "Expected i * tile_size in rewritten indices"
+
+
+# =========================================================
+# Annotation contract tests: tile.scope_entry, tile.interior
+# =========================================================
+
+
+def _collect_annotations(func):
+    """Collect annotation info from all For loops in the function."""
+    scope_entry_loops = []
+    interior_loops = []
+
+    def visitor(stmt):
+        if isinstance(stmt, tir.For):
+            ann = stmt.annotations
+            if ann and ann.get("tile.scope_entry", 0) == 1:
+                scope_entry_loops.append(stmt)
+            if ann and ann.get("tile.interior", 0) == 1:
+                interior_loops.append(stmt)
+
+    tvm.tir.stmt_functor.post_order_visit(func.body, visitor)
+    return scope_entry_loops, interior_loops
+
+
+def test_annotations_2d():
+    """
+    For 2D tile_size=(32, 32):
+    - Exactly 1 tile.scope_entry loop (the outermost tile.execution)
+    - Exactly 2 tile.interior loops (ki axis=0, kj axis=1)
+    - kj is vectorized, ki is serial
+    """
+    mod = IRModule.from_expr(
+        dot_mul_tiled_parallel_2d(
+            M=512,
+            N=1024,
+            block_M=256,
+            block_N=128,
+            tile_size=(32, 32),
+            index_map=(-2, -1),
+        ).with_attr("global_symbol", "main")
+    )
+    mod = tl.transform.LegalizeTilesLoop()(mod)
+    mod = tl.transform.TilesLoop()(mod)
+    main_func = mod["main"]
+
+    scope_entries, interiors = _collect_annotations(main_func)
+
+    # 1. Exactly one scope entry
+    assert len(scope_entries) == 1, f"Expected 1 tile.scope_entry, got {len(scope_entries)}"
+
+    # 2. Exactly two interior loops
+    assert len(interiors) == 2, f"Expected 2 tile.interior loops, got {len(interiors)}"
+
+    # 3. Check axes and loop kinds
+    axes = {int(loop.annotations["tile.interior_axis"]): loop for loop in interiors}
+    assert 0 in axes, "Missing tile.interior_axis=0"
+    assert 1 in axes, "Missing tile.interior_axis=1"
+    assert axes[0].kind == tir.ForKind.SERIAL, "axis=0 should be serial"
+    assert axes[1].kind == tir.ForKind.VECTORIZED, "axis=1 should be vectorized"
+
+    # 4. Interior loops carry tiled_buffer annotation
+    for loop in interiors:
+        assert "tile.tiled_buffer" in loop.annotations, "tile.interior loop missing tile.tiled_buffer"
+
+
+def test_annotations_1d():
+    """
+    For 1D tile_size=(32,):
+    - Exactly 1 tile.scope_entry loop
+    - Exactly 1 tile.interior loop (ki axis=0, vectorized)
+    """
+    mod = IRModule.from_expr(
+        dot_mul_tiled_parallel_1d(
+            M=1024,
+            block_M=256,
+            tile_size=(32,),
+            index_map=(-1,),
+        ).with_attr("global_symbol", "main")
+    )
+    mod = tl.transform.LegalizeTilesLoop()(mod)
+    mod = tl.transform.TilesLoop()(mod)
+    main_func = mod["main"]
+
+    scope_entries, interiors = _collect_annotations(main_func)
+
+    # 1. Exactly one scope entry
+    assert len(scope_entries) == 1, f"Expected 1 tile.scope_entry, got {len(scope_entries)}"
+
+    # 2. Exactly one interior loop
+    assert len(interiors) == 1, f"Expected 1 tile.interior loop, got {len(interiors)}"
+
+    # 3. Check axis=0, vectorized
+    loop = interiors[0]
+    assert int(loop.annotations["tile.interior_axis"]) == 0
+    assert loop.kind == tir.ForKind.VECTORIZED
+
+    # 4. Interior loop carries tiled_buffer annotation
+    assert "tile.tiled_buffer" in loop.annotations
+
+
+def test_annotations_3d():
+    """
+    For 3D buffer with tile_size=(32, 32), index_map=(-2, -1):
+    - The batch dimension is NOT tile.execution, so only 1 scope_entry
+    - Still 2 interior loops (same as 2D tile)
+    """
+    mod = IRModule.from_expr(
+        dot_mul_tiled_parallel_3d(
+            Batch=64,
+            M=512,
+            N=1024,
+            block_B=16,
+            block_M=256,
+            block_N=128,
+            tile_size=(32, 32),
+            index_map=(-2, -1),
+        ).with_attr("global_symbol", "main")
+    )
+    mod = tl.transform.LegalizeTilesLoop()(mod)
+    mod = tl.transform.TilesLoop()(mod)
+    main_func = mod["main"]
+
+    scope_entries, interiors = _collect_annotations(main_func)
+
+    assert len(scope_entries) == 1, f"Expected 1 tile.scope_entry, got {len(scope_entries)}"
+    assert len(interiors) == 2, f"Expected 2 tile.interior loops, got {len(interiors)}"
+
+
+# =========================================================
+# Nested T.Tiles rejection test
+# =========================================================
+
+
+def nested_tiles_different_buffers(M, N, block_M, block_N, tile_size, index_map, dtype="float16"):
+    """Kernel with nested T.Tiles from different buffers — must be rejected."""
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, N), dtype),
+        B: T.Tensor((M, N), dtype),
+        C: T.Tensor((M, N), dtype),
+    ):
+        with T.Kernel(
+            T.ceildiv(N, block_N),
+            T.ceildiv(M, block_M),
+            threads=128,
+        ) as (bx, by):
+            A_shared = T.alloc_shared((block_M, block_N), dtype)
+            B_shared = T.alloc_shared((block_M, block_N), dtype)
+            C_shared = T.alloc_fragment((block_M, block_N), dtype)
+
+            T.annotate_tileview(
+                {
+                    A_shared: make_tileview(A_shared, tile_size, index_map),
+                    B_shared: make_tileview(B_shared, tile_size, index_map),
+                    C_shared: make_tileview(C_shared, tile_size, index_map),
+                }
+            )
+
+            T.clear(C_shared)
+            T.copy(A[by * block_M, bx * block_N], A_shared)
+            T.copy(B[by * block_M, bx * block_N], B_shared)
+
+            # Nested T.Tiles from different buffers — should be rejected
+            for i, j in T.Tiles(A_shared, parallel=True):
+                for k, l in T.Tiles(B_shared, parallel=True):
+                    C_shared[i, j] = A_shared[i, j] * B_shared[k, l]
+
+            T.copy(C_shared, C[by * block_M, bx * block_N])
+
+    return main
+
+
+def test_nested_tiles_different_buffers_rejected():
+    """LegalizeTilesLoop must reject nested T.Tiles from different buffers."""
+    mod = IRModule.from_expr(
+        nested_tiles_different_buffers(
+            M=512,
+            N=1024,
+            block_M=256,
+            block_N=128,
+            tile_size=(32, 32),
+            index_map=(-2, -1),
+        ).with_attr("global_symbol", "main")
+    )
+
+    with pytest.raises(Exception, match="Nested T.Tiles from different buffers"):
+        tl.transform.LegalizeTilesLoop()(mod)

--- a/testing/python/transform/test_tilelang_transform_sunmmio_infer_tileview.py
+++ b/testing/python/transform/test_tilelang_transform_sunmmio_infer_tileview.py
@@ -28,7 +28,6 @@ def apply_sunmmio_passes(mod, target):
     mod = tilelang.transform.LowerTileOp()(mod)
     mod = tl.transform.LegalizeTilesLoop()(mod)
     mod = tl.transform.TilesLoop()(mod)
-    print(mod)
     return mod
 
 
@@ -105,24 +104,20 @@ def test_infer_tileview_2d_no_annotation():
     mod = IRModule.from_expr(main.with_attr("global_symbol", "main"))
     # Omit layout inference to test rowmajor case
     mod = tl.transform.LegalizeTilesLoop()(mod)
+    mod = tl.transform.TilesLoop()(mod)
 
     loops, exec_count = collect_tile_annotations(mod["main"])
 
     # Should have 2 tile loops (i, j)
-    assert len(loops) == 2, f"Expected 2 tile loops, got {len(loops)}"
+    assert len(loops) == 4, f"Expected 4 tile loops, got {len(loops)}"
     assert exec_count == 2, f"Expected 2 tile.execution, got {exec_count}"
 
-    # All annotations should be present
-    for loop_info in loops:
-        for k in ["tile.tile_size", "tile.dim_map", "tile.buffer_new_shape"]:
-            assert loop_info[k] is not None, f"Missing annotation '{k}'"
-
     # Verify inferred tile_size = (1, 32) — no layout, so row-major
-    assert _to_int_list(loops[0]["tile.tile_size"]) == [1, 32]
+    assert _to_int_list(loops[-1]["tile.tile_size"]) == [1, 32]
     # dim_map should be (-2, -1)
-    assert _to_int_list(loops[0]["tile.dim_map"]) == [-2, -1]
+    assert _to_int_list(loops[-1]["tile.dim_map"]) == [-2, -1]
     # tiled shape: [num_tiles..., tile_shape...] = [256/1, 128/32, 1, 32]
-    assert _to_int_list(loops[0]["tile.buffer_new_shape"]) == [256, 4, 1, 32]
+    assert _to_int_list(loops[-1]["tile.buffer_new_shape"]) == [256, 4, 1, 32]
 
 
 def test_infer_tileview_2d_with_layout_annotation():
@@ -165,20 +160,15 @@ def test_infer_tileview_2d_with_layout_annotation():
     loops, exec_count = collect_tile_annotations(mod["main"])
 
     # Should have 2 tile loops (i, j)
-    assert len(loops) == 2, f"Expected 2 tile loops, got {len(loops)}"
+    assert len(loops) == 4, f"Expected 4 tile loops, got {len(loops)}"
     assert exec_count == 2, f"Expected 2 tile.execution, got {exec_count}"
 
-    # All annotations should be present
-    for loop_info in loops:
-        for k in ["tile.tile_size", "tile.dim_map", "tile.buffer_new_shape"]:
-            assert loop_info[k] is not None, f"Missing annotation '{k}'"
-
     # Verify inferred tile_size = (32, 32) — blockwise layout
-    assert _to_int_list(loops[0]["tile.tile_size"]) == [32, 32]
+    assert _to_int_list(loops[-1]["tile.tile_size"]) == [32, 32]
     # dim_map should be (-2, -1)
-    assert _to_int_list(loops[0]["tile.dim_map"]) == [-2, -1]
+    assert _to_int_list(loops[-1]["tile.dim_map"]) == [-2, -1]
     # tiled shape: [num_tiles..., tile_shape...] = [256/32, 128/32, 32, 32]
-    assert _to_int_list(loops[0]["tile.buffer_new_shape"]) == [8, 4, 32, 32]
+    assert _to_int_list(loops[-1]["tile.buffer_new_shape"]) == [8, 4, 32, 32]
 
 
 # ---------------------------------------------------------
@@ -211,15 +201,15 @@ def test_infer_tileview_1d_no_annotation():
 
     loops, exec_count = collect_tile_annotations(mod["main"])
 
-    assert len(loops) == 1, f"Expected 1 tile loop, got {len(loops)}"
+    assert len(loops) == 2, f"Expected 2 tile loop, got {len(loops)}"
     assert exec_count == 1, f"Expected 1 tile.execution, got {exec_count}"
 
     # Verify inferred tile_size = (32,)
-    assert _to_int_list(loops[0]["tile.tile_size"]) == [32]
+    assert _to_int_list(loops[-1]["tile.tile_size"]) == [32]
     # dim_map = (-1,)
-    assert _to_int_list(loops[0]["tile.dim_map"]) == [-1]
+    assert _to_int_list(loops[-1]["tile.dim_map"]) == [-1]
     # tiled shape: [num_tiles..., tile_shape...] = [256/32, 32]
-    assert _to_int_list(loops[0]["tile.buffer_new_shape"]) == [8, 32]
+    assert _to_int_list(loops[-1]["tile.buffer_new_shape"]) == [8, 32]
 
 
 # ---------------------------------------------------------
@@ -256,14 +246,14 @@ def test_infer_tileview_mixed_rank():
     loops, exec_count = collect_tile_annotations(mod["main"])
 
     # Primary buffer is 2D -> 2 tile loops, both execution
-    assert len(loops) == 2, f"Expected 2 tile loops, got {len(loops)}"
+    assert len(loops) == 4, f"Expected 4 tile loops, got {len(loops)}"
     assert exec_count == 2, f"Expected 2 tile.execution, got {exec_count}"
 
     # Loop structure follows primary (2D) buffer: tile_size = (32, 32)
-    assert _to_int_list(loops[0]["tile.tile_size"]) == [32, 32]
-    assert _to_int_list(loops[0]["tile.dim_map"]) == [-2, -1]
+    assert _to_int_list(loops[-1]["tile.tile_size"]) == [32, 32]
+    assert _to_int_list(loops[-1]["tile.dim_map"]) == [-2, -1]
     # tiled shape: [num_tiles..., tile_shape...] = [128/32, 64/32, 32, 32]
-    assert _to_int_list(loops[0]["tile.buffer_new_shape"]) == [4, 2, 32, 32]
+    assert _to_int_list(loops[-1]["tile.buffer_new_shape"]) == [4, 2, 32, 32]
 
 
 # ---------------------------------------------------------
@@ -309,11 +299,11 @@ def test_manual_annotation_overrides_inference():
 
     loops, exec_count = collect_tile_annotations(mod["main"])
 
-    assert len(loops) == 2, f"Expected 2 tile loops, got {len(loops)}"
+    assert len(loops) == 4, f"Expected 4 tile loops, got {len(loops)}"
     assert exec_count == 2, f"Expected 2 tile.execution, got {exec_count}"
 
     # Must be (32, 32) from manual annotation, NOT (1, 32) from inference
-    assert _to_int_list(loops[0]["tile.tile_size"]) == [32, 32]
-    assert _to_int_list(loops[0]["tile.dim_map"]) == [-2, -1]
+    assert _to_int_list(loops[-1]["tile.tile_size"]) == [32, 32]
+    assert _to_int_list(loops[-1]["tile.dim_map"]) == [-2, -1]
     # tiled shape: [num_tiles..., tile_shape...] = [256/32, 128/32, 32, 32]
-    assert _to_int_list(loops[0]["tile.buffer_new_shape"]) == [8, 4, 32, 32]
+    assert _to_int_list(loops[-1]["tile.buffer_new_shape"]) == [8, 4, 32, 32]

--- a/testing/python/transform/test_tilelang_transform_sunmmio_infer_tileview.py
+++ b/testing/python/transform/test_tilelang_transform_sunmmio_infer_tileview.py
@@ -1,0 +1,319 @@
+"""Tests for automatic TileView inference in LegalizeTilesLoop.
+
+Verifies that when no T.annotate_tileview() is used, LegalizeTilesLoop
+auto-infers TileView from buffer shape and layout_map, and that the
+inferred tile_size / dim_map values are correct.
+"""
+
+import tilelang
+import tilelang as tl
+import tilelang.language as T
+from tilelang import tvm as tvm
+from tilelang.layout import make_blockwise_zz_layout
+from tilelang.utils.target import SUNMMIO_TARGET_DESC
+from tvm import tir
+from tvm import IRModule
+
+
+def apply_sunmmio_passes(mod, target):
+    """Apply the full SUNMMIO pass pipeline used for DMA copy lowering."""
+    mod = tvm.tir.transform.BindTarget(target)(mod)
+    mod = tilelang.transform.AddWrapperForSingleBufStore()(mod)
+    mod = tilelang.transform.LegalizeNegativeIndex()(mod)
+    mod = tilelang.transform.InjectAssumes()(mod)
+    mod = tilelang.transform.Simplify()(mod)
+    mod = tilelang.transform.InferSramScope()(mod)
+    mod = tilelang.transform.LayoutReducer()(mod)
+    mod = tilelang.transform.LayoutInference()(mod)
+    mod = tilelang.transform.LowerTileOp()(mod)
+    mod = tl.transform.LegalizeTilesLoop()(mod)
+    mod = tl.transform.TilesLoop()(mod)
+    print(mod)
+    return mod
+
+
+# ---------------------------------------------------------
+# Helper: collect tile loop annotations from IR
+# ---------------------------------------------------------
+def collect_tile_annotations(func):
+    """Walk IR and collect tile loop annotation values.
+
+    Returns (loops, exec_count) where:
+      loops: list of dicts, one per tile-level For loop (outermost first),
+             each containing the annotation values.
+      exec_count: number of loops marked tile.execution.
+    """
+    tile_execution_count = 0
+    loops = []
+
+    def visit(stmt):
+        nonlocal tile_execution_count
+        if isinstance(stmt, tir.For):
+            ann = stmt.annotations
+            if ann is not None and "tile.loop_stage" in ann:
+                info = {}
+                for k in [
+                    "tile.tile_size",
+                    "tile.dim_map",
+                    "tile.buffer_new_shape",
+                    "tile.loop_parallel",
+                    "tile.loop_stage",
+                    "tile.tiled_buffer",
+                ]:
+                    info[k] = ann.get(k, None)
+                info["tile.execution"] = "tile.execution" in ann
+                if info["tile.execution"]:
+                    tile_execution_count += 1
+                loops.append(info)
+
+    tvm.tir.stmt_functor.post_order_visit(func.body, visit)
+    return loops, tile_execution_count
+
+
+def _to_int_list(arr):
+    """Convert an Array<PrimExpr> annotation to a Python list of ints."""
+    return [int(x) for x in arr]
+
+
+# ---------------------------------------------------------
+# Test 1: 2D T.Tiles without annotate_tileview
+# ---------------------------------------------------------
+def test_infer_tileview_2d_no_annotation():
+    """2D buffers without layout -> inferred TileView (1, 32)."""
+    M, N = 256, 128
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, N), "float16"),
+        B: T.Tensor((M, N), "float16"),
+        C: T.Tensor((M, N), "float16"),
+    ):
+        with T.Kernel(1, threads=128) as (bx,):
+            A_shared = T.alloc_shared((M, N), "float16")
+            B_shared = T.alloc_shared((M, N), "float16")
+            C_shared = T.alloc_shared((M, N), "float16")
+
+            T.copy(A[0:M, 0:N], A_shared)
+            T.copy(B[0:M, 0:N], B_shared)
+
+            # No annotate_tileview — should be auto-inferred
+            for i, j in T.Tiles(A_shared, parallel=True):
+                C_shared[i, j] = A_shared[i, j] * B_shared[i, j]
+
+            T.copy(C_shared, C[0:M, 0:N])
+
+    mod = IRModule.from_expr(main.with_attr("global_symbol", "main"))
+    # Omit layout inference to test rowmajor case
+    mod = tl.transform.LegalizeTilesLoop()(mod)
+
+    loops, exec_count = collect_tile_annotations(mod["main"])
+
+    # Should have 2 tile loops (i, j)
+    assert len(loops) == 2, f"Expected 2 tile loops, got {len(loops)}"
+    assert exec_count == 2, f"Expected 2 tile.execution, got {exec_count}"
+
+    # All annotations should be present
+    for loop_info in loops:
+        for k in ["tile.tile_size", "tile.dim_map", "tile.buffer_new_shape"]:
+            assert loop_info[k] is not None, f"Missing annotation '{k}'"
+
+    # Verify inferred tile_size = (1, 32) — no layout, so row-major
+    assert _to_int_list(loops[0]["tile.tile_size"]) == [1, 32]
+    # dim_map should be (-2, -1)
+    assert _to_int_list(loops[0]["tile.dim_map"]) == [-2, -1]
+    # tiled shape: [num_tiles..., tile_shape...] = [256/1, 128/32, 1, 32]
+    assert _to_int_list(loops[0]["tile.buffer_new_shape"]) == [256, 4, 1, 32]
+
+
+def test_infer_tileview_2d_with_layout_annotation():
+    """2D buffers without layout -> inferred TileView (1, 32)."""
+    M, N = 256, 128
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, N), "float16"),
+        B: T.Tensor((M, N), "float16"),
+        C: T.Tensor((M, N), "float16"),
+    ):
+        with T.Kernel(1, threads=128) as (bx,):
+            A_shared = T.alloc_shared((M, N), "float16")
+            B_shared = T.alloc_shared((M, N), "float16")
+            C_shared = T.alloc_shared((M, N), "float16")
+
+            T.annotate_layout(
+                {
+                    A_shared: make_blockwise_zz_layout(A_shared),
+                    B_shared: make_blockwise_zz_layout(B_shared),
+                    C_shared: make_blockwise_zz_layout(C_shared),
+                }
+            )
+
+            T.copy(A[0:M, 0:N], A_shared)
+            T.copy(B[0:M, 0:N], B_shared)
+
+            # No annotate_tileview — should be auto-inferred
+            for i, j in T.Tiles(A_shared, parallel=True):
+                C_shared[i, j] = A_shared[i, j] * B_shared[i, j]
+
+            T.copy(C_shared, C[0:M, 0:N])
+
+    mod = IRModule.from_expr(main.with_attr("global_symbol", "main"))
+    target = tvm.target.Target(SUNMMIO_TARGET_DESC)
+    with tvm.target.Target(target):
+        mod = apply_sunmmio_passes(mod, target)
+
+    loops, exec_count = collect_tile_annotations(mod["main"])
+
+    # Should have 2 tile loops (i, j)
+    assert len(loops) == 2, f"Expected 2 tile loops, got {len(loops)}"
+    assert exec_count == 2, f"Expected 2 tile.execution, got {exec_count}"
+
+    # All annotations should be present
+    for loop_info in loops:
+        for k in ["tile.tile_size", "tile.dim_map", "tile.buffer_new_shape"]:
+            assert loop_info[k] is not None, f"Missing annotation '{k}'"
+
+    # Verify inferred tile_size = (32, 32) — blockwise layout
+    assert _to_int_list(loops[0]["tile.tile_size"]) == [32, 32]
+    # dim_map should be (-2, -1)
+    assert _to_int_list(loops[0]["tile.dim_map"]) == [-2, -1]
+    # tiled shape: [num_tiles..., tile_shape...] = [256/32, 128/32, 32, 32]
+    assert _to_int_list(loops[0]["tile.buffer_new_shape"]) == [8, 4, 32, 32]
+
+
+# ---------------------------------------------------------
+# Test 2: 1D T.Tiles without annotate_tileview
+# ---------------------------------------------------------
+def test_infer_tileview_1d_no_annotation():
+    """1D buffers -> inferred TileView (32,)."""
+    N = 256
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((N,), "float32"),
+        B: T.Tensor((N,), "float32"),
+    ):
+        with T.Kernel(1, threads=128) as (bx,):
+            A_shared = T.alloc_shared((N,), "float32")
+            B_shared = T.alloc_shared((N,), "float32")
+
+            T.copy(A[0:N], A_shared)
+
+            for i in T.Tiles(A_shared, parallel=True):
+                B_shared[i] = A_shared[i] * A_shared[i]
+
+            T.copy(B_shared, B[0:N])
+
+    mod = IRModule.from_expr(main.with_attr("global_symbol", "main"))
+    target = tvm.target.Target(SUNMMIO_TARGET_DESC)
+    with tvm.target.Target(target):
+        mod = apply_sunmmio_passes(mod, target)
+
+    loops, exec_count = collect_tile_annotations(mod["main"])
+
+    assert len(loops) == 1, f"Expected 1 tile loop, got {len(loops)}"
+    assert exec_count == 1, f"Expected 1 tile.execution, got {exec_count}"
+
+    # Verify inferred tile_size = (32,)
+    assert _to_int_list(loops[0]["tile.tile_size"]) == [32]
+    # dim_map = (-1,)
+    assert _to_int_list(loops[0]["tile.dim_map"]) == [-1]
+    # tiled shape: [num_tiles..., tile_shape...] = [256/32, 32]
+    assert _to_int_list(loops[0]["tile.buffer_new_shape"]) == [8, 32]
+
+
+# ---------------------------------------------------------
+# Test 3: Mixed-rank (1D + 2D) in same T.Tiles
+# ---------------------------------------------------------
+def test_infer_tileview_mixed_rank():
+    """1D and 2D buffers coexisting — primary is 2D, 1D gets compatible tile."""
+    M, N = 128, 64
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, N), "float32"),
+        B: T.Tensor((M,), "float32"),
+        C: T.Tensor((M, N), "float32"),
+    ):
+        with T.Kernel(1, threads=128) as (bx,):
+            A_shared = T.alloc_shared((M, N), "float32")
+            B_shared = T.alloc_shared((M,), "float32")
+            C_shared = T.alloc_shared((M, N), "float32")
+
+            T.copy(A[0:M, 0:N], A_shared)
+
+            # B_shared is 1D but used inside a 2D tile loop
+            for i, j in T.Tiles(A_shared, parallel=True):
+                C_shared[i, j] = A_shared[i, j] + B_shared[i]
+
+            T.copy(C_shared, C[0:M, 0:N])
+
+    mod = IRModule.from_expr(main.with_attr("global_symbol", "main"))
+    target = tvm.target.Target(SUNMMIO_TARGET_DESC)
+    with tvm.target.Target(target):
+        mod = apply_sunmmio_passes(mod, target)
+
+    loops, exec_count = collect_tile_annotations(mod["main"])
+
+    # Primary buffer is 2D -> 2 tile loops, both execution
+    assert len(loops) == 2, f"Expected 2 tile loops, got {len(loops)}"
+    assert exec_count == 2, f"Expected 2 tile.execution, got {exec_count}"
+
+    # Loop structure follows primary (2D) buffer: tile_size = (32, 32)
+    assert _to_int_list(loops[0]["tile.tile_size"]) == [32, 32]
+    assert _to_int_list(loops[0]["tile.dim_map"]) == [-2, -1]
+    # tiled shape: [num_tiles..., tile_shape...] = [128/32, 64/32, 32, 32]
+    assert _to_int_list(loops[0]["tile.buffer_new_shape"]) == [4, 2, 32, 32]
+
+
+# ---------------------------------------------------------
+# Test 4: Manual annotation overrides inference
+# ---------------------------------------------------------
+def test_manual_annotation_overrides_inference():
+    """When T.annotate_tileview is provided, it overrides inference.
+
+    Without annotation, inference would produce tile_size=(1, 32).
+    With annotation specifying (32, 32), we should see that instead.
+    """
+    from tilelang.tileview import make_tileview
+
+    M, N = 256, 128
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, N), "float16"),
+        C: T.Tensor((M, N), "float16"),
+    ):
+        with T.Kernel(1, threads=128) as (bx,):
+            A_shared = T.alloc_shared((M, N), "float16")
+            C_shared = T.alloc_shared((M, N), "float16")
+
+            T.annotate_tileview(
+                {
+                    A_shared: make_tileview(A_shared, (32, 32), (-2, -1)),
+                    C_shared: make_tileview(C_shared, (32, 32), (-2, -1)),
+                }
+            )
+
+            T.copy(A[0:M, 0:N], A_shared)
+
+            for i, j in T.Tiles(A_shared, parallel=True):
+                C_shared[i, j] = A_shared[i, j] * A_shared[i, j]
+
+            T.copy(C_shared, C[0:M, 0:N])
+
+    mod = IRModule.from_expr(main.with_attr("global_symbol", "main"))
+    target = tvm.target.Target(SUNMMIO_TARGET_DESC)
+    with tvm.target.Target(target):
+        mod = apply_sunmmio_passes(mod, target)
+
+    loops, exec_count = collect_tile_annotations(mod["main"])
+
+    assert len(loops) == 2, f"Expected 2 tile loops, got {len(loops)}"
+    assert exec_count == 2, f"Expected 2 tile.execution, got {exec_count}"
+
+    # Must be (32, 32) from manual annotation, NOT (1, 32) from inference
+    assert _to_int_list(loops[0]["tile.tile_size"]) == [32, 32]
+    assert _to_int_list(loops[0]["tile.dim_map"]) == [-2, -1]
+    # tiled shape: [num_tiles..., tile_shape...] = [256/32, 128/32, 32, 32]
+    assert _to_int_list(loops[0]["tile.buffer_new_shape"]) == [8, 4, 32, 32]


### PR DESCRIPTION
1. Automatically infer Tileview for a buffer used in T.Tiles.
2. Relax the constraint that tileview of each used buffer should be same. Now, we allow compatible tileview, e.g., (8x32) tile can multiplied view a 1x32 tile.
3. Add new annotation attributes to ease codegen
4. Disallow nested T.Tiles
5. Broadcast is natively supported (We need to recognize this pattern in codegen)
6. Fix bug in copy layout inference. For 1d buffer, we don't need specify its layout (keep it row-major).