### PR TITLE
[Op] Support copying between RSRAM with T.Tiles

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,6 @@ repos:
       - id: check-added-large-files
       - id: check-merge-conflict
         fail_fast: true
-      - id: check-executables-have-shebangs
       - id: check-shebang-scripts-are-executable
       - id: detect-private-key
       - id: check-yaml

--- a/src/op/copy.cc
+++ b/src/op/copy.cc
@@ -11,6 +11,7 @@
 #include "copy.h"
 #include "../layout/tcgen05_layout.h"
 #include "../target/utils.h"
+#include "../transform/common/attr.h"
 #include "../transform/common/loop_fusion_utils.h"
 #include "../transform/loop_partition.h"
 #include "../transform/loop_vectorize.h"
@@ -247,14 +248,15 @@ For CopyNode::MakeSIMTLoop(arith::Analyzer *analyzer) const {
     // Only attach the parallel related annotations on the outermost loop (i ==
     // 0)
     if (i == 0) {
-      if (annotations.count(attr::kCoalescedWidth)) {
-        loop_annotations.Set(attr::kCoalescedWidth,
-                             annotations.Get(attr::kCoalescedWidth).value());
-      }
-      if (annotations.count(attr::kParallelLoopLayout)) {
+      if (annotations.count(tl::attr::kCoalescedWidth)) {
         loop_annotations.Set(
-            attr::kParallelLoopLayout,
-            annotations.Get(attr::kParallelLoopLayout).value());
+            tl::attr::kCoalescedWidth,
+            annotations.Get(tl::attr::kCoalescedWidth).value());
+      }
+      if (annotations.count(tl::attr::kParallelLoopLayout)) {
+        loop_annotations.Set(
+            tl::attr::kParallelLoopLayout,
+            annotations.Get(tl::attr::kParallelLoopLayout).value());
       }
     }
 
@@ -298,7 +300,7 @@ LayoutMap CopyNode::InferLayout(const LayoutInferArgs &T,
   // If user annotated a loop layout on T.copy, enforce SIMT (normal) copy.
   // Parallel-loop layout only applies to SIMT-style loops we generate here;
   // other copy instructions (TMA/LDSM/STSM/TMem) are incompatible.
-  if (annotations.count(attr::kParallelLoopLayout)) {
+  if (annotations.count(tl::attr::kParallelLoopLayout)) {
     if (copy_inst != CopyInst::kNormal) {
       std::ostringstream oss;
       oss << "T.copy loop layout annotation requires SIMT copy; got "
@@ -450,7 +452,8 @@ LayoutMap CopyNode::InferLayout(const LayoutInferArgs &T,
   }
 
   // Sunmmio DMA Layout Inference
-  if (copy_inst == CopyInst::kSunmmioDMACopy) {
+  if (copy_inst == CopyInst::kSunmmioDMACopy ||
+      copy_inst == CopyInst::kSunmmioTileCopy) {
     const auto f =
         ffi::Function::GetGlobal("tl.layout.make_blockwise_zz_layout");
     auto result = Map<Buffer, Layout>();
@@ -671,19 +674,46 @@ bool CopyNode::CheckSunmmioDMACopy(Target target) const {
     scope_check = true;
   if (src.scope() == "shared.rsram" && dst.scope() == "shared.asram")
     scope_check = true;
-  if (src.scope() == "shared.rsram" && dst.scope() == "shared.rsram")
-    scope_check = true;
   if (src.scope() == "shared.rsram" && dst.scope() == "global")
     scope_check = true;
   if (!scope_check) {
-    ICHECK(0) << "Unsupported copy from " << src.scope() << " to "
-              << dst.scope() << " of Sunmmio target.";
     return false;
   }
-
-  // 2. src and dst must have the same dtype
+  // 2. src and dst must have the same dtype for DMA-based lowering
   if (src->dtype != dst->dtype) {
-    ICHECK(0) << "src and dst must have the same dtype for copy.";
+    ICHECK(0) << "src and dst must have the same dtype for Sunmmio DMA copy.";
+    return false;
+  }
+  return true;
+}
+
+bool CopyNode::CheckSunmmioTileCopy(Target target) const {
+  auto is_full_buffer_region = [](const Buffer &buffer,
+                                  const Array<Range> &ranges) {
+    if (ranges.size() != buffer->shape.size()) {
+      return false;
+    }
+    for (size_t i = 0; i < ranges.size(); ++i) {
+      if (!is_zero(ranges[i]->min) ||
+          !StructuralEqual()(ranges[i]->extent, buffer->shape[i])) {
+        return false;
+      }
+    }
+    return true;
+  };
+
+  // shared.rsram -> shared.rsram is lowered via tile loops instead of DMA, so
+  // dtype mismatch is allowed and handled by an inserted Cast during lowering.
+  // For now, only support full-buffer copies. Region copies require the
+  // T.Tiles legalization path to preserve copy-region semantics.
+  if (src.scope() != "shared.rsram" || dst.scope() != "shared.rsram") {
+    return false;
+  }
+  if (!StructuralEqual()(src->shape, dst->shape)) {
+    return false;
+  }
+  if (!is_full_buffer_region(src, src_range) ||
+      !is_full_buffer_region(dst, dst_range)) {
     return false;
   }
   return true;
@@ -718,8 +748,14 @@ CopyInst CopyNode::GetCopyInst(Target target, bool disable_tma_lower,
     return CopyInst::kTMemLoad;
   } else if (CheckTMemStore(target)) {
     return CopyInst::kTMemStore;
-  } else if (TargetIsSunmmio(target) && CheckSunmmioDMACopy(target)) {
-    return CopyInst::kSunmmioDMACopy;
+  } else if (TargetIsSunmmio(target)) {
+    if (CheckSunmmioDMACopy(target)) {
+      return CopyInst::kSunmmioDMACopy;
+    } else if (CheckSunmmioTileCopy(target)) {
+      return CopyInst::kSunmmioTileCopy;
+    }
+    ICHECK(0) << "Unsupported copy from " << src.scope() << " to "
+              << dst.scope() << " of Sunmmio target.";
   } else {
     return CopyInst::kNormal;
   }
@@ -757,8 +793,12 @@ Stmt CopyNode::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
     return LowerNormalCopy(T, analyzer);
   } else if (copy_inst == CopyInst::kSunmmioDMACopy) {
     auto dma_copy = LowerSunmmioDmaCopy(T, analyzer);
-    ICHECK(dma_copy.defined()) << "Failed to lower dma copy";
+    ICHECK(dma_copy.defined()) << "Failed to lower sunmmio dma copy";
     return dma_copy;
+  } else if (copy_inst == CopyInst::kSunmmioTileCopy) {
+    auto tile_copy = LowerSunmmioTileCopy(T, analyzer);
+    ICHECK(tile_copy.defined()) << "Failed to lower sunmmio tile copy";
+    return tile_copy;
   } else {
     LOG(FATAL) << "Unsupported copy inst " << static_cast<int>(copy_inst);
   }
@@ -770,6 +810,95 @@ Stmt CopyNode::LowerSunmmioDmaCopy(const LowerArgs &T,
   PrimExpr dst_region = MakeRegionExpr(dst, dst_range, /*access_mask=*/2);
   return Evaluate(
       Call(DataType::Handle(), dma_copy(), {src_region, dst_region}));
+}
+
+Stmt CopyNode::LowerSunmmioTileCopy(const LowerArgs &T,
+                                    arith::Analyzer *analyzer) const {
+  // Lower rsram-to-rsram copies through tile-loop-shaped serial loops so
+  // LegalizeTilesLoop/TilesLoop can route them through the tile unit.
+  Array<Var> loop_vars;
+  loop_vars.reserve(src_range.size());
+  for (size_t i = 0; i < src_range.size(); ++i) {
+    loop_vars.push_back(
+        Var("v" + std::to_string(i), src_range[i]->extent.dtype()));
+    analyzer->Bind(loop_vars[i], Range::FromMinExtent(0, src_range[i]->extent));
+  }
+
+  auto make_indices = [&](const Array<Range> &ranges) {
+    ICHECK_EQ(loop_vars.size(), ranges.size());
+    Array<PrimExpr> indices;
+    indices.reserve(ranges.size());
+    for (size_t i = 0; i < ranges.size(); ++i) {
+      if (is_one(ranges[i]->extent)) {
+        indices.push_back(ranges[i]->min);
+      } else {
+        indices.push_back(ranges[i]->min + loop_vars[i]);
+      }
+    }
+    return indices;
+  };
+
+  auto make_predicate = [&](const Array<Range> &ranges,
+                            const Array<PrimExpr> &buffer_shape) {
+    ICHECK_EQ(loop_vars.size(), ranges.size());
+    ICHECK_EQ(buffer_shape.size(), ranges.size());
+
+    Array<PrimExpr> cond_list;
+    for (size_t i = 0; i < ranges.size(); ++i) {
+      PrimExpr idx = is_one(ranges[i]->extent) ? ranges[i]->min
+                                               : ranges[i]->min + loop_vars[i];
+
+      PrimExpr upper = idx < buffer_shape[i];
+      if (!analyzer->CanProve(upper, arith::ProofStrength::kSymbolicBound)) {
+        cond_list.push_back(upper);
+      }
+
+      PrimExpr lower = idx >= 0;
+      if (!analyzer->CanProve(lower, arith::ProofStrength::kSymbolicBound)) {
+        cond_list.push_back(lower);
+      }
+    }
+
+    if (cond_list.empty()) {
+      return PrimExpr();
+    }
+
+    PrimExpr predicate = cond_list[0];
+    for (size_t i = 1; i < cond_list.size(); ++i) {
+      predicate = And(predicate, cond_list[i]);
+    }
+    return predicate;
+  };
+
+  Array<PrimExpr> src_indices = make_indices(src_range);
+  Array<PrimExpr> dst_indices = make_indices(dst_range);
+  PrimExpr src_predicate = make_predicate(src_range, src->shape);
+  PrimExpr dst_predicate = make_predicate(dst_range, dst->shape);
+
+  PrimExpr value = BufferLoad(src, src_indices);
+  if (src->dtype != dst->dtype) {
+    value = Cast(dst->dtype, value);
+  }
+  if (src_predicate.defined()) {
+    value = if_then_else(src_predicate, value, make_zero(dst->dtype));
+  }
+
+  Stmt body = BufferStore(dst, value, dst_indices);
+  if (dst_predicate.defined()) {
+    body = IfThenElse(dst_predicate, body);
+  }
+
+  Map<String, ObjectRef> tile_annotations;
+  tile_annotations.Set(tl::attr::tile_level_loop, Integer(1));
+  tile_annotations.Set(tl::attr::tiled_buffer, src->data);
+  tile_annotations.Set(tl::attr::kTileLoopStage,
+                       Integer(static_cast<int>(TileLoopStage::kInitial)));
+
+  for (int i = static_cast<int>(loop_vars.size()) - 1; i >= 0; --i) {
+    body = For(loop_vars[i], 0, src_range[i]->extent, ForKind::kSerial, body,
+               std::nullopt, tile_annotations);
+  }
+  return body;
 }
 
 // Lowers the copy using standard load/store with loop transformations.

--- a/src/op/copy.h
+++ b/src/op/copy.h
@@ -22,11 +22,12 @@ enum class CopyInst : uint8_t {
   kBulkStore = 4, // utilize tma store
   // we should separate the bulk load and store for 1d and multi-dim
   // as they have different memory access patterns
-  kBulkLoad1D = 5,     // utilize tma load 1d
-  kBulkStore1D = 6,    // utilize tma store 1d
-  kTMemLoad = 7,       // tcgen05.ld (tensor memory -> register)
-  kTMemStore = 8,      // tcgen05.st (register -> tensor memory)
-  kSunmmioDMACopy = 9, // Sunmmio DMA
+  kBulkLoad1D = 5,       // utilize tma load 1d
+  kBulkStore1D = 6,      // utilize tma store 1d
+  kTMemLoad = 7,         // tcgen05.ld (tensor memory -> register)
+  kTMemStore = 8,        // tcgen05.st (register -> tensor memory)
+  kSunmmioDMACopy = 9,   // Sunmmio DMA Copy
+  kSunmmioTileCopy = 10, // Sunmmio Tile-based Copy
 };
 
 /// Convert CopyInst enum to string for debugging
@@ -52,6 +53,8 @@ inline const char *CopyInstToString(CopyInst inst) {
     return "TMemStore";
   case CopyInst::kSunmmioDMACopy:
     return "SunmmioDMACopy";
+  case CopyInst::kSunmmioTileCopy:
+    return "SunmmioTileCopy";
   default:
     return "Unknown";
   }
@@ -234,6 +237,11 @@ public:
   bool CheckSunmmioDMACopy(Target target) const;
 
   /*!
+   * \brief Check if Sunmmio tile-based copy is supported.
+   */
+  bool CheckSunmmioTileCopy(Target target) const;
+
+  /*!
    * \brief Get the copy instruction type.
    */
   CopyInst GetCopyInst(Target target, bool disable_tma_lower,
@@ -277,6 +285,14 @@ protected:
    * buffer region semantics for later SUNMMIO codegen consumption.
    */
   Stmt LowerSunmmioDmaCopy(const LowerArgs &T, arith::Analyzer *analyzer) const;
+
+  /*!
+   * \brief Generate lowering for SUNMMIO Tile-based copy.
+   *
+   * Emits a T.Tiles for-loop to copy data between shared.rsram buffers
+   */
+  Stmt LowerSunmmioTileCopy(const LowerArgs &T,
+                            arith::Analyzer *analyzer) const;
 
   /*!
    * \brief Generate SIMT (thread-level) loop for copying.

--- a/testing/python/ops/test_tilelang_ops_sunmmio_dma_copy.py
+++ b/testing/python/ops/test_tilelang_ops_sunmmio_dma_copy.py
@@ -316,8 +316,6 @@ MESH_COPY_CASES = [
             'T.dma_copy(T.region(C_shared[8, 16], 1, 16, 32), T.region(A_shared[24, 8], 2, 16, 32))',
             # RSRAM -> WSRAM
             'T.dma_copy(T.region(C_shared[8, 48], 1, 24, 8), T.region(B_shared[40, 0], 2, 24, 8))',
-            # RSRAM <-> RSRAM
-            'T.dma_copy(T.region(C_shared[0, 0], 1, 64, 64), T.region(D_shared[0, 0], 2, 64, 64))',
         ],
     ),
     (
@@ -335,8 +333,6 @@ MESH_COPY_CASES = [
             'T.dma_copy(T.region(C_shared[8, 16], 1, 16, 32), T.region(A_shared[24, 8], 2, 16, 32))',
             # RSRAM -> WSRAM
             'T.dma_copy(T.region(C_shared[8, 48], 1, 24, 8), T.region(B_shared[40, 0], 2, 24, 8))',
-            # RSRAM <-> RSRAM
-            'T.dma_copy(T.region(C_shared[0, 0], 1, 64, 64), T.region(D_shared[0, 0], 2, 64, 64))',
         ],
     ),
 ]

--- a/testing/python/ops/test_tilelang_ops_sunmmio_rsram_copy.py
+++ b/testing/python/ops/test_tilelang_ops_sunmmio_rsram_copy.py
@@ -1,0 +1,181 @@
+"""Regression tests for Sunmmio shared.rsram -> shared.rsram copy lowering."""
+
+import pytest
+import tilelang
+import tilelang as tl
+import tilelang.language as T
+from tilelang import tvm as tvm
+from tilelang.utils.target import determine_target
+from tvm import tir
+
+tilelang.env.disable_cache()
+
+
+def apply_sunmmio_passes(mod, target):
+    """Apply the Sunmmio lowering pipeline through tile-loop legalization."""
+
+    mod = tvm.tir.transform.BindTarget(target)(mod)
+    mod = tilelang.transform.AddWrapperForSingleBufStore()(mod)
+    mod = tilelang.transform.LegalizeNegativeIndex()(mod)
+    mod = tilelang.transform.InjectAssumes()(mod)
+    mod = tilelang.transform.Simplify()(mod)
+    mod = tilelang.transform.InferSramScope()(mod)
+    mod = tilelang.transform.LayoutReducer()(mod)
+    mod = tilelang.transform.LayoutInference()(mod)
+    mod = tilelang.transform.LowerTileOp()(mod)
+    print(mod)
+    mod = tl.transform.LegalizeTilesLoop()(mod)
+    mod = tl.transform.TilesLoop()(mod)
+    print(mod)
+    return mod
+
+
+def rsram_copy(block_M=64, block_N=64, dtype="float16", dst_dtype=None):
+    """Build a kernel with a single shared.rsram -> shared.rsram T.copy."""
+
+    if dst_dtype is None:
+        dst_dtype = dtype
+
+    @T.prim_func
+    def main():
+        with T.Kernel(1, 1, threads=128) as (_bx, _by):
+            A_shared = T.alloc_shared((block_M, block_N), dtype, scope="shared.rsram")
+            B_shared = T.alloc_shared((block_M, block_N), dst_dtype, scope="shared.rsram")
+            T.copy(A_shared, B_shared)
+
+    return tvm.IRModule({"main": main})
+
+
+def rsram_copy_region(block_M=64, block_N=64, dtype="float16"):
+    """Build a kernel with a sliced shared.rsram -> shared.rsram T.copy."""
+
+    @T.prim_func
+    def main():
+        with T.Kernel(1, 1, threads=128) as (_bx, _by):
+            A_shared = T.alloc_shared((block_M, block_N), dtype, scope="shared.rsram")
+            B_shared = T.alloc_shared((block_M, block_N), dtype, scope="shared.rsram")
+            T.copy(A_shared[8:24, 16:48], B_shared[0:16, 0:32])
+
+    return tvm.IRModule({"main": main})
+
+
+def extract_dma_copy_lines(mod):
+    return [line.lstrip() for line in mod.script().split("\n") if "T.dma_copy" in line]
+
+
+def collect_loops_with_attr(func, attr_name):
+    loops = []
+
+    def visit(stmt):
+        if isinstance(stmt, tir.For):
+            ann = stmt.annotations
+            if ann is not None and ann.get(attr_name, 0) == 1:
+                loops.append(stmt)
+
+    tvm.tir.stmt_functor.post_order_visit(func.body, visit)
+    return loops
+
+
+def collect_buffer_stores(func, buffer_name):
+    stores = []
+
+    def visit(stmt):
+        if isinstance(stmt, tir.BufferStore) and stmt.buffer.name == buffer_name:
+            stores.append(stmt)
+
+    tvm.tir.stmt_functor.post_order_visit(func.body, visit)
+    return stores
+
+
+def expr_has_cast(expr, dst_dtype, src_dtype):
+    found = False
+
+    def visit(node):
+        nonlocal found
+        if isinstance(node, tir.Cast) and str(node.dtype) == dst_dtype and str(node.value.dtype) == src_dtype:
+            found = True
+
+    tvm.tir.stmt_functor.post_order_visit(expr, visit)
+    return found
+
+
+def expr_has_if_then_else(expr):
+    found = False
+
+    def visit(node):
+        nonlocal found
+        if isinstance(node, tir.Call) and hasattr(node.op, "name") and node.op.name == "tir.if_then_else":
+            found = True
+
+    tvm.tir.stmt_functor.post_order_visit(expr, visit)
+    return found
+
+
+def test_tilelang_rsram_copy_lowers_to_tile_loop():
+    target = determine_target("Sunmmio", return_object=True)
+
+    with tvm.target.Target(target):
+        mod = apply_sunmmio_passes(rsram_copy(), target)
+
+    func = mod["main"]
+    stores = collect_buffer_stores(func, "B_shared")
+
+    assert extract_dma_copy_lines(mod) == []
+    assert collect_loops_with_attr(func, "tile.scope_entry")
+    assert collect_loops_with_attr(func, "tile.interior")
+    assert stores
+    assert not any(expr_has_if_then_else(store.value) for store in stores)
+
+
+def test_tilelang_rsram_copy_inserts_cast_for_dtype_mismatch():
+    target = determine_target("Sunmmio", return_object=True)
+
+    with tvm.target.Target(target):
+        mod = apply_sunmmio_passes(
+            rsram_copy(dtype="float16", dst_dtype="float32"),
+            target,
+        )
+
+    func = mod["main"]
+    stores = collect_buffer_stores(func, "B_shared")
+
+    assert extract_dma_copy_lines(mod) == []
+    assert collect_loops_with_attr(func, "tile.scope_entry")
+    assert collect_loops_with_attr(func, "tile.interior")
+    assert stores
+    assert not any(expr_has_if_then_else(store.value) for store in stores)
+    assert any(
+        isinstance(store.value, tir.Cast) and str(store.value.dtype) == "float32" and str(store.value.value.dtype) == "float16"
+        for store in stores
+    )
+
+
+def test_tilelang_rsram_region_copy_is_rejected_for_now():
+    target = determine_target("Sunmmio", return_object=True)
+
+    with (
+        pytest.raises(
+            tvm.error.InternalError,
+            match="Unsupported copy from shared.rsram to shared.rsram of Sunmmio target.",
+        ),
+        tvm.target.Target(target),
+    ):
+        mod = rsram_copy_region()
+        apply_sunmmio_passes(mod, target)
+
+
+def extract_block_attr_lines(mod):
+    """Extract block attributes from TIR script"""
+    return [line.lstrip() for line in mod.script().split("\n") if "T.block_attr" in line]
+
+
+def test_tilelang_rsram_copy_layout_inference():
+    target = determine_target("Sunmmio", return_object=True)
+
+    with tvm.target.Target(target):
+        mod = apply_sunmmio_passes(rsram_copy(64, 64), target)
+
+    # Check layout map
+    texts = extract_block_attr_lines(mod)
+    for text in texts:
+        assert '"layout_map"' in text and 'A_shared: metadata["tl.Layout"]' in text and 'B_shared: metadata["tl.Layout"]' in text


### PR DESCRIPTION
Copying data between buffers of the scope `shared.rsram` is lowered to `T.Tiles` loop. Layout inference is the same as `dma_copy`.

## Limitation

As `T.Tiles` doesn't support region-based tiling, this rsram copy can only support full-buffer copying.