### PR TITLE
[Refactor][Codegen]SunMMIO generic codegen traversing fails loudly on pre-lowered TIR nodes that should not reach backend codegen.

### DIFF
--- a/src/target/sunmmio/codegen_sunmmio.cc
+++ b/src/target/sunmmio/codegen_sunmmio.cc
@@ -711,9 +711,10 @@ void CodeGenTileLangSunMMIO::VisitStmt_(const tir::AllocateConstNode *op) {
 }
 
 void CodeGenTileLangSunMMIO::VisitStmt_(const tir::DeclBufferNode *op) {
-  UnsupportedStmt(op,
-                  "DeclBufferNode should be lowered into a concrete view/alias "
-                  "representation before SunMMIO codegen");
+  // DeclBuffer may still survive the current pipeline. For this backend path it
+  // is treated as a benign declaration wrapper with no direct codegen effect.
+  // Dedicated view/alias lowering can be added later if required.
+  VisitStmtTracked(op->body);
 }
 
 void CodeGenTileLangSunMMIO::VisitStmt_(const tir::BufferStoreNode *op) {

--- a/src/target/sunmmio/codegen_sunmmio.cc
+++ b/src/target/sunmmio/codegen_sunmmio.cc
@@ -705,52 +705,27 @@ void CodeGenTileLangSunMMIO::VisitStmt_(const tir::AllocateNode *op) {
 }
 
 void CodeGenTileLangSunMMIO::VisitStmt_(const tir::AllocateConstNode *op) {
-  LOG(FATAL) << "SunMMIO SUVM allocate phase does not support "
-             << "AllocateConstNode";
-  EnterScope();
-  // EmitAlloc(op->buffer_var, op->dtype, op->extents, "const");
-  VisitStmtTracked(op->body);
-  ExitScope();
+  UnsupportedStmt(
+      op, "AllocateConstNode should be lowered/eliminated before SunMMIO "
+          "codegen");
 }
 
 void CodeGenTileLangSunMMIO::VisitStmt_(const tir::DeclBufferNode *op) {
-  LOG(FATAL) << "SunMMIO SUVM allocate phase treats DeclBuffer as view/alias "
-             << "and does not handle it yet";
-  // RegisterBuffer(op->buffer, false, NewValueName());
-  // const BufferBinding &binding = LookupBuffer(op->buffer);
-  // builder_->Alloc(binding.handle, binding.buffer_type, {},
-  //                 MapStorageScope(op->buffer.scope()), op->buffer->dtype);
-  VisitStmtTracked(op->body);
+  UnsupportedStmt(op,
+                  "DeclBufferNode should be lowered into a concrete view/alias "
+                  "representation before SunMMIO codegen");
 }
 
 void CodeGenTileLangSunMMIO::VisitStmt_(const tir::BufferStoreNode *op) {
-  LOG(FATAL) << "SunMMIO SUVM allocate phase does not handle BufferStore yet";
-  // if (!buffer_registry_.count(op->buffer.get())) {
-  //   RegisterBuffer(op->buffer, false, NewValueName());
-  //   const BufferBinding &binding = LookupBuffer(op->buffer);
-  //   builder_->Alloc(binding.handle, binding.buffer_type, {},
-  //                   MapStorageScope(op->buffer.scope()), op->buffer->dtype);
-  // }
-  EmitStore(op->buffer, op->indices, EvalExpr(op->value));
+  UnsupportedStmt(
+      op, "generic BufferStoreNode should not reach SunMMIO codegen; "
+          "tiled buffer stores must be lowered through tile-aware paths");
 }
 
 void CodeGenTileLangSunMMIO::VisitStmt_(const tir::BufferRealizeNode *op) {
-  LOG(FATAL) << "SunMMIO SUVM allocate phase treats BufferRealize as "
-             << "view/alias and does not handle it yet";
-  EnterScope();
-  // RegisterBuffer(op->buffer, false, NewValueName());
-  // const BufferBinding &binding = LookupBuffer(op->buffer);
-  // std::vector<SunMMIOValue> dyn_bounds;
-  // for (const Range &range : op->bounds) {
-  //   EvalExpr(range->min);
-  //   if (!range->extent.as<IntImmNode>()) {
-  //     dyn_bounds.push_back(EnsureIndex(EvalExpr(range->extent)));
-  //   }
-  // }
-  // builder_->Alloc(binding.handle, binding.buffer_type, dyn_bounds,
-  //                 MapStorageScope(op->buffer.scope()), op->buffer->dtype);
-  VisitStmtTracked(op->body);
-  ExitScope();
+  UnsupportedStmt(
+      op, "BufferRealizeNode should be lowered into a concrete view/alias "
+          "representation before SunMMIO codegen");
 }
 
 void CodeGenTileLangSunMMIO::VisitStmt_(const tir::AssertStmtNode *op) {
@@ -862,51 +837,9 @@ void CodeGenTileLangSunMMIO::VisitStmt_(const tir::BlockNode *op) {
 }
 
 void CodeGenTileLangSunMMIO::VisitStmt_(const tir::BlockRealizeNode *op) {
-  auto is_trivially_true = [](const PrimExpr &expr) {
-    if (is_one(expr)) {
-      return true;
-    }
-    if (const auto *imm = expr.as<IntImmNode>()) {
-      return imm->value != 0;
-    }
-    return false;
-  };
-
-  EnterScope();
-  for (size_t i = 0;
-       i < op->iter_values.size() && i < op->block->iter_vars.size(); ++i) {
-    BindVar(op->block->iter_vars[i]->var, EvalExpr(op->iter_values[i]));
-  }
-  if (is_trivially_true(op->predicate)) {
-    VisitStmtTracked(op->block);
-  } else {
-    SunMMIOValue pred = EnsureType(
-        EvalExpr(op->predicate),
-        SunMMIOType{SunMMIOType::Kind::kScalar, DataType::Bool(), 1, {}},
-        DataType::Bool());
-    TokenAnalyzer analyzer;
-    IterState st;
-    analyzer.AnalyzeStmt(op->block, st);
-    std::vector<int64_t> live_out_ids;
-    std::unordered_set<int64_t> live_out_seen;
-    auto add_live_out = [&](int64_t t) {
-      if (t < 0) {
-        return;
-      }
-      if (live_out_seen.insert(t).second) {
-        live_out_ids.push_back(t);
-      }
-    };
-    for (int64_t t : st.produced_order) {
-      if (t >= 0 && st.avail_tokens.count(t) != 0) {
-        add_live_out(t);
-      }
-    }
-    builder_->BeginIf(pred, live_out_ids);
-    VisitStmtTracked(op->block);
-    builder_->EndIf();
-  }
-  ExitScope();
+  UnsupportedStmt(
+      op, "BlockRealizeNode should be eliminated by LowerOpaqueBlock before "
+          "SunMMIO codegen");
 }
 
 void CodeGenTileLangSunMMIO::VisitStmtDefault_(const Object *op) {
@@ -1074,14 +1007,9 @@ void CodeGenTileLangSunMMIO::EmitStore(const tir::Buffer &buffer,
 }
 
 SunMMIOValue CodeGenTileLangSunMMIO::VisitExpr_(const tir::BufferLoadNode *op) {
-  LOG(FATAL) << "SunMMIO SUVM allocate phase does not handle BufferLoad yet";
-  // if (!buffer_registry_.count(op->buffer.get())) {
-  //   RegisterBuffer(op->buffer, false, NewValueName());
-  //   const BufferBinding &b = LookupBuffer(op->buffer);
-  //   builder_->Alloc(b.handle, b.buffer_type, {},
-  //                   MapStorageScope(op->buffer.scope()), op->buffer->dtype);
-  // }
-  return EmitLoad(op->buffer, op->indices);
+  UnsupportedExpr(
+      op, "generic BufferLoadNode should not reach SunMMIO codegen; tiled "
+          "buffer accesses must be lowered through tile-aware paths");
 }
 
 SunMMIOValue
@@ -1379,13 +1307,8 @@ SunMMIOValue CodeGenTileLangSunMMIO::EmitCall(const tir::CallNode *op) {
 [[noreturn]] void
 CodeGenTileLangSunMMIO::UnsupportedStmt(const Object *op,
                                         const std::string &detail) const {
-  // Intentional unsupported contract for this backend:
-  // - tir::WhileNode
-  // - legacy tir::LoadNode
-  // - tir::AnyNode
-  // - tir::ShuffleNode
-  // These forms must be eliminated before SunMMIO codegen; reaching here is
-  // a pipeline bug and should fail loudly.
+  // Generic SunMMIO codegen intentionally rejects pre-lowered structural forms.
+  // Reaching unsupported nodes here indicates a pipeline invariant violation.
   std::ostringstream os;
   os << "CodeGenTileLangSunMMIO unsupported stmt: " << op->GetTypeKey();
   if (!detail.empty()) {
@@ -1398,13 +1321,8 @@ CodeGenTileLangSunMMIO::UnsupportedStmt(const Object *op,
 [[noreturn]] void
 CodeGenTileLangSunMMIO::UnsupportedExpr(const Object *op,
                                         const std::string &detail) const {
-  // Intentional unsupported contract for this backend:
-  // - tir::WhileNode
-  // - legacy tir::LoadNode
-  // - tir::AnyNode
-  // - tir::ShuffleNode
-  // These forms must be eliminated before SunMMIO codegen; reaching here is
-  // a pipeline bug and should fail loudly.
+  // Generic SunMMIO codegen intentionally rejects pre-lowered structural forms.
+  // Reaching unsupported nodes here indicates a pipeline invariant violation.
   std::ostringstream os;
   os << "CodeGenTileLangSunMMIO unsupported expr: " << op->GetTypeKey();
   if (!detail.empty()) {

--- a/src/target/sunmmio/codegen_sunmmio.cc
+++ b/src/target/sunmmio/codegen_sunmmio.cc
@@ -1357,6 +1357,25 @@ SunMMIOValue CodeGenTileLangSunMMIO::EmitCall(const tir::CallNode *op) {
                         CallBucketName(bucket), op->dtype, ret_ty);
 }
 
+/*!
+ * \brief Backend input invariants for generic SunMMIO codegen.
+ *
+ * This backend is not a generic TIR code generator. It expects the input to
+ * have already been lowered into a SunMMIO-oriented form where tiled buffers
+ * are accessed through tile-aware paths rather than generic element-wise
+ * BufferLoad/BufferStore. Nodes such as BlockRealize, BufferRealize, and
+ * DeclBuffer should normally have been eliminated or lowered before reaching
+ * this layer. Likewise, generic BufferLoad/BufferStore on tiled buffers are
+ * treated as pipeline violations unless intercepted by a dedicated tile-based
+ * lowering path earlier in the pipeline.
+ *
+ * The generic SunMMIO codegen path is expected to handle control flow, scalar
+ * and index expressions, loop structure, target intrinsics, and tile-aware
+ * operations that have already been normalized into backend-expected forms.
+ * Reaching unsupported structural nodes here should fail loudly so pipeline
+ * regressions are caught early.
+ */
+
 [[noreturn]] void
 CodeGenTileLangSunMMIO::UnsupportedStmt(const Object *op,
                                         const std::string &detail) const {

--- a/testing/python/target/test_sunmmio_codegen_skeleton.py
+++ b/testing/python/target/test_sunmmio_codegen_skeleton.py
@@ -240,15 +240,14 @@ def test_sunmmio_codegen_block_realize_fails_loudly():
         builder(mod, target, "suvm")
 
 
-def test_sunmmio_codegen_decl_buffer_fails_loudly():
+def test_sunmmio_codegen_decl_buffer_is_benign_wrapper():
     target = determine_target("Sunmmio", return_object=True)
     mod = tvm.IRModule({"main": make_decl_buffer_kernel()})
     builder = tvm.ffi.get_global_func("target.build.tilelang_sunmmio_without_compile")
-    with pytest.raises(
-        Exception,
-        match="DeclBufferNode should be lowered into a concrete view/alias representation before SunMMIO codegen",
-    ):
-        builder(mod, target, "suvm")
+    src = builder(mod, target, "suvm").inspect_source()
+    assert src.strip()
+    assert "module" in src
+    assert "func.func @main" in src
 
 
 def test_sunmmio_codegen_buffer_realize_fails_loudly():

--- a/testing/python/target/test_sunmmio_codegen_skeleton.py
+++ b/testing/python/target/test_sunmmio_codegen_skeleton.py
@@ -117,6 +117,52 @@ def make_intrinsic_sync_kernel():
     return _primfunc_from_stmt(stmt)
 
 
+def make_block_realize_kernel():
+    body = tvm.tir.Evaluate(tvm.tir.IntImm("int32", 0))
+    block = tvm.tir.Block([], [], [], "B", body)
+    stmt = tvm.tir.BlockRealize([], tvm.tir.IntImm("bool", 1), block)
+    return _primfunc_from_stmt(stmt)
+
+
+def make_decl_buffer_kernel():
+    body = tvm.tir.Evaluate(tvm.tir.IntImm("int32", 0))
+    buf = tvm.tir.decl_buffer((16, 16), "float16", name="A")
+    stmt = tvm.tir.DeclBuffer(buf, body)
+    return _primfunc_from_stmt(stmt)
+
+
+def make_buffer_realize_kernel():
+    body = tvm.tir.Evaluate(tvm.tir.IntImm("int32", 0))
+    buf = tvm.tir.decl_buffer((16, 16), "float16", name="A")
+    bounds = [
+        tvm.ir.Range.from_min_extent(0, 16),
+        tvm.ir.Range.from_min_extent(0, 16),
+    ]
+    stmt = tvm.tir.BufferRealize(buf, bounds, tvm.tir.IntImm("bool", 1), body)
+    return _primfunc_from_stmt(stmt)
+
+
+def make_buffer_load_kernel():
+    buf = tvm.tir.decl_buffer((16, 16), "float16", name="A")
+    stmt = tvm.tir.Evaluate(
+        tvm.tir.BufferLoad(
+            buf,
+            [tvm.tir.IntImm("int32", 0), tvm.tir.IntImm("int32", 0)],
+        )
+    )
+    return _primfunc_from_stmt(stmt)
+
+
+def make_buffer_store_kernel():
+    buf = tvm.tir.decl_buffer((16, 16), "float16", name="A")
+    stmt = tvm.tir.BufferStore(
+        buf,
+        tvm.tir.FloatImm("float16", 1.0),
+        [tvm.tir.IntImm("int32", 0), tvm.tir.IntImm("int32", 0)],
+    )
+    return _primfunc_from_stmt(stmt)
+
+
 def make_real_tilelang_frontend_kernel():
     @T.prim_func
     def main():
@@ -183,13 +229,79 @@ def test_sunmmio_codegen_compile_path_not_implemented():
         builder(mod, target)
 
 
+def test_sunmmio_codegen_block_realize_fails_loudly():
+    target = determine_target("Sunmmio", return_object=True)
+    mod = tvm.IRModule({"main": make_block_realize_kernel()})
+    builder = tvm.ffi.get_global_func("target.build.tilelang_sunmmio_without_compile")
+    with pytest.raises(
+        Exception,
+        match="BlockRealizeNode should be eliminated by LowerOpaqueBlock before SunMMIO codegen",
+    ):
+        builder(mod, target, "suvm")
+
+
+def test_sunmmio_codegen_decl_buffer_fails_loudly():
+    target = determine_target("Sunmmio", return_object=True)
+    mod = tvm.IRModule({"main": make_decl_buffer_kernel()})
+    builder = tvm.ffi.get_global_func("target.build.tilelang_sunmmio_without_compile")
+    with pytest.raises(
+        Exception,
+        match="DeclBufferNode should be lowered into a concrete view/alias representation before SunMMIO codegen",
+    ):
+        builder(mod, target, "suvm")
+
+
+def test_sunmmio_codegen_buffer_realize_fails_loudly():
+    target = determine_target("Sunmmio", return_object=True)
+    mod = tvm.IRModule({"main": make_buffer_realize_kernel()})
+    builder = tvm.ffi.get_global_func("target.build.tilelang_sunmmio_without_compile")
+    with pytest.raises(
+        Exception,
+        match="BufferRealizeNode should be lowered into a concrete view/alias representation before SunMMIO codegen",
+    ):
+        builder(mod, target, "suvm")
+
+
+def test_sunmmio_codegen_buffer_load_fails_loudly():
+    target = determine_target("Sunmmio", return_object=True)
+    mod = tvm.IRModule({"main": make_buffer_load_kernel()})
+    builder = tvm.ffi.get_global_func("target.build.tilelang_sunmmio_without_compile")
+    with pytest.raises(
+        Exception,
+        match="generic BufferLoadNode should not reach SunMMIO codegen; tiled buffer accesses must be lowered through tile-aware paths",
+    ):
+        builder(mod, target, "suvm")
+
+
+def test_sunmmio_codegen_buffer_store_fails_loudly():
+    target = determine_target("Sunmmio", return_object=True)
+    mod = tvm.IRModule({"main": make_buffer_store_kernel()})
+    builder = tvm.ffi.get_global_func("target.build.tilelang_sunmmio_without_compile")
+    with pytest.raises(
+        Exception,
+        match="generic BufferStoreNode should not reach SunMMIO codegen; tiled buffer stores must be lowered through tile-aware paths",
+    ):
+        builder(mod, target, "suvm")
+
+
 @pytest.mark.parametrize(
     "kernel_name,kernel_factory",
     [
         ("scalar_control", make_scalar_control_kernel),
         ("alloc_scope", make_alloc_scope_kernel),
         ("intrinsic_sync", make_intrinsic_sync_kernel),
-        ("real_tilelang_frontend", make_real_tilelang_frontend_kernel),
+        pytest.param(
+            "real_tilelang_frontend",
+            make_real_tilelang_frontend_kernel,
+            marks=pytest.mark.xfail(
+                reason=(
+                    "generic SunMMIO codegen now requires pre-lowered backend IR; "
+                    "this real frontend case still bypasses the full SunMMIO "
+                    "lowering pipeline. Revisit when the full pass pipeline lands."
+                ),
+                strict=True,
+            ),
+        ),
     ],
 )
 def test_sunmmio_codegen_coverage_report_has_no_missing_entries(tmp_path, kernel_name, kernel_factory):


### PR DESCRIPTION
## Summary
This PR tightens SunMMIO generic codegen input invariants for pre-lowered TIR forms, while explicitly allowing `DeclBufferNode` as a temporary benign wrapper.

The backend remains intentionally non-generic for tiled memory access patterns: unsupported structural and generic buffer element-access nodes fail loudly, except `DeclBufferNode`, which is currently tolerated because it can survive the present pipeline and has no direct codegen effect in this path.

## What Changed

### 1. Strict invariant enforcement in generic SunMMIO codegen
In `src/target/sunmmio/codegen_sunmmio.cc`, generic path now rejects:

- `tir::BlockRealizeNode`
- `tir::BufferRealizeNode`
- `tir::AllocateConstNode`
- generic `tir::BufferLoadNode`
- generic `tir::BufferStoreNode`

with explicit fatal messages describing expected earlier lowering (e.g. `LowerOpaqueBlock`, tile-aware access lowering).

### 2. `DeclBufferNode` is now tolerated (non-fatal)
`VisitStmt_(const tir::DeclBufferNode* op)` no longer fails.
It is treated as a benign declaration wrapper and simply traverses `op->body`.

Rationale documented in code:
- `DeclBuffer` may still survive current pipeline stages.
- For current SunMMIO generic backend path, it has no direct emission semantics.
- Full view/alias lowering can be added later if needed.

### 3. Test updates
In `testing/python/target/test_sunmmio_codegen_skeleton.py`:

- Updated DeclBuffer test to expect **success** (non-fatal codegen).
- Kept failure tests for:
  - `BlockRealizeNode`
  - `BufferRealizeNode`
  - generic `BufferLoadNode`
  - generic `BufferStoreNode`
- Kept `real_tilelang_frontend` coverage case marked `xfail` (strict), documenting temporary mismatch until full lowering pipeline lands.


## Validation
- Rebuilt `libtilelang.so`
- Ran:
  - `conda run -n tl pytest -q testing/python/target/test_sunmmio_codegen_skeleton.py`
- Result:
  - `12 passed, 1 xfailed`

