### PR TITLE
[CI] Set NPUIR to OFF when PR is created from fork

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          submodules: recursive
-          ssh-key: ${{ secrets.SUNMMIONPUIR }}
 
       - name: Setup Python 3.9
         id: setup-pylowest

--- a/.github/workflows/sunmmio-ci.yml
+++ b/.github/workflows/sunmmio-ci.yml
@@ -36,14 +36,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          submodules: recursive
           set-safe-directory: true
-          ssh-key: ${{ secrets.SUNMMIONPUIR }}
-
-      - name: Verify submodule
-        run: |
-          git submodule sync --recursive
-          git submodule status --recursive
 
       - name: Setup Python 3.9
         id: setup-pylowest
@@ -164,9 +157,55 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          submodules: recursive
           set-safe-directory: true
-          ssh-key: ${{ secrets.SUNMMIONPUIR }}
+
+      - name: Determine NPU-IR access mode
+        id: npuir-mode
+        env:
+          HAS_PRIVATE_NPUIR_ACCESS: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+        run: |
+          set -euo pipefail
+          if [[ "${HAS_PRIVATE_NPUIR_ACCESS}" == "true" ]]; then
+            echo "available=1" >> "${GITHUB_OUTPUT}"
+            echo "TILELANG_NPUIR_CMAKE_ARGS=" >> "${GITHUB_ENV}"
+            echo "Running full CI with private NPU-IR access."
+          else
+            echo "available=0" >> "${GITHUB_OUTPUT}"
+            echo "TILELANG_NPUIR_CMAKE_ARGS=-DUSE_NPUIR=OFF" >> "${GITHUB_ENV}"
+            echo "Running fork-safe CI without private NPU-IR checkout."
+          fi
+
+      - name: Checkout public submodules
+        run: |
+          set -euo pipefail
+          git submodule sync --recursive
+          git -c protocol.version=2 submodule update --init --force --recursive \
+            3rdparty/composable_kernel \
+            3rdparty/cutlass \
+            3rdparty/tvm
+
+      - name: Configure SSH for private NPU-IR submodule
+        if: steps.npuir-mode.outputs.available == '1'
+        env:
+          SUNMMIONPUIR: ${{ secrets.SUNMMIONPUIR }}
+        run: |
+          set -euo pipefail
+          install -m 700 -d "${HOME}/.ssh"
+          printf '%s\n' "${SUNMMIONPUIR}" > "${HOME}/.ssh/sunmmio_npuir"
+          chmod 600 "${HOME}/.ssh/sunmmio_npuir"
+          ssh-keyscan -t rsa,ecdsa,ed25519 github.com >> "${HOME}/.ssh/known_hosts"
+
+      - name: Checkout private NPU-IR submodule
+        if: steps.npuir-mode.outputs.available == '1'
+        run: |
+          set -euo pipefail
+          export GIT_SSH_COMMAND="ssh -i ${HOME}/.ssh/sunmmio_npuir -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes"
+          git submodule sync -- 3rdparty/NPU-IR
+          git -c protocol.version=2 submodule update --init --force --recursive 3rdparty/NPU-IR
+
+      - name: Report submodule state
+        run: |
+          git submodule status --recursive
 
       - name: Install uv
         run: |
@@ -180,6 +219,7 @@ jobs:
           uv pip install --python .clang-tidy-venv/bin/python -v -r requirements-lint.txt
 
       - name: Read LLVM pin from NPU-IR
+        if: steps.npuir-mode.outputs.available == '1'
         run: |
           set -euo pipefail
 
@@ -204,6 +244,7 @@ jobs:
           echo "Using NPU-IR LLVM pin ${NPUIR_LLVM_COMMIT}"
 
       - name: Prepare cached LLVM checkout for NPU-IR
+        if: steps.npuir-mode.outputs.available == '1'
         run: |
           set -euo pipefail
 
@@ -215,6 +256,7 @@ jobs:
           echo "NPUIR_CACHE_DIR=${NPUIR_CACHE_DIR}" >> "${GITHUB_ENV}"
           echo "NPUIR_LLVM_SOURCE_DIR=${NPUIR_LLVM_SOURCE_DIR}" >> "${GITHUB_ENV}"
           echo "NPUIR_LLVM_BUILD_DIR=${NPUIR_LLVM_BUILD_DIR}" >> "${GITHUB_ENV}"
+          echo "TILELANG_NPUIR_CMAKE_ARGS=-DTILELANG_NPUIR_BINARY_DIR=${NPUIR_CACHE_DIR}" >> "${GITHUB_ENV}"
 
           lock_file="${NPUIR_CACHE_ROOT}/llvm-project.lock"
           exec 9>"${lock_file}"
@@ -270,6 +312,7 @@ jobs:
           CLANG_TIDY_BIN=".clang-tidy-venv/bin/clang-tidy"
           CLANG_APPLY_REPLACEMENTS_BIN=".clang-tidy-venv/bin/clang-apply-replacements"
           echo "\$ ${CLANG_TIDY_BIN} --version" && "${CLANG_TIDY_BIN}" --version
