### PR TITLE
Featured: Comprehensive Lowering Pipeline Enhancements (Passes & CodeGen)

### DIFF
--- a/src/op/builtin.h
+++ b/src/op/builtin.h
@@ -32,6 +32,10 @@ static constexpr const char *kLocalVarInit = "tl.local_var_init";
 // that must NOT be marked with the restrict qualifier in codegen.
 // Type: Array<tir::Var>
 static constexpr const char *kNonRestrictParams = "tl.non_restrict_params";
+// A PrimFunc-level internal marker listing attrs that SplitHostDevice should
+// propagate to generated device functions.
+// Type: Array<String>
+static constexpr const char *kDeviceFuncAttrKeys = "tl.device_func_attr_keys";
 } // namespace attr
 
 static constexpr const char *kDebugMergeSharedMemoryAllocations =

--- a/src/target/sunmmio/codegen_sunmmio.cc
+++ b/src/target/sunmmio/codegen_sunmmio.cc
@@ -1,10 +1,15 @@
 #include "codegen_sunmmio.h"
 #include "sunmmio_mlir_builder.h"
 
+#include "../../layout/layout.h"
+#include "../../op/region.h"
+
+#include <tvm/arith/analyzer.h>
 #include <tvm/ir/type.h>
 #include <tvm/tir/analysis.h>
 #include <tvm/tir/builtin.h>
 #include <tvm/tir/op.h>
+#include <tvm/tir/stmt.h>
 #include <tvm/tir/stmt_functor.h>
 
 #include <algorithm>