+          echo "Using NPU-IR CMake args: ${TILELANG_NPUIR_CMAKE_ARGS}"
 
           # Run clang-tidy before provisioning the heavyweight Python/CUDA test env.
           # The clang-tidy configure only needs system Python and CUDA headers.
@@ -284,13 +327,12 @@ jobs:
             echo "::warning::clang-apply-replacements not found in PATH, automatic fixing disabled."
           fi
 
-          # Reuse a persistent NPU-IR/LLVM cache so clang-tidy does not need to
-          # clone llvm-project or reconfigure its build tree on every run.
+          # Reuse the persistent NPU-IR/LLVM cache when available; otherwise
+          # configure clang-tidy with NPU-IR disabled for fork-safe CI.
           lock_file="${NPUIR_CACHE_ROOT}/llvm-project.lock"
           exec 9>"${lock_file}"
           flock 9
-          cmake -S . -B cmake-build --fresh ${CLANG_TIDY_CMAKE_OPTIONS} \
-            -DTILELANG_NPUIR_BINARY_DIR="${NPUIR_CACHE_DIR}"
+          cmake -S . -B cmake-build --fresh ${CLANG_TIDY_CMAKE_OPTIONS} ${TILELANG_NPUIR_CMAKE_ARGS}
           flock -u 9
 
           CXX_FILES=$(find src -type f \( -iname "*.[ch]pp" -o -iname "*.cc" -o -iname "*.c" -o -iname "*.h" \))
@@ -321,8 +363,9 @@ jobs:
 
       - name: Install project (wheel form)
         run: |
-          # Reuse the same cached NPU-IR/LLVM tree during the wheel build.
-          export CMAKE_ARGS="${CMAKE_ARGS} -DTILELANG_NPUIR_BINARY_DIR=${NPUIR_CACHE_DIR}"
+          # Match the wheel build mode to the checkout mode:
+          # use the cached NPU-IR tree when available, otherwise disable NPU-IR.
+          export CMAKE_ARGS="${CMAKE_ARGS} ${TILELANG_NPUIR_CMAKE_ARGS}"
           uv pip install -v .
 
       - name: Run Python test suite

--- a/.github/workflows/sunmmio-ci.yml
+++ b/.github/workflows/sunmmio-ci.yml
@@ -178,6 +178,7 @@ jobs:
       - name: Checkout public submodules
         run: |
           set -euo pipefail
+          git config --global --add safe.directory "${GITHUB_WORKSPACE}"
           git submodule sync --recursive
           git -c protocol.version=2 submodule update --init --force --recursive \
             3rdparty/composable_kernel \

--- a/.github/workflows/sunmmio-ci.yml
+++ b/.github/workflows/sunmmio-ci.yml
@@ -185,24 +185,28 @@ jobs:
             3rdparty/cutlass \
             3rdparty/tvm
 
-      - name: Configure SSH for private NPU-IR submodule
+      - name: Resolve pinned NPU-IR commit
         if: steps.npuir-mode.outputs.available == '1'
-        env:
-          SUNMMIONPUIR: ${{ secrets.SUNMMIONPUIR }}
+        id: npuir-ref
         run: |
           set -euo pipefail
-          install -m 700 -d "${HOME}/.ssh"
-          printf '%s\n' "${SUNMMIONPUIR}" > "${HOME}/.ssh/sunmmio_npuir"
-          chmod 600 "${HOME}/.ssh/sunmmio_npuir"
-          ssh-keyscan -t rsa,ecdsa,ed25519 github.com >> "${HOME}/.ssh/known_hosts"
+          NPUIR_SHA="$(git ls-tree HEAD 3rdparty/NPU-IR | awk '{print $3}')"
+          if [[ -z "${NPUIR_SHA}" ]]; then
+            echo "::error::Could not determine the pinned NPU-IR commit from the superproject gitlink."
+            exit 1
+          fi
+          echo "sha=${NPUIR_SHA}" >> "${GITHUB_OUTPUT}"
+          echo "Pinned NPU-IR commit: ${NPUIR_SHA}"
 
       - name: Checkout private NPU-IR submodule
         if: steps.npuir-mode.outputs.available == '1'
-        run: |
-          set -euo pipefail
-          export GIT_SSH_COMMAND="ssh -i ${HOME}/.ssh/sunmmio_npuir -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes"
-          git submodule sync -- 3rdparty/NPU-IR
-          git -c protocol.version=2 submodule update --init --force --recursive 3rdparty/NPU-IR
+        uses: actions/checkout@v6
+        with:
+          repository: SUNMMIO/NPU-IR
+          ref: ${{ steps.npuir-ref.outputs.sha }}
+          path: 3rdparty/NPU-IR
+          ssh-key: ${{ secrets.SUNMMIONPUIR }}
+          fetch-depth: 1
 
       - name: Report submodule state
         run: |


### PR DESCRIPTION
PR created from forks cannot leverage the deployment key to access NPU-IR. Hence, in this PR, we detect those PRs and run CI wihout NPU-IR