@@ -21,6 +26,31 @@ namespace codegen {
 using namespace tir;
 
 namespace {
+
+class DeclBufferCollector final : public tir::StmtVisitor {
+public:
+  std::unordered_map<const tir::VarNode *, tir::Buffer> buffer_data_to_buffer;
+
+private:
+  void VisitStmt_(const tir::DeclBufferNode *op) final {
+    Record(op->buffer);
+    tir::StmtVisitor::VisitStmt_(op);
+  }
+
+  void Record(const tir::Buffer &buffer) {
+    if (!buffer.defined() || !buffer->data.defined()) {
+      return;
+    }
+    const tir::VarNode *data = buffer->data.get();
+    auto it = buffer_data_to_buffer.find(data);
+    if (it == buffer_data_to_buffer.end()) {
+      buffer_data_to_buffer.emplace(data, buffer);
+      // return;
+    } else {
+      LOG(WARNING) << "Found duplicate DeclBuffer for data var " << data;
+    }
+  }
+};
 
 std::string GetAllocateStorageScope(const tir::Var &buffer_var) {
   if (const auto *ptr = buffer_var->type_annotation.as<PointerTypeNode>()) {
@@ -56,6 +86,7 @@ void CodeGenTileLangSunMMIO::Clear() {
   ssa_counter_ = 0;
   var_table_.clear();
   buffer_registry_.clear();
+  buffer_data_to_buffer_.clear();
   attr_stack_.clear();
   scoped_vars_.clear();
   scoped_buffers_.clear();
@@ -118,6 +149,12 @@ void CodeGenTileLangSunMMIO::CollectExpectedCoverage(const tir::PrimFunc &f) {
       }
     }
   });
+}
+
+void CodeGenTileLangSunMMIO::CollectDeclBuffers(const tir::Stmt &stmt) {
+  DeclBufferCollector collector;
+  collector(stmt);
+  buffer_data_to_buffer_ = std::move(collector.buffer_data_to_buffer);
 }
 
 void CodeGenTileLangSunMMIO::WriteCoverageReport() const {
@@ -213,13 +250,28 @@ void CodeGenTileLangSunMMIO::AddFunction(const GlobalVar &gvar,
   }
   ICHECK(builder_) << "CodeGenTileLangSunMMIO builder is not initialized";
   CollectExpectedCoverage(f);
+  CollectDeclBuffers(f->body);
+
+  SunMMIOBuilder::TirLayoutMap layout_map;
+  SunMMIOBuilder::TirLayoutMap global_layout_map;
+  if (auto opt =
+          f->GetAttr<SunMMIOBuilder::TirLayoutMap>(tl::attr::kLayoutMap)) {
+    layout_map = opt.value();
+  }
+  if (auto opt = f->GetAttr<SunMMIOBuilder::TirLayoutMap>(
+          tl::attr::kGlobalLayoutMap)) {
+    global_layout_map = opt.value();
+  }
+  builder_->PushLayoutScope(layout_map, global_layout_map);
+
   EnterScope();
   std::vector<BuilderArg> args;
   int arg_index = 0;
   for (const tir::Var &p : f->params) {
     std::string arg_name = "%arg" + std::to_string(arg_index++);
-    if (f->buffer_map.count(p)) {
-      const tir::Buffer &buffer = f->buffer_map.at(p);
+    auto buffer_it = buffer_data_to_buffer_.find(p.get());
+    if (buffer_it != buffer_data_to_buffer_.end()) {
+      const tir::Buffer &buffer = buffer_it->second;
       SunMMIOType buf_ty = MapBufferType(buffer);
       args.push_back({arg_name, buf_ty});
       BindVar(p, SunMMIOValue{p.dtype(), arg_name, buf_ty});
@@ -236,6 +288,7 @@ void CodeGenTileLangSunMMIO::AddFunction(const GlobalVar &gvar,
   builder_->EmitReturn();
   builder_->EndFunction();
   ExitScope();
+  builder_->PopLayoutScope();
 }
 
 std::string CodeGenTileLangSunMMIO::Finish() {
@@ -286,8 +339,17 @@ CodeGenTileLangSunMMIO::MapBufferType(const tir::Buffer &buffer) const {
   for (const PrimExpr &dim : buffer->shape) {
     shape.push_back(dim);
   }
-  return SunMMIOType{SunMMIOType::Kind::kMemRef, buffer->dtype, 1,
-                     std::move(shape)};
+  SunMMIOType type;
+  type.kind = SunMMIOType::Kind::kMemTensor;
+  type.dtype = buffer->dtype.with_lanes(1);
+  type.lanes = 1;
+  type.shape = std::move(shape);
+  type.memory_scope = buffer.scope();
+  type.byte_offset = 0;
+  if (builder_) {
+    builder_->ApplyLayoutToType(buffer, &type);
+  }
+  return type;
 }
 
 void CodeGenTileLangSunMMIO::VisitStmt_(const tir::SeqStmtNode *op) {
@@ -358,6 +420,15 @@ SunMMIOValue CodeGenTileLangSunMMIO::BindVar(const tir::Var &var,
   return value;
 }
 
+const SunMMIOValue &
+CodeGenTileLangSunMMIO::LookupVar(const tir::VarNode *var) const {
+  ICHECK(var != nullptr);
+  auto it = var_table_.find(var);
+  ICHECK(it != var_table_.end())
+      << "CodeGenTileLangSunMMIO: unbound var %" << var->name_hint;
+  return it->second;
+}
+
 void CodeGenTileLangSunMMIO::RegisterBuffer(const tir::Buffer &buffer,
                                             bool is_external,
                                             const std::string &handle_hint) {
@@ -374,10 +445,12 @@ void CodeGenTileLangSunMMIO::RegisterBuffer(const tir::Buffer &buffer,
   binding.is_external = is_external;
   if (!handle_hint.empty()) {
     binding.handle = handle_hint;
-  } else if (var_table_.count(buffer->data.get())) {
-    binding.handle = var_table_.at(buffer->data.get()).value;
   } else {
-    binding.handle = NewValueName();
+    const SunMMIOValue &storage = LookupVar(buffer->data.get());
+    binding.handle = storage.value;
+    if (storage.type.kind == SunMMIOType::Kind::kMemTensor) {
+      binding.buffer_type = storage.type;
+    }
   }
   buffer_registry_[buffer.get()] = std::move(binding);
   scoped_buffers_.push_back(buffer.get());
@@ -386,35 +459,37 @@ void CodeGenTileLangSunMMIO::RegisterBuffer(const tir::Buffer &buffer,
 const BufferBinding &
 CodeGenTileLangSunMMIO::LookupBuffer(const tir::Buffer &buffer) const {
   auto it = buffer_registry_.find(buffer.get());
+  if (it == buffer_registry_.end()) {
+    LOG(WARNING) << "SunMMIO LookupBuffer: missing name=" << buffer->name
+                 << ", buffer_ptr=" << buffer.get()
+                 << ", data_name=" << buffer->data->name_hint
+                 << ", data_ptr=" << buffer->data.get();
+    return buffer_registry_
+        .find(buffer_data_to_buffer_.at(buffer->data.get()).get())
+        ->second;
+  }
   ICHECK(it != buffer_registry_.end())
       << "CodeGenTileLangSunMMIO: unknown buffer " << buffer;
   return it->second;
 }
 
-void CodeGenTileLangSunMMIO::EmitAlloc(const tir::Var &buffer_var,
-                                       DataType dtype,
-                                       const ffi::Array<PrimExpr> &extents,
+void CodeGenTileLangSunMMIO::EmitAlloc(const tir::Buffer &buffer,
                                        const std::string &scope_hint) {
   std::vector<SunMMIOValue> dyn_extents;
-  std::vector<PrimExpr> shape;
-  shape.reserve(extents.size());
-  for (size_t i = 0; i < extents.size(); ++i) {
-    shape.push_back(extents[i]);
-    if (!extents[i].as<IntImmNode>()) {
-      dyn_extents.push_back(EnsureIndex(EvalExpr(extents[i])));
+  for (const PrimExpr &dim : buffer->shape) {
+    if (!dim.as<IntImmNode>()) {
+      dyn_extents.push_back(EnsureIndex(EvalExpr(dim)));
     }
   }
-  SunMMIOType memtensor_type;
-  memtensor_type.kind = SunMMIOType::Kind::kMemTensor;
-  memtensor_type.dtype = dtype.with_lanes(1);
-  memtensor_type.lanes = 1;
-  memtensor_type.shape = std::move(shape);
-  memtensor_type.memory_scope = scope_hint;
-  memtensor_type.byte_offset = 0;
+
+  SunMMIOType memtensor_type = MapBufferType(buffer);
+  if (memtensor_type.memory_scope.empty()) {
+    memtensor_type.memory_scope = scope_hint;
+  }
 
   SunMMIOValue alloc = builder_->Alloc(NewValueName(), memtensor_type,
-                                       dyn_extents, scope_hint, dtype);
-  BindVar(buffer_var, alloc);
+                                       dyn_extents, scope_hint, buffer->dtype);
+  BindVar(buffer->data, alloc);
 }
 
 namespace {
@@ -699,7 +774,13 @@ void CodeGenTileLangSunMMIO::VisitStmt_(const tir::WhileNode *op) {
 void CodeGenTileLangSunMMIO::VisitStmt_(const tir::AllocateNode *op) {
   std::string scope = GetAllocateStorageScope(op->buffer_var);
   EnterScope();
-  EmitAlloc(op->buffer_var, op->dtype, op->extents, scope);
+  auto buffer_it = buffer_data_to_buffer_.find(op->buffer_var.get());
+  if (buffer_it != buffer_data_to_buffer_.end()) {
+    EmitAlloc(buffer_it->second, scope);
+  } else {
+    LOG(FATAL) << "SunMMIO SUVM allocate cannot find buffer for variable "
+               << op->buffer_var->name_hint;
+  }
   VisitStmtTracked(op->body);
   ExitScope();
 }
@@ -711,10 +792,10 @@ void CodeGenTileLangSunMMIO::VisitStmt_(const tir::AllocateConstNode *op) {
 }
 
 void CodeGenTileLangSunMMIO::VisitStmt_(const tir::DeclBufferNode *op) {
-  // DeclBuffer may still survive the current pipeline. For this backend path it
-  // is treated as a benign declaration wrapper with no direct codegen effect.
-  // Dedicated view/alias lowering can be added later if required.
+  EnterScope();
+  RegisterBuffer(op->buffer, false);
   VisitStmtTracked(op->body);
+  ExitScope();
 }
 
 void CodeGenTileLangSunMMIO::VisitStmt_(const tir::BufferStoreNode *op) {
@@ -800,8 +881,6 @@ void CodeGenTileLangSunMMIO::VisitStmt_(const tir::BlockNode *op) {
     }
   }
   for (const Buffer &alloc : op->alloc_buffers) {
-    EmitAlloc(alloc->data, alloc->dtype, alloc->shape,
-              alloc.scope().empty() ? "global" : alloc.scope());
     RegisterBuffer(alloc, false);
   }
   for (const MatchBufferRegion &match : op->match_buffers) {
@@ -848,23 +927,11 @@ void CodeGenTileLangSunMMIO::VisitStmtDefault_(const Object *op) {
 }
 
 SunMMIOValue CodeGenTileLangSunMMIO::VisitExpr_(const tir::VarNode *op) {
-  auto it = var_table_.find(op);
-  if (it != var_table_.end()) {
-    return it->second;
-  }
-  SunMMIOValue info{op->dtype, "%" + op->name_hint, MapType(op->dtype)};
-  var_table_[op] = info;
-  return info;
+  return LookupVar(op);
 }
 
 SunMMIOValue CodeGenTileLangSunMMIO::VisitExpr_(const tir::SizeVarNode *op) {
-  auto it = var_table_.find(op);
-  if (it != var_table_.end()) {
-    return it->second;
-  }
-  SunMMIOValue info{op->dtype, "%" + op->name_hint, MapType(op->dtype)};
-  var_table_[op] = info;
-  return info;
+  return LookupVar(op);
 }
 
 SunMMIOValue CodeGenTileLangSunMMIO::VisitExpr_(const tir::IntImmNode *op) {

--- a/src/target/sunmmio/codegen_sunmmio.h
+++ b/src/target/sunmmio/codegen_sunmmio.h
@@ -8,9 +8,11 @@
 #include <tvm/tir/stmt.h>
 #include <tvm/tir/stmt_functor.h>
 
+#include "../../layout/layout.h"
 #include "sunmmio_mlir_type.h"
 
 #include <memory>
+#include <optional>
 #include <set>
 #include <sstream>
 #include <string>
@@ -23,6 +25,8 @@ namespace codegen {
 class SunMMIOBuilder {
 public:
   virtual ~SunMMIOBuilder() = default;
+
+  using TirLayoutMap = ffi::Map<tir::Buffer, tl::Layout>;
 
   virtual void Init() = 0;
   virtual void Clear() = 0;
@@ -112,6 +116,23 @@ public:
 
   virtual void EmitAssert(const SunMMIOValue &cond,
                           const std::string &msg_text) = 0;
+
+  virtual void PushLayoutScope(const TirLayoutMap &layout_map,
+                               const TirLayoutMap &global_layout_map) {
+    (void)layout_map;
+    (void)global_layout_map;
+  }
+  virtual void PopLayoutScope() {}
+  virtual ffi::Optional<tl::Layout>
+  LookupLayout(const tir::Buffer &buffer) const {
+    (void)buffer;
+    return ffi::Optional<tl::Layout>();
+  }
+  virtual void ApplyLayoutToType(const tir::Buffer &buffer,
+                                 SunMMIOType *type) const {
+    (void)buffer;
+    (void)type;
+  }
 };
 
 class CodeGenTileLangSunMMIO final
@@ -201,6 +222,7 @@ private:
   SunMMIOValue EvalExpr(const tvm::PrimExpr &expr);
   void VisitStmtTracked(const tir::Stmt &stmt);
   void CollectExpectedCoverage(const tir::PrimFunc &f);
+  void CollectDeclBuffers(const tir::Stmt &stmt);
   void MarkVisitedNodeType(const std::string &type_key);
   void MarkVisitedCallOpFromExpr(const tvm::PrimExpr &expr);
   void WriteCoverageReport() const;
@@ -215,9 +237,7 @@ private:
                         const ffi::Array<PrimExpr> &indices);
   void EmitStore(const tir::Buffer &buffer, const ffi::Array<PrimExpr> &indices,
                  const SunMMIOValue &value);
-  void EmitAlloc(const tir::Var &buffer_var, DataType dtype,
-                 const ffi::Array<PrimExpr> &extents,
-                 const std::string &scope_hint);
+  void EmitAlloc(const tir::Buffer &buffer, const std::string &scope_hint);
   void EmitFor(const tir::ForNode *op);
   void EmitIf(const tir::IfThenElseNode *op);
 
@@ -232,6 +252,7 @@ private:
   ArithmeticFlavor GetArithmeticFlavor(DataType dtype) const;
   CompareDomain GetCompareDomain(DataType dtype) const;
   SunMMIOValue BindVar(const tir::Var &var, const SunMMIOValue &value);
+  const SunMMIOValue &LookupVar(const tir::VarNode *var) const;
   void RegisterBuffer(const tir::Buffer &buffer, bool is_external,
                       const std::string &handle_hint = "");
   const BufferBinding &LookupBuffer(const tir::Buffer &buffer) const;
@@ -251,6 +272,7 @@ private:
 
   std::unordered_map<const tir::VarNode *, SunMMIOValue> var_table_;
   std::unordered_map<const tir::BufferNode *, BufferBinding> buffer_registry_;
+  std::unordered_map<const tir::VarNode *, tir::Buffer> buffer_data_to_buffer_;
   std::vector<ScopedAttr> attr_stack_;
 
   std::vector<const tir::VarNode *> scoped_vars_;

--- a/src/target/sunmmio/sunmmio_mlir_builder.cc
+++ b/src/target/sunmmio/sunmmio_mlir_builder.cc
@@ -168,5 +168,22 @@ void SuvmSunmmioBuilder::EmitAssert(const SunMMIOValue &cond,
   function_->EmitAssert(cond, msg_text);
 }
 
+void SuvmSunmmioBuilder::PushLayoutScope(
+    const TirLayoutMap &layout_map, const TirLayoutMap &global_layout_map) {
+  ctx_.PushLayoutScope(layout_map, global_layout_map);
+}
+
+void SuvmSunmmioBuilder::PopLayoutScope() { ctx_.PopLayoutScope(); }
+
+ffi::Optional<tl::Layout>
+SuvmSunmmioBuilder::LookupLayout(const tir::Buffer &buffer) const {
+  return ctx_.LookupLayout(buffer);
+}
+
+void SuvmSunmmioBuilder::ApplyLayoutToType(const tir::Buffer &buffer,
+                                           SunMMIOType *type) const {
+  ctx_.ApplyLayoutToType(buffer, type);
+}
+
 } // namespace codegen
 } // namespace tvm

--- a/src/target/sunmmio/sunmmio_mlir_builder.h
+++ b/src/target/sunmmio/sunmmio_mlir_builder.h
@@ -98,6 +98,13 @@ public:
 
   void EmitAssert(const SunMMIOValue &cond, const std::string &msg_text) final;
 
+  void PushLayoutScope(const TirLayoutMap &layout_map,
+                       const TirLayoutMap &global_layout_map) final;
+  void PopLayoutScope() final;
+  ffi::Optional<tl::Layout> LookupLayout(const tir::Buffer &buffer) const final;
+  void ApplyLayoutToType(const tir::Buffer &buffer,
+                         SunMMIOType *type) const final;
+
 private:
   SunmmioMlirContext ctx_;
   std::unique_ptr<SunmmioMlirFunction> function_;

--- a/src/target/sunmmio/sunmmio_mlir_context.cc
+++ b/src/target/sunmmio/sunmmio_mlir_context.cc
@@ -1,9 +1,132 @@
 #include "sunmmio_mlir_context.h"
 
+#include "../../layout/cute_layout.h"
+
+#include <tvm/arith/analyzer.h>
+#include <tvm/tir/expr.h>
+#include <tvm/tir/op.h>
+
+#include <limits>
+
 namespace tvm {
 namespace codegen {
 
 SunmmioMlirContext::SunmmioMlirContext() : builder(&mlir_ctx) {}
+
+namespace {
+
+bool IsGlobalScope(const tir::Buffer &buffer) {
+  return buffer.scope().empty() || buffer.scope() == "global";
+}
+
+ffi::Optional<tl::Layout>
+LookupLayoutInMap(const SunmmioMlirContext::TirLayoutMap &layout_map,
+                  const tir::Buffer &buffer) {
+  if (layout_map.count(buffer)) {
+    return layout_map[buffer];
+  }
+  for (const auto &kv : layout_map) {
+    const tir::Buffer &candidate = kv.first;
+    if (candidate->data.same_as(buffer->data) ||
+        candidate->name == buffer->name) {
+      return kv.second;
+    }
+  }
+  return ffi::Optional<tl::Layout>();
+}
+
+int64_t StaticIntValue(const PrimExpr &expr, arith::Analyzer *analyzer,
+                       const char *field_name, const tl::Layout &layout) {
+  PrimExpr simplified = analyzer->Simplify(expr);
+  if (const auto *imm = simplified.as<tir::IntImmNode>()) {
+    return imm->value;
+  }
+  LOG(FATAL) << "SunMMIO SUVM layout " << field_name << " must be static, got "
+             << simplified << " in layout: " << layout->DebugOutput();
+  TVM_FFI_UNREACHABLE();
+}
+
+} // namespace
+
+void SunmmioMlirContext::ClearLayoutScopes() {
+  layout_map_stack.clear();
+  global_layout_map_stack.clear();
+}
+
+void SunmmioMlirContext::PushLayoutScope(
+    const TirLayoutMap &layout_map, const TirLayoutMap &global_layout_map) {
+  layout_map_stack.push_back(layout_map);
+  global_layout_map_stack.push_back(global_layout_map);
+}
+
+void SunmmioMlirContext::PopLayoutScope() {
+  ICHECK(!layout_map_stack.empty());
+  ICHECK(!global_layout_map_stack.empty());
+  layout_map_stack.pop_back();
+  global_layout_map_stack.pop_back();
+}
+
+ffi::Optional<tl::Layout>
+SunmmioMlirContext::LookupLayout(const tir::Buffer &buffer) const {
+  auto lookup_stack =
+      [&](const std::vector<TirLayoutMap> &stack) -> ffi::Optional<tl::Layout> {
+    for (auto it = stack.rbegin(); it != stack.rend(); ++it) {
+      auto layout = LookupLayoutInMap(*it, buffer);
+      if (layout.defined()) {
+        return layout;
+      }
+    }
+    return ffi::Optional<tl::Layout>();
+  };
+
+  if (IsGlobalScope(buffer)) {
+    auto global_layout = lookup_stack(global_layout_map_stack);
+    if (global_layout.defined()) {
+      return global_layout;
+    }
+    return lookup_stack(layout_map_stack);
+  }
+
+  auto local_layout = lookup_stack(layout_map_stack);
+  if (local_layout.defined()) {
+    return local_layout;
+  }
+  return lookup_stack(global_layout_map_stack);
+}
+
+void SunmmioMlirContext::ApplyLayoutToType(const tir::Buffer &buffer,
+                                           SunMMIOType *type) const {
+  auto layout_opt = LookupLayout(buffer);
+  if (!layout_opt.defined()) {
+    return;
+  }
+
+  const tl::Layout &layout = layout_opt.value();
+  const auto *cute = layout.as<tl::CuteLayoutNode>();
+  ICHECK(cute) << "SunMMIO SUVM codegen expects CuteLayout for buffer "
+               << buffer->name << ", got " << layout->DebugOutput();
+
+  arith::Analyzer analyzer;
+  type->layout_hshape.clear();
+  type->layout_hstride.clear();
+  type->layout_dim_levels.clear();
+
+  for (const PrimExpr &dim : cute->GetModeShape()) {
+    type->layout_hshape.push_back(
+        StaticIntValue(dim, &analyzer, "mode_shape", layout));
+  }
+  for (const PrimExpr &stride : cute->GetModeStride()) {
+    type->layout_hstride.push_back(
+        StaticIntValue(stride, &analyzer, "mode_stride", layout));
+  }
+  for (const Integer &level : cute->GetDimLevels()) {
+    int64_t value = level.IntValue();
+    ICHECK_GT(value, 0) << "SunMMIO SUVM layout dim level must be > 0";
+    ICHECK_LE(value, static_cast<int64_t>(std::numeric_limits<uint8_t>::max()))
+        << "SunMMIO SUVM layout dim level does not fit uint8_t: " << value;
+    type->layout_dim_levels.push_back(static_cast<uint8_t>(value));
+  }
+}
 
 void SunmmioMlirContext::Clear() {
   mlir_value_table_stack.clear();
@@ -11,6 +134,7 @@ void SunmmioMlirContext::Clear() {
   for_stack.clear();
   if_stack.clear();
   control_flow_stack.clear();
+  ClearLayoutScopes();
   module = nullptr;
 }
 

--- a/src/target/sunmmio/sunmmio_mlir_context.h
+++ b/src/target/sunmmio/sunmmio_mlir_context.h
@@ -3,6 +3,8 @@
 
 #include "sunmmio_mlir_type.h"
 
+#include "../../layout/layout.h"
+
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/Builders.h"
@@ -10,6 +12,8 @@
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/OwningOpRef.h"
 #include "mlir/IR/Value.h"
+#include <tvm/ffi/container/map.h>
+#include <tvm/ffi/optional.h>
 
 #include <cstdint>
 #include <string>
@@ -21,6 +25,8 @@ namespace codegen {
 
 struct SunmmioMlirContext {
   SunmmioMlirContext();
+
+  using TirLayoutMap = ffi::Map<tir::Buffer, tl::Layout>;
 
   mlir::MLIRContext mlir_ctx;
   mlir::OpBuilder builder;
@@ -52,6 +58,8 @@ struct SunmmioMlirContext {
     std::unordered_map<int64_t, SavedToken> saved_token_by_id;
   };
   std::vector<ForFrame> for_stack;
+  std::vector<TirLayoutMap> layout_map_stack;
+  std::vector<TirLayoutMap> global_layout_map_stack;
 
   struct IfFrame {
     mlir::scf::IfOp op;
@@ -135,6 +143,13 @@ struct SunmmioMlirContext {
     }
     mlir_value_table_stack.back()[name] = v;
   }
+
+  void ClearLayoutScopes();
+  void PushLayoutScope(const TirLayoutMap &layout_map,
+                       const TirLayoutMap &global_layout_map);
+  void PopLayoutScope();
+  ffi::Optional<tl::Layout> LookupLayout(const tir::Buffer &buffer) const;
+  void ApplyLayoutToType(const tir::Buffer &buffer, SunMMIOType *type) const;
 
   void Clear();
 };

--- a/src/target/sunmmio/sunmmio_mlir_memory.cc
+++ b/src/target/sunmmio/sunmmio_mlir_memory.cc
@@ -23,7 +23,6 @@ SunmmioMlirMemory::Alloc(const std::string &result_name,
     LOG(FATAL) << "SunMMIO SUVM alloc does not support dynamic extents yet";
   }
 
-  // Reuse SunmmioMlirType::MapType for shape/layout/memory-space mapping.
   SunMMIOType updated_type = memref_type;
   if (updated_type.memory_scope.empty()) {
     updated_type.memory_scope = scope_name;
@@ -38,8 +37,7 @@ SunmmioMlirMemory::Alloc(const std::string &result_name,
       ctx_.builder, ctx_.builder.getUnknownLoc(), tensor_type);
 
   SunMMIOValue out{dtype, result_name, updated_type};
-  // ctx_.mlir_value_symbol_table[result_name] = alloc.getResult();
-  // ctx_.value_symbol_table[result_name] = out;
+  ctx_.BindMLIRValue(result_name, alloc.getResult());
   return out;
 }
 

--- a/src/transform/hoist_block_annotations_to_func_attrs.cc
+++ b/src/transform/hoist_block_annotations_to_func_attrs.cc
@@ -1,0 +1,159 @@
+/*
+ * Hoist selected block annotations to PrimFunc attributes.
+ *
+ * This pass is intentionally small: it preserves metadata that later block
+ * lowering would otherwise drop, without changing block annotations in-place.
+ */
+#include <tvm/ffi/container/array.h>
+#include <tvm/ffi/container/map.h>
+#include <tvm/ffi/reflection/registry.h>
+#include <tvm/ir/attrs.h>
+#include <tvm/ir/transform.h>
+#include <tvm/tir/function.h>
+#include <tvm/tir/stmt.h>
+#include <tvm/tir/stmt_functor.h>
+#include <tvm/tir/transform.h>
+
+#include <string>
+#include <utility>
+
+#include "../layout/layout.h"
+#include "../op/builtin.h"
+
+namespace tvm {
+namespace tl {
+using namespace tvm::tir;
+
+namespace {
+
+// 需要将block注释提升到函数属性的annotation key列表
+constexpr const char *kHoistedAnnotationKeys[] = {
+    attr::kLayoutMap,
+    attr::kGlobalLayoutMap,
+};
+// 需要保存到device_func_attr_keys列表中的属性key
+constexpr const char *kDeviceFuncPropagatedAttrKeys[] = {
+    attr::kLayoutMap,
+    attr::kGlobalLayoutMap,
+};
+
+void CopyMapEntries(const ffi::Map<ffi::Any, ffi::Any> &map,
+                    ffi::Map<ffi::Any, ffi::Any> *out) {
+  for (const auto &kv : map) {
+    out->Set(kv.first, kv.second);
+  }
+}
+
+ffi::Any MergeAnnotationValue(const ffi::Any &existing,
+                              const ffi::Any &incoming) {
+  auto existing_map = existing.try_cast<ffi::Map<ffi::Any, ffi::Any>>();
+  auto incoming_map = incoming.try_cast<ffi::Map<ffi::Any, ffi::Any>>();
+  if (existing_map && incoming_map) {
+    ffi::Map<ffi::Any, ffi::Any> merged;
+    CopyMapEntries(existing_map.value(), &merged);
+    CopyMapEntries(incoming_map.value(), &merged);
+    return merged;
+  }
+  return existing;
+}
+
+void AppendUniqueString(ffi::Array<ffi::String> *array,
+                        const ffi::String &key) {
+  for (const ffi::String &existing : *array) {
+    if (static_cast<std::string>(existing) == static_cast<std::string>(key)) {
+      return;
+    }
+  }
+  array->push_back(key);
+}
+
+ffi::Array<ffi::String> MergeDeviceFuncAttrKeys(const PrimFunc &f) {
+  ffi::Array<ffi::String> result;
+  if (f->attrs.defined()) {
+    if (auto existing = f->GetAttr<ffi::Array<ffi::String>>(
+            tl::attr::kDeviceFuncAttrKeys)) {
+      for (const ffi::String &key : existing.value()) {
+        AppendUniqueString(&result, key);
+      }
+    }
+  }
+  for (const char *key : kDeviceFuncPropagatedAttrKeys) {
+    AppendUniqueString(&result, key);
+  }
+  return result;
+}
+
+class BlockAnnotationCollector : public StmtVisitor {
+public:
+  void Collect(const Stmt &stmt) { VisitStmt(stmt); }
+
+  const ffi::Map<ffi::String, ffi::Any> &Result() const { return collected_; }
+
+private:
+  void VisitStmt_(const BlockNode *op) final {
+    for (const char *key : kHoistedAnnotationKeys) {
+      auto it = op->annotations.find(key);
+      if (it == op->annotations.end()) {
+        continue;
+      }
+
+      if (auto existing = collected_.Get(key)) {
+        collected_.Set(key,
+                       MergeAnnotationValue(existing.value(), (*it).second));
+      } else {
+        collected_.Set(key, (*it).second);
+      }
+    }
+    StmtVisitor::VisitStmt_(op);
+  }
+
+  ffi::Map<ffi::String, ffi::Any> collected_;
+};
+
+PrimFunc HoistBlockAnnotationsToFuncAttrs(PrimFunc f) {
+  if (!f.defined()) {
+    return f;
+  }
+
+  BlockAnnotationCollector collector;
+  collector.Collect(f->body);
+
+  for (const auto &kv : collector.Result()) {
+    std::string key = kv.first;
+    ffi::Any value = kv.second;
+    if (f->attrs.defined()) {
+      auto it = f->attrs->dict.find(key);
+      if (it != f->attrs->dict.end()) {
+        value = MergeAnnotationValue((*it).second, kv.second);
+      }
+    }
+    f = WithAttr(std::move(f), key, value);
+  }
+  f = WithAttr(std::move(f), tl::attr::kDeviceFuncAttrKeys,
+               MergeDeviceFuncAttrKeys(f));
+  return f;
+}
+
+} // namespace
+
+namespace transform {
+
+tvm::transform::Pass HoistBlockAnnotationsToFuncAttrs() {
+  auto pass_func = [](PrimFunc f, const IRModule &,
+                      const tvm::transform::PassContext &) {
+    return tvm::tl::HoistBlockAnnotationsToFuncAttrs(std::move(f));
+  };
+  return tvm::tir::transform::CreatePrimFuncPass(
+      pass_func, 0, "tl.HoistBlockAnnotationsToFuncAttrs", {});
+}
+
+} // namespace transform
+
+} // namespace tl
+} // namespace tvm
+
+TVM_FFI_STATIC_INIT_BLOCK() {
+  namespace refl = tvm::ffi::reflection;
+  refl::GlobalDef().def("tl.transform.HoistBlockAnnotationsToFuncAttrs",
+                        tvm::tl::transform::HoistBlockAnnotationsToFuncAttrs);
+}

--- a/src/transform/split_host_device.cc
+++ b/src/transform/split_host_device.cc
@@ -33,6 +33,12 @@
 #include <tvm/tir/stmt_functor.h>
 #include <tvm/tir/transform.h>
 
+#include <functional>
+#include <optional>
+#include <utility>
+
+#include "../layout/cute_layout.h"
+#include "../layout/layout.h"
 #include "../op/builtin.h"
 #include "common/assume.h"
 #include "tir/analysis/var_use_def_analysis.h"
@@ -62,6 +68,10 @@ public:
     for (auto param : params.value()) {
       non_restrict_params_.push_back(param);
     }
+  }
+
+  void SetExtraDeviceFuncAttrs(Map<String, Any> attrs) {
+    extra_device_func_attrs_ = std::move(attrs);
   }
 
   tir::Stmt VisitStmt_(const tir::AttrStmtNode *op) final {
@@ -134,6 +144,189 @@ private:
     return body;
   }
 
+  static Layout RemapLayout(const Layout &layout,
+                            const Map<tir::Var, PrimExpr> &var_remap) {
+    auto substitute = [&](const PrimExpr &expr) {
+      return tir::Substitute(expr, var_remap);
+    };
+
+    Array<PrimExpr> input_size = layout->InputShape().Map(
+        [&](const PrimExpr &expr) { return substitute(expr); });
+    Array<PrimExpr> forward_index = layout->GetForwardIndex().Map(
+        [&](const PrimExpr &expr) { return substitute(expr); });
+
+    if (auto cute = layout.as<CuteLayoutNode>()) {
+      Array<PrimExpr> logical_shape = cute->GetLogicalShape().Map(
+          [&](const PrimExpr &expr) { return substitute(expr); });
+      Array<PrimExpr> mode_shape = cute->GetModeShape().Map(
+          [&](const PrimExpr &expr) { return substitute(expr); });
+      Array<PrimExpr> mode_stride = cute->GetModeStride().Map(
+          [&](const PrimExpr &expr) { return substitute(expr); });
+      return CuteLayout(logical_shape, mode_shape, mode_stride,
+                        cute->GetDimLevels());
+    }
+
+    if (auto fragment = layout.as<FragmentNode>()) {
+      Fragment remapped(input_size, forward_index,
+                        substitute(fragment->GetForwardThread()),
+                        substitute(fragment->ReplicateExtent()), std::nullopt);
+      Range thread_range = fragment->ThreadRange();
+      if (thread_range.defined()) {
+        remapped = remapped->BindThreadRange(Range(
+            substitute(thread_range->min), substitute(thread_range->extent)));
+      }
+      return remapped;
+    }
+
+    return Layout(input_size, forward_index);
+  }
+
+  Any RemapLayoutMapAttr(
+      const String &key, const Any &value,
+      const Map<tir::Var, PrimExpr> &var_remap,
+      const std::function<tir::Buffer(const tir::Buffer &)> &remap_buffer) {
+    if (auto layout_map = value.as<Map<tir::Buffer, Layout>>()) {
+      Map<tir::Buffer, Layout> remapped_layout_map;
+      for (const auto &[buffer, layout] : layout_map.value()) {
+        remapped_layout_map.Set(remap_buffer(buffer),
+                                RemapLayout(layout, var_remap));
+      }
+      return remapped_layout_map;
+    }
+
+    if (auto layout_map = value.as<Map<tir::Var, Layout>>()) {
+      Map<tir::Var, Layout> remapped_layout_map;
+      for (const auto &[var, layout] : layout_map.value()) {
+        tir::Var remapped_var = var;
+        if (var_remap.count(var)) {
+          remapped_var = Downcast<tir::Var>(var_remap[var]);
+        }
+        remapped_layout_map.Set(remapped_var, RemapLayout(layout, var_remap));
+      }
+      return remapped_layout_map;
+    }
+
+    LOG(FATAL) << "Unsupported `" << key
+               << "` attr type for device function propagation: "
+               << value.GetTypeKey();
+    return Any();
+  }
+
+  struct SimpleAttrRemapResult {
+    Any value;
+    bool changed{false};
+  };
+
+  static std::optional<SimpleAttrRemapResult> TryRemapSimpleScalarAttrValue(
+      const Any &value, const Map<tir::Var, PrimExpr> &var_remap,
+      const std::function<tir::Buffer(const tir::Buffer &)> &remap_buffer) {
+    if (auto var = value.as<tir::Var>()) {
+      tir::Var remapped_var = var.value();
+      if (var_remap.count(var.value())) {
+        remapped_var = Downcast<tir::Var>(var_remap[var.value()]);
+      }
+      return SimpleAttrRemapResult{remapped_var,
+                                   !remapped_var.same_as(var.value())};
+    }
+
+    if (auto buffer = value.as<tir::Buffer>()) {
+      tir::Buffer remapped_buffer = remap_buffer(buffer.value());
+      return SimpleAttrRemapResult{remapped_buffer,
+                                   !remapped_buffer.same_as(buffer.value())};
+    }
+
+    if (auto expr = value.as<PrimExpr>()) {
+      PrimExpr remapped_expr = tir::Substitute(expr.value(), var_remap);
+      return SimpleAttrRemapResult{remapped_expr,
+                                   !remapped_expr.same_as(expr.value())};
+    }
+
+    return std::nullopt;
+  }
+
+  static std::optional<SimpleAttrRemapResult> TryRemapSimpleArrayAttrValue(
+      const Any &value, const Map<tir::Var, PrimExpr> &var_remap,
+      const std::function<tir::Buffer(const tir::Buffer &)> &remap_buffer) {
+    if (auto array = value.as<Array<Any>>()) {
+      Array<Any> remapped_array;
+      bool changed = false;
+      for (const Any &item : array.value()) {
+        auto remapped_item =
+            TryRemapSimpleScalarAttrValue(item, var_remap, remap_buffer);
+        if (remapped_item) {
+          remapped_array.push_back(remapped_item->value);
+          changed = changed || remapped_item->changed;
+        } else {
+          remapped_array.push_back(item);
+        }
+      }
+      if (changed) {
+        return SimpleAttrRemapResult{remapped_array, true};
+      }
+      return SimpleAttrRemapResult{value, false};
+    }
+
+    return std::nullopt;
+  }
+
+  static std::optional<SimpleAttrRemapResult> TryRemapSimpleMapAttrValue(
+      const Any &value, const Map<tir::Var, PrimExpr> &var_remap,
+      const std::function<tir::Buffer(const tir::Buffer &)> &remap_buffer) {
+    if (auto map = value.as<Map<Any, Any>>()) {
+      Map<Any, Any> remapped_map;
+      bool changed = false;
+      for (const auto &[key, map_value] : map.value()) {
+        auto remapped_key =
+            TryRemapSimpleScalarAttrValue(key, var_remap, remap_buffer);
+        auto remapped_value =
+            TryRemapSimpleScalarAttrValue(map_value, var_remap, remap_buffer);
+        const Any &new_key = remapped_key ? remapped_key->value : key;
+        const Any &new_value =
+            remapped_value ? remapped_value->value : map_value;
+        remapped_map.Set(new_key, new_value);
+        changed = changed || (remapped_key && remapped_key->changed) ||
+                  (remapped_value && remapped_value->changed);
+      }
+      if (changed) {
+        return SimpleAttrRemapResult{remapped_map, true};
+      }
+      return SimpleAttrRemapResult{value, false};
+    }
+
+    return std::nullopt;
+  }
+
+  static Any RemapSimpleAttrValue(
+      const Any &value, const Map<tir::Var, PrimExpr> &var_remap,
+      const std::function<tir::Buffer(const tir::Buffer &)> &remap_buffer) {
+    if (auto scalar =
+            TryRemapSimpleScalarAttrValue(value, var_remap, remap_buffer)) {
+      return scalar->value;
+    }
+    if (auto array =
+            TryRemapSimpleArrayAttrValue(value, var_remap, remap_buffer)) {
+      return array->value;
+    }
+    if (auto map = TryRemapSimpleMapAttrValue(value, var_remap, remap_buffer)) {
+      return map->value;
+    }
+    return value;
+  }
+
+  // remap 参数，复杂类型，指定key进行特殊处理
+  // 普通类型，var、buffer、primexpr，直接进行替换
+  // list,map等容器类型，如果直接包含上述普通类型，也进行替换
+  // map支持仅key或仅value进行替换的情况
+  Any RemapDeviceFuncAttr(
+      const String &key, const Any &value,
+      const Map<tir::Var, PrimExpr> &var_remap,
+      const std::function<tir::Buffer(const tir::Buffer &)> &remap_buffer) {
+    if (key == tl::attr::kLayoutMap || key == tl::attr::kGlobalLayoutMap) {
+      return RemapLayoutMapAttr(key, value, var_remap, remap_buffer);
+    }
+    return RemapSimpleAttrValue(value, var_remap, remap_buffer);
+  }
+
   tir::Stmt SplitDeviceFunc(tir::Stmt body, tvm::Target device_target) {
     // First, analyze undefined variables in the device body
     auto [old_params, buffers_to_declare] =
@@ -174,9 +367,16 @@ private:
     // Substitute old variables with new ones in the body
     body = tir::Substitute(body, var_remap);
 
-    // Also remap buffers to use new variables
-    Array<tir::Buffer> new_buffers_to_declare;
-    for (const auto &buf : buffers_to_declare) {
+    // Remap buffers to use new variables.  Keep a cache so DeclBuffer and
+    // function attributes that reference the same old Buffer also share the
+    // same remapped Buffer.
+    Map<tir::Buffer, tir::Buffer> buffer_remap;
+    std::function<tir::Buffer(const tir::Buffer &)> remap_buffer =
+        [&](const tir::Buffer &buf) -> tir::Buffer {
+      if (buffer_remap.count(buf)) {
+        return buffer_remap[buf];
+      }
+
       auto new_shape = buf->shape.Map(
           [&](const PrimExpr &e) { return tir::Substitute(e, var_remap); });
       auto new_strides = buf->strides.Map(
@@ -185,11 +385,24 @@ private:
       auto new_data = var_remap.count(buf->data)
                           ? Downcast<tir::Var>(var_remap[buf->data])
                           : buf->data;
+
+      if (new_data.same_as(buf->data) && new_shape.same_as(buf->shape) &&
+          new_strides.same_as(buf->strides) &&
+          new_elem_offset.same_as(buf->elem_offset)) {
+        return buf;
+      }
+
       tir::Buffer new_buf(new_data, buf->dtype, new_shape, new_strides,
                           new_elem_offset, buf->name, buf->data_alignment,
                           buf->offset_factor, buf->buffer_type,
                           buf->axis_separators, buf->span);
-      new_buffers_to_declare.push_back(new_buf);
+      buffer_remap.Set(buf, new_buf);
+      return new_buf;
+    };
+
+    Array<tir::Buffer> new_buffers_to_declare;
+    for (const auto &buf : buffers_to_declare) {
+      new_buffers_to_declare.push_back(remap_buffer(buf));
     }
     buffers_to_declare = new_buffers_to_declare;
 
@@ -240,6 +453,14 @@ private:
          {tir::attr::kIsGlobalFunc, true},
          {tl::attr::kNonRestrictParams, remapped_non_restrict_params}});
 
+    Map<String, Any> remapped_extra_device_func_attrs;
+    for (const auto &[key, value] : extra_device_func_attrs_) {
+      remapped_extra_device_func_attrs.Set(
+          key, RemapDeviceFuncAttr(key, value, var_remap, remap_buffer));
+    }
+    device_func =
+        WithAttrs(std::move(device_func), remapped_extra_device_func_attrs);
+
     GlobalVar kernel_symbol_global = var_supply_();
     (*device_mod_)->Add(kernel_symbol_global, device_func);
     // Use old_params as call arguments (host-side variables)
@@ -268,11 +489,30 @@ private:
   std::function<GlobalVar()> var_supply_;
   // Collect assumes in host side
   Array<const tir::AttrStmtNode *> host_assumes_;
+  Map<String, Any> extra_device_func_attrs_;
 };
 
 tir::PrimFunc SplitHostDevice(tir::PrimFunc func, IRModule *device_mod,
                               std::function<GlobalVar()> var_supply) {
   HostDeviceSplitter splitter(device_mod, std::move(var_supply));
+  // 保存需要保留到device_function的属性
+  Map<String, Any> extra_device_func_attrs;
+  if (func->attrs.defined()) {
+    if (auto opt_keys =
+            func->GetAttr<Array<String>>(tl::attr::kDeviceFuncAttrKeys)) {
+      for (const String &key : opt_keys.value()) {
+        if (key == tl::attr::kDeviceFuncAttrKeys) {
+          continue;
+        }
+        if (auto it = func->attrs->dict.find(key);
+            it != func->attrs->dict.end()) {
+          extra_device_func_attrs.Set(key, (*it).second);
+        }
+      }
+    }
+  }
+  splitter.SetExtraDeviceFuncAttrs(std::move(extra_device_func_attrs));
+
   // Propagate non-restrict parameter list from host func to device kernels
   if (auto opt = func->GetAttr<Array<tir::Var>>(tl::attr::kNonRestrictParams)) {
     splitter.SetNonRestrictParams(opt.value());
@@ -295,6 +535,10 @@ tir::PrimFunc SplitHostDevice(tir::PrimFunc func, IRModule *device_mod,
         }
       }
     }
+  }
+  if (func->attrs.defined() &&
+      func->attrs->dict.count(tl::attr::kDeviceFuncAttrKeys)) {
+    func = tvm::WithoutAttr(std::move(func), tl::attr::kDeviceFuncAttrKeys);
   }
   return func;
 }

--- a/src/transform/split_host_device.cc
+++ b/src/transform/split_host_device.cc
@@ -313,10 +313,11 @@ private:
     return value;
   }
 
-  // remap 参数，复杂类型，指定key进行特殊处理
-  // 普通类型，var、buffer、primexpr，直接进行替换
-  // list,map等容器类型，如果直接包含上述普通类型，也进行替换
-  // map支持仅key或仅value进行替换的情况
+  // Remap parameters. Special handling is applied to complex types based on
+  // specific keys. Primitive types (Var, Buffer, PrimExpr) are substituted
+  // directly. Container types (List, Map) are also remapped if they contain
+  // these primitive types. For Maps, supports replacing only the keys or only
+  // the values.
   Any RemapDeviceFuncAttr(
       const String &key, const Any &value,
       const Map<tir::Var, PrimExpr> &var_remap,

--- a/testing/python/transform/test_tilelang_transform_sunmmio_hoist_block_annotations_to_func_attrs.py
+++ b/testing/python/transform/test_tilelang_transform_sunmmio_hoist_block_annotations_to_func_attrs.py
@@ -1,0 +1,44 @@
+from tilelang import tvm as tvm
+import tilelang as tl
+import tilelang.language as T
+import tilelang.testing
+
+
+def _buffer_names(attr_map):
+    return {var.name for var in attr_map}
+
+
+def test_hoist_layout_annotations_to_func_attrs():
+    @T.prim_func
+    def before(A: T.Buffer((16,), "float32")):
+        B = T.alloc_buffer((16,), "float32", scope="shared")
+        C = T.alloc_buffer((16,), "float32", scope="global")
+        with T.block("producer"):
+            T.block_attr({"layout_map": {B.data: T.int32(1)}})
+            T.evaluate(0)
+        with T.block("consumer"):
+            T.block_attr(
+                {
+                    "layout_map": {A.data: T.int32(2)},
+                    "global_layout_map": {C.data: T.int32(3)},
+                }
+            )
+            T.evaluate(0)
+
+    mod = tvm.IRModule.from_expr(before.with_attr("global_symbol", "main"))
+    mod = tl.transform.HoistBlockAnnotationsToFuncAttrs()(mod)
+    func = mod["main"]
+
+    assert "layout_map" in func.attrs
+    assert "global_layout_map" in func.attrs
+    assert _buffer_names(func.attrs["layout_map"]) == {"A", "B"}
+    assert _buffer_names(func.attrs["global_layout_map"]) == {"C"}
+
+    layout_values = {var.name: int(value) for var, value in func.attrs["layout_map"].items()}
+    global_layout_values = {var.name: int(value) for var, value in func.attrs["global_layout_map"].items()}
+    assert layout_values == {"A": 2, "B": 1}
+    assert global_layout_values == {"C": 3}
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/testing/python/transform/test_tilelang_transform_sunmmio_split_host_device.py
+++ b/testing/python/transform/test_tilelang_transform_sunmmio_split_host_device.py
@@ -67,8 +67,6 @@ def run_sunmmio_split(mod, *, hoist=False):
 
 
 def test_sunmmio_split_host_device_propagates_hoisted_layout_attrs():
-    """测试 hoist 后的 layout attrs 能传到 Sunmmio device func.
-    同时检查 Var remap 和内部 marker 清理."""
     n = T.dynamic("n")
 
     @T.prim_func
@@ -114,9 +112,6 @@ def test_sunmmio_split_host_device_propagates_hoisted_layout_attrs():
 
 
 def test_sunmmio_split_host_device_preserves_cute_layout_attr_type():
-    """测试 layout remap 后仍保留 CuteLayout 类型.
-    Sunmmio codegen 依赖 CuteLayout 的结构化字段."""
-
     @T.prim_func
     def before(A: T.Buffer((16, 16), "float32")):
         with T.Kernel(1):
@@ -138,8 +133,6 @@ def test_sunmmio_split_host_device_preserves_cute_layout_attr_type():
 
 
 def test_sunmmio_split_host_device_remaps_marked_simple_attrs():
-    """测试标记的非 layout attrs 会保守复制并 remap。
-    标量直接 remap,Array/Map 中的元素独立 remap."""
     n = T.dynamic("n")
 
     @T.prim_func

--- a/testing/python/transform/test_tilelang_transform_sunmmio_split_host_device.py
+++ b/testing/python/transform/test_tilelang_transform_sunmmio_split_host_device.py
@@ -1,0 +1,203 @@
+"""Sunmmio tests for SplitHostDevice device-function attribute propagation."""
+
+import tilelang
+import tilelang.language as T
+import tilelang.transform
+from tilelang import tvm as tvm
+import tilelang.testing
+from tilelang.engine.lower import canon_target_host
+from tilelang.layout.cute_layout import CuteLayout
+from tilelang.utils.target import determine_target, target_is_sunmmio
+from tvm import tir
+
+tilelang.env.disable_cache()
+
+
+def make_sunmmio_target_with_host():
+    target = determine_target("Sunmmio", return_object=True)
+    target_host = tvm.target.Target.canon_target(canon_target_host(target, None))
+    return tvm.target.Target(target, target_host)
+
+
+def get_device_func(mod):
+    device_funcs = [
+        func
+        for func in mod.functions.values()
+        if isinstance(func, tir.PrimFunc)
+        and func.attrs is not None
+        and func.attrs.get("tir.is_global_func", False)
+        and "target" in func.attrs
+        and target_is_sunmmio(func.attrs["target"])
+    ]
+    assert len(device_funcs) == 1, (
+        f"Expected exactly one Sunmmio device function, got {len(device_funcs)}.\n"
+        f"Functions: { {gv.name_hint: dict(func.attrs) for gv, func in mod.functions.items()} }"
+    )
+    return device_funcs[0]
+
+
+def get_host_func(mod):
+    host_funcs = [
+        func for func in mod.functions.values() if isinstance(func, tir.PrimFunc) and not func.attrs.get("tir.is_global_func", False)
+    ]
+    assert len(host_funcs) == 1, (
+        f"Expected exactly one host function, got {len(host_funcs)}.\n"
+        f"Functions: { {gv.name_hint: dict(func.attrs) for gv, func in mod.functions.items()} }"
+    )
+    return host_funcs[0]
+
+
+def get_param_by_name(func, name):
+    for param in func.params:
+        if getattr(param, "name_hint", getattr(param, "name", None)) == name:
+            return param
+    return None
+
+
+def run_sunmmio_split(mod, *, hoist=False):
+    target = make_sunmmio_target_with_host()
+    with tvm.target.Target(target):
+        mod = tvm.tir.transform.BindTarget(target)(mod)
+        if hoist:
+            mod = tilelang.transform.HoistBlockAnnotationsToFuncAttrs()(mod)
+        mod = tilelang.transform.LowerOpaqueBlock()(mod)
+        mod = tilelang.transform.AnnotateDeviceRegions()(mod)
+        mod = tilelang.transform.SplitHostDevice()(mod)
+    return mod
+
+
+def test_sunmmio_split_host_device_propagates_hoisted_layout_attrs():
+    """测试 hoist 后的 layout attrs 能传到 Sunmmio device func.
+    同时检查 Var remap 和内部 marker 清理."""
+    n = T.dynamic("n")
+
+    @T.prim_func
+    def before(A: T.Buffer((n,), "float32")):
+        B = T.alloc_buffer((n,), "float32", scope="shared")
+        with T.block("producer"):
+            T.block_attr(
+                {
+                    "layout_map": {B.data: T.Layout((n,), lambda i: i)},
+                    "global_layout_map": {A.data: T.Layout((n,), lambda i: i)},
+                }
+            )
+            with T.Kernel(1):
+                B[0] = A[0]
+
+    mod = tvm.IRModule.from_expr(before.with_attr("global_symbol", "main"))
+    mod = run_sunmmio_split(mod, hoist=True)
+
+    host_func = get_host_func(mod)
+    device_func = get_device_func(mod)
+
+    assert "tl.device_func_attr_keys" not in host_func.attrs
+    assert "tl.device_func_attr_keys" not in device_func.attrs
+    assert "layout_map" in device_func.attrs
+    assert "global_layout_map" in device_func.attrs
+
+    device_n = get_param_by_name(device_func, "n")
+    device_a = get_param_by_name(device_func, "A")
+    device_b = get_param_by_name(device_func, "B")
+    assert device_n is not None
+    assert device_a is not None
+    assert device_b is not None
+
+    shared_key = next(iter(device_func.attrs["layout_map"].keys()))
+    global_key = next(iter(device_func.attrs["global_layout_map"].keys()))
+    assert shared_key.same_as(device_b)
+    assert global_key.same_as(device_a)
+
+    shared_layout = next(iter(device_func.attrs["layout_map"].values()))
+    global_layout = next(iter(device_func.attrs["global_layout_map"].values()))
+    assert shared_layout.get_input_shape()[0].same_as(device_n)
+    assert global_layout.get_input_shape()[0].same_as(device_n)
+
+
+def test_sunmmio_split_host_device_preserves_cute_layout_attr_type():
+    """测试 layout remap 后仍保留 CuteLayout 类型.
+    Sunmmio codegen 依赖 CuteLayout 的结构化字段."""
+
+    @T.prim_func
+    def before(A: T.Buffer((16, 16), "float32")):
+        with T.Kernel(1):
+            A[0, 0] = A[0, 0]
+
+    func = before.with_attr("global_symbol", "main")
+    buffer = func.buffer_map[func.params[0]]
+    layout = CuteLayout([16, 16], [4, 4, 16], [64, 16, 1], [2, 1])._inner
+    func = func.with_attr("layout_map", {buffer: layout}).with_attr("tl.device_func_attr_keys", ["layout_map"])
+
+    mod = run_sunmmio_split(tvm.IRModule.from_expr(func))
+    device_func = get_device_func(mod)
+
+    remapped_layout = next(iter(device_func.attrs["layout_map"].values()))
+    assert remapped_layout.__class__.__name__ == "CuteLayout"
+    assert list(remapped_layout.mode_shape) == list(layout.mode_shape)
+    assert list(remapped_layout.mode_stride) == list(layout.mode_stride)
+    assert list(remapped_layout.dim_levels) == list(layout.dim_levels)
+
+
+def test_sunmmio_split_host_device_remaps_marked_simple_attrs():
+    """测试标记的非 layout attrs 会保守复制并 remap。
+    标量直接 remap,Array/Map 中的元素独立 remap."""
+    n = T.dynamic("n")
+
+    @T.prim_func
+    def before(A: T.Buffer((n,), "float32")):
+        B = T.alloc_buffer((n,), "float32", scope="shared")
+        with T.Kernel(1):
+            B[0] = A[0]
+
+    func = before.with_attr("global_symbol", "main")
+    buffer_a = func.buffer_map[func.params[0]]
+    data_a = buffer_a.data
+    n_var = buffer_a.shape[0]
+
+    func = (
+        func.with_attr("var_attr", data_a)
+        .with_attr("buffer_attr", buffer_a)
+        .with_attr("expr_attr", n_var + 1)
+        .with_attr("array_attr", [data_a, "keep_me", n_var + 2])
+        .with_attr("map_attr", {data_a: n_var + 3, "plain_key": data_a})
+        .with_attr("unmarked_attr", data_a)
+        .with_attr(
+            "tl.device_func_attr_keys",
+            [
+                "var_attr",
+                "buffer_attr",
+                "expr_attr",
+                "array_attr",
+                "map_attr",
+            ],
+        )
+    )
+
+    mod = run_sunmmio_split(tvm.IRModule.from_expr(func))
+    device_func = get_device_func(mod)
+    device_a = get_param_by_name(device_func, "A")
+    device_n = get_param_by_name(device_func, "n")
+    assert device_a is not None
+    assert device_n is not None
+
+    assert device_func.attrs["var_attr"].same_as(device_a)
+    assert device_func.attrs["buffer_attr"].data.same_as(device_a)
+    assert device_func.attrs["buffer_attr"].shape[0].same_as(device_n)
+    assert device_func.attrs["expr_attr"].a.same_as(device_n)
+
+    array_attr = device_func.attrs["array_attr"]
+    assert array_attr[0].same_as(device_a)
+    assert array_attr[1] == "keep_me"
+    assert array_attr[2].a.same_as(device_n)
+
+    map_attr = device_func.attrs["map_attr"]
+    remapped_key = next(key for key in map_attr.keys() if hasattr(key, "same_as"))
+    assert remapped_key.same_as(device_a)
+    assert map_attr[remapped_key].a.same_as(device_n)
+    assert map_attr["plain_key"].same_as(device_a)
+
+    assert "unmarked_attr" not in device_func.attrs
+    assert "tl.device_func_attr_keys" not in device_func.attrs
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/tilelang/transform/__init__.py
+++ b/tilelang/transform/__init__.py
@@ -544,6 +544,10 @@ def HoistNonRestrictParams():
     return _ffi_api.HoistNonRestrictParams()  # type: ignore
 
 
+def HoistBlockAnnotationsToFuncAttrs():
+    return _ffi_api.HoistBlockAnnotationsToFuncAttrs()  # type: ignore
+
+
 def StorageRewrite():
     """StorageRewrite
 


### PR DESCRIPTION
Description
This PR introduces a new optimization pass, enhances the host/device splitting logic, and extends the CodeGen to fully support and propagate layout and memory tensor information down to MLIR.

Key Changes
**1. New Pass: hoist_block_annotations_to_func_attr**
Introduces a new pass to lift block-level annotations to function attributes (func_attr).

Placement: Positioned immediately after HoistNonRestrictParams.

Merging Rules:

Map types are merged.

For other types, the first encountered value takes precedence.

Device Propagation: Added kDeviceFuncPropagatedAttrKeys to identify specific attributes that must be propagated to device functions.

**2. Enhanced split_host_device Pass**
Updated the host-device splitting logic to properly handle and remap attribute metadata when functions are split.

Attribute Injection: Propagates keys specified in kDeviceFuncPropagatedAttrKeys into the generated device functions.

Remapping Logic: Since the split process generates new buffers and variables, the corresponding attribute metadata is remapped as follows:

Primitive Types: Buffer, Var, and PrimExpr are remapped directly.

Containers (List/Map): First-level elements are remapped if they contain primitive types.

Specialized Types: Dedicated remap handling is added for specific keys, currently targeting layout_map and global_layout_map.

Fallback: All other types are kept as-is.

**3. CodeGen: Layout Information Resolution**
Added support for receiving and querying layout information during the CodeGen phase.

Context Storage: Layout information is retrieved during AddFunction and stored inside the CodeGen context.

Context Operations: Implemented foundational APIs for layout management: push, pop, lookup, and apply_to_type.

**4. CodeGen: Finalized MemTensor Construction Workflow**
Streamlined the end-to-end pipeline for binding TIR variables to MLIR values using layout information.

Function Arguments: Layout information is queried during AddFunction to construct SunMMIOValue and trigger bindVar. The actual bindMlir is executed later during begin_function.

Allocate Nodes: For standard allocations, layout info is queried inside AllocateNode. EmitAlloc handles bindVar, while the memory allocator handles bindMlir.

Unified Querying: Developers can now seamlessly query mapping from TIR to MLIR using LookupBuffer and LookupMLIRValue.