### PR TITLE
[Op] Add axis argument for T.comm collectives

### DIFF
--- a/src/op/comm.cc
+++ b/src/op/comm.cc
@@ -111,9 +111,8 @@ BroadcastOp::BroadcastOp(Array<PrimExpr> args,
   std::tie(node->src, node->dst) = std::tie(bf[0], bf[1]);
   std::tie(node->src_range, node->dst_range) = std::tie(rgs[0], rgs[1]);
   node->size = Downcast<IntImm>(args[2]);
-  node->dst_offset = Downcast<IntImm>(args[3]);
-  node->src_core = args[4];
-  node->direction = Downcast<IntImm>(args[5])->value;
+  node->src_core = args[3];
+  node->direction = Downcast<IntImm>(args[4])->value;
   data_ = std::move(node);
 }
 
@@ -171,7 +170,7 @@ Stmt BroadcastOpNode::Lower(const LowerArgs &T,
       << "Broadcast size larger than data size: " << size->value << " vs "
       << Downcast<IntImm>(src_elements)->value;
 
-  // check for size and dst_offset
+  // check for size
   PrimExpr broadcast_elements;
   if (size->value < 0) {
     broadcast_elements = src_elements;
@@ -183,11 +182,11 @@ Stmt BroadcastOpNode::Lower(const LowerArgs &T,
       << "Broadcast size Larger than source buffer size: "
       << (Downcast<IntImm>(broadcast_elements)->value) << " vs "
       << Downcast<IntImm>(src_elements)->value;
-  ICHECK((Downcast<IntImm>(broadcast_elements)->value + dst_offset->value) <=
+  ICHECK((Downcast<IntImm>(broadcast_elements)->value) <=
          Downcast<IntImm>(dst_elements)->value)
-      << "Broadcast size + dst_offset larger than destination buffer size: "
-      << (Downcast<IntImm>(broadcast_elements)->value + dst_offset->value)
-      << " vs " << Downcast<IntImm>(dst_elements)->value;
+      << "Broadcast size larger than destination buffer size: "
+      << (Downcast<IntImm>(broadcast_elements)->value) << " vs "
+      << Downcast<IntImm>(dst_elements)->value;
 
   // check for valid direction
   if (direction != 0 and direction != 1 and direction != 2) {
@@ -196,11 +195,6 @@ Stmt BroadcastOpNode::Lower(const LowerArgs &T,
   }
 
   // all checks passed, generate the call
-  PrimExpr src_addr = src.access_ptr(1, DataType::Handle(), 1, 0, src_elements);
-  PrimExpr dst_addr =
-      dst.access_ptr(2, DataType::Handle(), 1,
-                     Downcast<IntImm>(dst_offset->value), src_elements);
-
   if (direction == 0 or direction == 1) {
     // 1D broadcast
     Array<PrimExpr> args;
@@ -244,7 +238,7 @@ Stmt BroadcastOpNode::Lower(const LowerArgs &T,
 }
 
 TIR_REGISTER_TL_TILE_OP(BroadcastOp, comm_broadcast)
-    .set_num_inputs(6)
+    .set_num_inputs(5)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));
 
@@ -439,6 +433,8 @@ AllgatherOp::AllgatherOp(Array<PrimExpr> args,
   node->recv = args[1];
   node->direction = Downcast<IntImm>(args[2])->value;
   node->size = Downcast<IntImm>(args[3]);
+  // axis is optional for backwards compatibility: -1 = legacy mode.
+  node->axis = (args.size() > 4) ? Downcast<IntImm>(args[4])->value : -1;
   data_ = std::move(node);
 }
 
@@ -567,130 +563,123 @@ Stmt AllgatherOpNode::Lower(const LowerArgs &T,
       << (Downcast<IntImm>(send_elements)->value * recv_num) << ", but got "
       << Downcast<IntImm>(recv_elements)->value;
 
-  // all checks passed, generate the calls
+  // Unified lowering for all axis modes. Every per-core contribution lands
+  // in an equal-size slot along a single axis of recv ("slice_axis"). Slot
+  // offset is encoded in the region's `min`, not in a separate offset arg.
+  //
+  //   axis == -1 (sentinel, "no axis") or axis == 0 -> slice_axis = 0
+  //     legacy recv [K, d0, ...]:        slot_extent = 1
+  //     axis=0 recv [K*d0, d1, ...]:     slot_extent = d0
+  //   axis > 0 (last dim of send)        -> slice_axis = recv_rank - 1
+  //     axis=-1 recv [d0, ..., K*dn-1]:  slot_extent = dn-1
+  Buffer send_buffer = send_region->buffer;
+  Buffer recv_buffer = recv_region->buffer;
+  int recv_rank = static_cast<int>(recv_range.size());
+  ICHECK_GT(recv_rank, 0) << "Allgather recv must have at least one dim.";
+  if (axis > 0) {
+    ICHECK_EQ(axis, static_cast<int>(send_range.size()) - 1)
+        << "Only axis = last dim of send is supported; got axis=" << axis
+        << " for send rank=" << send_range.size();
+    ICHECK_EQ(recv_range.size(), send_range.size())
+        << "In axis mode, recv and send must have the same rank.";
+  }
+  int slice_axis = (axis > 0) ? (recv_rank - 1) : 0;
+  ICHECK(analyzer->CanProve(FloorMod(recv_range[slice_axis]->extent,
+                                     IntImm(DataType::Int(32), recv_num)) ==
+                            0))
+      << "Recv extent along slice axis " << slice_axis << " ("
+      << recv_range[slice_axis]->extent << ") must be divisible by recv_num ("
+      << recv_num << ").";
+  PrimExpr slot_extent_p1 = analyzer->Simplify(FloorDiv(
+      recv_range[slice_axis]->extent, IntImm(DataType::Int(32), recv_num)));
+  IntImm bcast_size_imm =
+      (size->value < 0) ? Downcast<IntImm>(send_elements) : size;
+
+  // Build a sub-region of recv spanning a single slab of width `slot_extent`
+  // along `slice_axis`, starting at slot index `slot_start`. All other dims
+  // pass through `recv_range` unchanged.
+  auto make_slab = [&](int slot_start, PrimExpr slot_extent) {
+    Array<Range> ranges;
+    for (int d = 0; d < recv_rank; d++) {
+      if (d == slice_axis) {
+        PrimExpr base = analyzer->Simplify(
+            recv_range[d]->min +
+            IntImm(DataType::Int(32), slot_start) * slot_extent);
+        ranges.push_back(Range::FromMinExtent(base, slot_extent));
+      } else {
+        ranges.push_back(recv_range[d]);
+      }
+    }
+    return ranges;
+  };
+
   Array<Stmt> bcast_stmts;
+
+  auto emit = [&](Array<Range> dst_ranges, IntImm bcast_elems, int src_core_id,
+                  int bcast_dir, bool src_from_send) {
+    Array<PrimExpr> args;
+    if (src_from_send) {
+      args.push_back(MakeRegionExpr(send_buffer, send_range, /*mask=*/1));
+    } else {
+      args.push_back(MakeRegionExpr(recv_buffer, dst_ranges, /*mask=*/1));
+    }
+    args.push_back(MakeRegionExpr(recv_buffer, dst_ranges, /*mask=*/2));
+    args.push_back(bcast_elems);
+    args.push_back(IntImm(DataType::Int(32), src_core_id));
+    args.push_back(IntImm(DataType::Int(32), bcast_dir));
+    BroadcastOp bcast(args);
+    bcast_stmts.push_back(bcast->Lower(T, analyzer));
+  };
 
   if (direction == 0) { // horizontal
     for (int i = 0; i < mesh_nrow; i++) {
-      for (size_t j = 0; j < mesh_ncol; j++) {
-        Array<PrimExpr> args;
-        args.push_back(send);
-        args.push_back(recv);
-        args.push_back(size);
-        args.push_back(IntImm(DataType::Int(32), j) * send_elements); // offset
-        args.push_back(
-            IntImm(DataType::Int(32), i * mesh_ncol + j)); // src_core
-        args.push_back(0); // direction: horizontal
-        BroadcastOp bcast = BroadcastOp(args);
-        Stmt bcast_stmt = bcast->Lower(T, analyzer);
-        bcast_stmts.push_back(bcast_stmt);
+      for (int j = 0; j < mesh_ncol; j++) {
+        emit(make_slab(/*slot_start=*/j, slot_extent_p1), bcast_size_imm,
+             /*src_core=*/i * mesh_ncol + j, /*bcast_dir=*/0,
+             /*src_from_send=*/true);
       }
     }
   } else if (direction == 1) { // vertical
     for (int j = 0; j < mesh_ncol; j++) {
-      for (size_t i = 0; i < mesh_nrow; i++) {
-        Array<PrimExpr> args;
-        args.push_back(send);
-        args.push_back(recv);
-        args.push_back(size);
-        args.push_back(IntImm(DataType::Int(32), i) * send_elements); // offset
-        args.push_back(
-            IntImm(DataType::Int(32), i * mesh_ncol + j)); // src_core
-        args.push_back(1); // direction: vertical
-        BroadcastOp bcast = BroadcastOp(args);
-        Stmt bcast_stmt = bcast->Lower(T, analyzer);
-        bcast_stmts.push_back(bcast_stmt);
+      for (int i = 0; i < mesh_nrow; i++) {
+        emit(make_slab(/*slot_start=*/i, slot_extent_p1), bcast_size_imm,
+             /*src_core=*/i * mesh_ncol + j, /*bcast_dir=*/1,
+             /*src_from_send=*/true);
       }
     }
-  } else if (direction == 2) { // all
-    // first do horizontal allgather
+  } else { // direction == 2 ("all")
+    // Phase 1: horizontal. Core (i,j) lands at slot (i*ncol + j).
     for (int i = 0; i < mesh_nrow; i++) {
-      for (size_t j = 0; j < mesh_ncol; j++) {
-        Array<PrimExpr> args;
-        args.push_back(send);
-        args.push_back(recv);
-        args.push_back(size);
-        args.push_back(IntImm(DataType::Int(32), i * mesh_ncol + j) *
-                       send_elements); // offset
-        args.push_back(
-            IntImm(DataType::Int(32), i * mesh_ncol + j)); // src_core
-        args.push_back(0); // direction: horizontal
-        BroadcastOp bcast = BroadcastOp(args);
-        Stmt bcast_stmt = bcast->Lower(T, analyzer);
-        bcast_stmts.push_back(bcast_stmt);
+      for (int j = 0; j < mesh_ncol; j++) {
+        emit(make_slab(/*slot_start=*/i * mesh_ncol + j, slot_extent_p1),
+             bcast_size_imm,
+             /*src_core=*/i * mesh_ncol + j, /*bcast_dir=*/0,
+             /*src_from_send=*/true);
       }
     }
-    // then do vertical allgather
-    Buffer recv_buffer = recv_region->buffer;
-    int allgather_size =
-        (size->value < 0) ? Downcast<IntImm>(send_elements)->value * mesh_ncol
-                          : size->value * mesh_ncol;
-
-    // Try to slice along the first dimension to avoid flattening
-    // This produces cleaner TIR when the buffer shape is aligned with the mesh
-    bool use_flatten = true;
-    PrimExpr dim0_extent = 0;
-    PrimExpr stride0 = 1;
-
-    if (!recv_buffer->shape.empty()) {
-      for (size_t k = 1; k < recv_buffer->shape.size(); k++) {
-        stride0 *= recv_buffer->shape[k];
-      }
-      stride0 = analyzer->Simplify(stride0);
-
-      PrimExpr row_size = IntImm(DataType::Int(32), mesh_ncol) * send_elements;
-      if (analyzer->CanProve(FloorMod(row_size, stride0) == 0)) {
-        dim0_extent = analyzer->Simplify(FloorDiv(row_size, stride0));
-        use_flatten = false;
-      }
-    }
-
-    Buffer target_buffer = recv_buffer;
-    if (use_flatten && recv_buffer->shape.size() > 1) {
-      target_buffer =
-          Buffer(recv_buffer->data, recv_buffer->dtype, {recv_elements}, {1},
-                 recv_buffer->elem_offset, recv_buffer->name + "_flat",
-                 recv_buffer->data_alignment, recv_buffer->offset_factor,
-                 recv_buffer->buffer_type);
-    }
-
+    // Phase 2: vertical. Each row's mesh_ncol-wide gathered slab (rows
+    // i*ncol .. (i+1)*ncol of phase-1 slots) is broadcast to every row in
+    // each column.
+    PrimExpr row_extent = analyzer->Simplify(
+        IntImm(DataType::Int(32), mesh_ncol) * slot_extent_p1);
+    IntImm row_size_imm =
+        IntImm(DataType::Int(32), bcast_size_imm->value * mesh_ncol);
     for (int j = 0; j < mesh_ncol; j++) {
-      for (size_t i = 0; i < mesh_nrow; i++) {
-        Array<PrimExpr> args;
-        Array<Range> ranges;
-
-        if (use_flatten) {
-          PrimExpr offset =
-              IntImm(DataType::Int(32), i * mesh_ncol) * send_elements;
-          PrimExpr extent =
-              IntImm(DataType::Int(32), mesh_ncol) * send_elements;
-          ranges.push_back(Range::FromMinExtent(offset, extent));
-        } else {
-          // Slice along the first dimension
-          ranges.push_back(Range::FromMinExtent(
-              IntImm(DataType::Int(32), i) * dim0_extent, dim0_extent));
-          for (size_t k = 1; k < recv_buffer->shape.size(); k++) {
-            ranges.push_back(Range::FromMinExtent(0, recv_buffer->shape[k]));
-          }
-        }
-
-        args.push_back(MakeRegionExpr(target_buffer, ranges, 1));
-        args.push_back(MakeRegionExpr(target_buffer, ranges, 2));
-        args.push_back(IntImm(DataType::Int(32), allgather_size)); // size
-        args.push_back(
-            IntImm(DataType::Int(32), i * mesh_ncol + j)); // src_core
-        args.push_back(1); // direction: vertical
-        Stmt bcast_stmt =
-            Evaluate(Call(DataType::Handle(), broadcast_(), args));
-        bcast_stmts.push_back(bcast_stmt);
+      for (int i = 0; i < mesh_nrow; i++) {
+        // slab index `i` covers slots [i*ncol .. (i+1)*ncol) of phase 1;
+        // offset along slice_axis is i * row_extent = i*ncol * slot_extent_p1.
+        emit(make_slab(/*slot_index=*/i, row_extent), row_size_imm,
+             /*src_core=*/i * mesh_ncol + j, /*bcast_dir=*/1,
+             /*src_from_send=*/false);
       }
     }
   }
+
   return SeqStmt::Flatten(bcast_stmts);
 }
 
 TIR_REGISTER_TL_TILE_OP(AllgatherOp, comm_allgather)
-    .set_num_inputs(4)
+    .set_num_inputs(5)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));
 

--- a/src/op/comm.cc
+++ b/src/op/comm.cc
@@ -585,8 +585,7 @@ Stmt AllgatherOpNode::Lower(const LowerArgs &T,
   }
   int slice_axis = (axis > 0) ? (recv_rank - 1) : 0;
   ICHECK(analyzer->CanProve(FloorMod(recv_range[slice_axis]->extent,
-                                     IntImm(DataType::Int(32), recv_num)) ==
-                            0))
+                                     IntImm(DataType::Int(32), recv_num)) == 0))
       << "Recv extent along slice axis " << slice_axis << " ("
       << recv_range[slice_axis]->extent << ") must be divisible by recv_num ("
       << recv_num << ").";

--- a/src/op/comm.h
+++ b/src/op/comm.h
@@ -24,7 +24,6 @@ public:
   Array<Range> src_range, dst_range;
   PrimExpr src_expr, dst_expr;
   IntImm size;
-  IntImm dst_offset;
   PrimExpr src_core;
   int direction;
 
@@ -38,10 +37,7 @@ public:
         .def_ro("dst", &BroadcastOpNode::dst)
         .def_ro("src_range", &BroadcastOpNode::src_range)
         .def_ro("dst_range", &BroadcastOpNode::dst_range)
-        .def_ro("src_core", &BroadcastOpNode::src_core)
-        // .def_ro("direction", &BroadcastOpNode::direction)
-        // .def_ro("size", &BroadcastOpNode::size)
-        .def_ro("dst_offset", &BroadcastOpNode::dst_offset);
+        .def_ro("src_core", &BroadcastOpNode::src_core);
   }
 
   TileOperator Clone() const override;
@@ -99,6 +95,10 @@ public:
   PrimExpr send, recv;
   int direction;
   IntImm size;
+  // -1 sentinel = legacy mode (recv has an extra leading axis of length K).
+  // Otherwise the (already-normalized non-negative) axis along which recv
+  // concatenates the K per-core contributions.
+  int axis;
 
   TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tl.comm_allgather", AllgatherOpNode,
                                     TileOperatorNode);

--- a/testing/python/language/test_tilelang_language_comm.py
+++ b/testing/python/language/test_tilelang_language_comm.py
@@ -15,9 +15,11 @@ from tilelang.utils.target import determine_target
 )
 def test_comm_python_api(M, N, block_M, block_N, dtype, accum_dtype):
     func_str = """
-        T.comm_broadcast(A_shared[0:128, 0:128], B_shared[0:128, 0:128], -1, 0, 6, 2)
+        T.comm_broadcast(A_shared[0:128, 0:128], B_shared[0:128, 0:128], -1, 6, 2)
         T.comm_put(A_shared[0:128, 0:128], B_shared[0:128, 0:128], -1, 6, 11)
-        T.comm_allgather(A_shared[0:128, 0:128], C_shared[0:16, 0:128, 0:128], 2, -1)""".strip()
+        T.comm_allgather(A_shared[0:128, 0:128], C_shared[0:16, 0:128, 0:128], 2, -1, -1)
+        T.comm_allgather(A_shared[0:128, 0:128], R0_shared[0:2048, 0:128], 2, -1, 0)
+        T.comm_allgather(A_shared[0:128, 0:128], R1_shared[0:128, 0:2048], 2, -1, 1)""".strip()
 
     @T.prim_func
     def main(
@@ -27,11 +29,15 @@ def test_comm_python_api(M, N, block_M, block_N, dtype, accum_dtype):
             A_shared = T.alloc_shared([block_M, block_N], dtype, scope="shared.rsram")
             B_shared = T.alloc_shared([block_M, block_N], dtype, scope="shared.rsram")
             C_shared = T.alloc_shared([16, block_M, block_N], dtype, scope="shared.rsram")
+            R0_shared = T.alloc_shared([16 * block_M, block_N], dtype, scope="shared.rsram")
+            R1_shared = T.alloc_shared([block_M, 16 * block_N], dtype, scope="shared.rsram")
             T.copy(A[by * block_M, bx * block_N], A_shared)
 
             T.comm.broadcast(A_shared, B_shared, (1, 2), direction="all")
             T.comm.put(A_shared, B_shared, (1, 2), (2, 3))
             T.comm.all_gather(A_shared, C_shared, direction="all")
+            T.comm.all_gather(A_shared, R0_shared, direction="all", axis=0)
+            T.comm.all_gather(A_shared, R1_shared, direction="all", axis=-1)
 
     assert main.script()[-len(func_str) :] == func_str, "The generated script does not match the expected output."
 
@@ -97,7 +103,6 @@ def test_comm_broadcast_lower_custom_mesh(M, N, block_M, block_N, dtype):
                     A_shared[0:128, 0:128],
                     B_shared[0:128, 0:128],
                     -1,
-                    0,
                     5,
                     2,
                 )
@@ -149,22 +154,22 @@ def test_comm_put_lower(M, N, block_M, block_N, dtype, accum_dtype):
 )
 def test_comm_all_gather_lower(M, N, block_M, block_N, dtype, accum_dtype):
     func_str = """
-            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(C_shared[0, 0, 0], 2, 16, 128, 128), 16384, 0, 0)
-            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(C_shared[0, 0, 0], 2, 16, 128, 128), 16384, 1, 0)
-            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(C_shared[0, 0, 0], 2, 16, 128, 128), 16384, 2, 0)
-            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(C_shared[0, 0, 0], 2, 16, 128, 128), 16384, 3, 0)
-            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(C_shared[0, 0, 0], 2, 16, 128, 128), 16384, 4, 0)
-            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(C_shared[0, 0, 0], 2, 16, 128, 128), 16384, 5, 0)
-            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(C_shared[0, 0, 0], 2, 16, 128, 128), 16384, 6, 0)
-            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(C_shared[0, 0, 0], 2, 16, 128, 128), 16384, 7, 0)
-            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(C_shared[0, 0, 0], 2, 16, 128, 128), 16384, 8, 0)
-            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(C_shared[0, 0, 0], 2, 16, 128, 128), 16384, 9, 0)
-            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(C_shared[0, 0, 0], 2, 16, 128, 128), 16384, 10, 0)
-            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(C_shared[0, 0, 0], 2, 16, 128, 128), 16384, 11, 0)
-            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(C_shared[0, 0, 0], 2, 16, 128, 128), 16384, 12, 0)
-            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(C_shared[0, 0, 0], 2, 16, 128, 128), 16384, 13, 0)
-            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(C_shared[0, 0, 0], 2, 16, 128, 128), 16384, 14, 0)
-            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(C_shared[0, 0, 0], 2, 16, 128, 128), 16384, 15, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(C_shared[0, 0, 0], 2, 1, 128, 128), 16384, 0, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(C_shared[1, 0, 0], 2, 1, 128, 128), 16384, 1, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(C_shared[2, 0, 0], 2, 1, 128, 128), 16384, 2, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(C_shared[3, 0, 0], 2, 1, 128, 128), 16384, 3, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(C_shared[4, 0, 0], 2, 1, 128, 128), 16384, 4, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(C_shared[5, 0, 0], 2, 1, 128, 128), 16384, 5, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(C_shared[6, 0, 0], 2, 1, 128, 128), 16384, 6, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(C_shared[7, 0, 0], 2, 1, 128, 128), 16384, 7, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(C_shared[8, 0, 0], 2, 1, 128, 128), 16384, 8, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(C_shared[9, 0, 0], 2, 1, 128, 128), 16384, 9, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(C_shared[10, 0, 0], 2, 1, 128, 128), 16384, 10, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(C_shared[11, 0, 0], 2, 1, 128, 128), 16384, 11, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(C_shared[12, 0, 0], 2, 1, 128, 128), 16384, 12, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(C_shared[13, 0, 0], 2, 1, 128, 128), 16384, 13, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(C_shared[14, 0, 0], 2, 1, 128, 128), 16384, 14, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(C_shared[15, 0, 0], 2, 1, 128, 128), 16384, 15, 0)
             T.broadcast_(T.region(C_shared[0, 0, 0], 1, 4, 128, 128), T.region(C_shared[0, 0, 0], 2, 4, 128, 128), 65536, 0, 1)
             T.broadcast_(T.region(C_shared[4, 0, 0], 1, 4, 128, 128), T.region(C_shared[4, 0, 0], 2, 4, 128, 128), 65536, 4, 1)
             T.broadcast_(T.region(C_shared[8, 0, 0], 1, 4, 128, 128), T.region(C_shared[8, 0, 0], 2, 4, 128, 128), 65536, 8, 1)
@@ -192,6 +197,173 @@ def test_comm_all_gather_lower(M, N, block_M, block_N, dtype, accum_dtype):
             T.copy(A[by * block_M, bx * block_N], A_shared)
 
             T.comm.all_gather(A_shared, C_shared, direction="all")
+
+    mod = tvm.IRModule({"main": main})
+    target = determine_target("Sunmmio", return_object=True)
+    with tvm.target.Target(target):
+        mod = tvm.tir.transform.BindTarget(target)(mod)
+        mod = tilelang.transform.LowerTileOp()(mod)
+        assert mod.script()[-len(func_str) :] == func_str, "The generated script does not match the expected output."
+
+
+@pytest.mark.parametrize(
+    "M, N, block_M, block_N, dtype",
+    [
+        (1024, 1024, 128, 128, "float16"),
+    ],
+)
+def test_comm_all_gather_axis0_all_lower(M, N, block_M, block_N, dtype):
+    func_str = """
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(R_shared[0, 0], 2, 128, 128), 16384, 0, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(R_shared[128, 0], 2, 128, 128), 16384, 1, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(R_shared[256, 0], 2, 128, 128), 16384, 2, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(R_shared[384, 0], 2, 128, 128), 16384, 3, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(R_shared[512, 0], 2, 128, 128), 16384, 4, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(R_shared[640, 0], 2, 128, 128), 16384, 5, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(R_shared[768, 0], 2, 128, 128), 16384, 6, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(R_shared[896, 0], 2, 128, 128), 16384, 7, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(R_shared[1024, 0], 2, 128, 128), 16384, 8, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(R_shared[1152, 0], 2, 128, 128), 16384, 9, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(R_shared[1280, 0], 2, 128, 128), 16384, 10, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(R_shared[1408, 0], 2, 128, 128), 16384, 11, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(R_shared[1536, 0], 2, 128, 128), 16384, 12, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(R_shared[1664, 0], 2, 128, 128), 16384, 13, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(R_shared[1792, 0], 2, 128, 128), 16384, 14, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(R_shared[1920, 0], 2, 128, 128), 16384, 15, 0)
+            T.broadcast_(T.region(R_shared[0, 0], 1, 512, 128), T.region(R_shared[0, 0], 2, 512, 128), 65536, 0, 1)
+            T.broadcast_(T.region(R_shared[512, 0], 1, 512, 128), T.region(R_shared[512, 0], 2, 512, 128), 65536, 4, 1)
+            T.broadcast_(T.region(R_shared[1024, 0], 1, 512, 128), T.region(R_shared[1024, 0], 2, 512, 128), 65536, 8, 1)
+            T.broadcast_(T.region(R_shared[1536, 0], 1, 512, 128), T.region(R_shared[1536, 0], 2, 512, 128), 65536, 12, 1)
+            T.broadcast_(T.region(R_shared[0, 0], 1, 512, 128), T.region(R_shared[0, 0], 2, 512, 128), 65536, 1, 1)
+            T.broadcast_(T.region(R_shared[512, 0], 1, 512, 128), T.region(R_shared[512, 0], 2, 512, 128), 65536, 5, 1)
+            T.broadcast_(T.region(R_shared[1024, 0], 1, 512, 128), T.region(R_shared[1024, 0], 2, 512, 128), 65536, 9, 1)
+            T.broadcast_(T.region(R_shared[1536, 0], 1, 512, 128), T.region(R_shared[1536, 0], 2, 512, 128), 65536, 13, 1)
+            T.broadcast_(T.region(R_shared[0, 0], 1, 512, 128), T.region(R_shared[0, 0], 2, 512, 128), 65536, 2, 1)
+            T.broadcast_(T.region(R_shared[512, 0], 1, 512, 128), T.region(R_shared[512, 0], 2, 512, 128), 65536, 6, 1)
+            T.broadcast_(T.region(R_shared[1024, 0], 1, 512, 128), T.region(R_shared[1024, 0], 2, 512, 128), 65536, 10, 1)
+            T.broadcast_(T.region(R_shared[1536, 0], 1, 512, 128), T.region(R_shared[1536, 0], 2, 512, 128), 65536, 14, 1)
+            T.broadcast_(T.region(R_shared[0, 0], 1, 512, 128), T.region(R_shared[0, 0], 2, 512, 128), 65536, 3, 1)
+            T.broadcast_(T.region(R_shared[512, 0], 1, 512, 128), T.region(R_shared[512, 0], 2, 512, 128), 65536, 7, 1)
+            T.broadcast_(T.region(R_shared[1024, 0], 1, 512, 128), T.region(R_shared[1024, 0], 2, 512, 128), 65536, 11, 1)
+            T.broadcast_(T.region(R_shared[1536, 0], 1, 512, 128), T.region(R_shared[1536, 0], 2, 512, 128), 65536, 15, 1)""".strip()
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, N), dtype),
+    ):
+        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=128) as (bx, by):
+            A_shared = T.alloc_shared([block_M, block_N], dtype, scope="shared.rsram")
+            # 4x4 mesh -> 16 cores gathered along axis=0: [16 * block_M, block_N]
+            R_shared = T.alloc_shared([16 * block_M, block_N], dtype, scope="shared.rsram")
+            T.copy(A[by * block_M, bx * block_N], A_shared)
+
+            T.comm.all_gather(A_shared, R_shared, direction="all", axis=0)
+
+    mod = tvm.IRModule({"main": main})
+    target = determine_target("Sunmmio", return_object=True)
+    with tvm.target.Target(target):
+        mod = tvm.tir.transform.BindTarget(target)(mod)
+        mod = tilelang.transform.LowerTileOp()(mod)
+        assert mod.script()[-len(func_str) :] == func_str, "The generated script does not match the expected output."
+
+
+@pytest.mark.parametrize(
+    "M, N, block_M, block_N, dtype",
+    [
+        (1024, 1024, 128, 128, "float16"),
+    ],
+)
+def test_comm_all_gather_axis_last_horizontal_lower(M, N, block_M, block_N, dtype):
+    func_str = """
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(R_shared[0, 0], 2, 128, 128), 16384, 0, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(R_shared[0, 128], 2, 128, 128), 16384, 1, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(R_shared[0, 256], 2, 128, 128), 16384, 2, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(R_shared[0, 384], 2, 128, 128), 16384, 3, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(R_shared[0, 0], 2, 128, 128), 16384, 4, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(R_shared[0, 128], 2, 128, 128), 16384, 5, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(R_shared[0, 256], 2, 128, 128), 16384, 6, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(R_shared[0, 384], 2, 128, 128), 16384, 7, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(R_shared[0, 0], 2, 128, 128), 16384, 8, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(R_shared[0, 128], 2, 128, 128), 16384, 9, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(R_shared[0, 256], 2, 128, 128), 16384, 10, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(R_shared[0, 384], 2, 128, 128), 16384, 11, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(R_shared[0, 0], 2, 128, 128), 16384, 12, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(R_shared[0, 128], 2, 128, 128), 16384, 13, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(R_shared[0, 256], 2, 128, 128), 16384, 14, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(R_shared[0, 384], 2, 128, 128), 16384, 15, 0)""".strip()
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, N), dtype),
+    ):
+        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=128) as (bx, by):
+            A_shared = T.alloc_shared([block_M, block_N], dtype, scope="shared.rsram")
+            # Horizontal allgather (K = mesh_ncol = 4) along last axis: [block_M, 4 * block_N]
+            R_shared = T.alloc_shared([block_M, 4 * block_N], dtype, scope="shared.rsram")
+            T.copy(A[by * block_M, bx * block_N], A_shared)
+
+            T.comm.all_gather(A_shared, R_shared, direction="horizontal", axis=-1)
+
+    mod = tvm.IRModule({"main": main})
+    target = determine_target("Sunmmio", return_object=True)
+    with tvm.target.Target(target):
+        mod = tvm.tir.transform.BindTarget(target)(mod)
+        mod = tilelang.transform.LowerTileOp()(mod)
+        assert mod.script()[-len(func_str) :] == func_str, "The generated script does not match the expected output."
+
+
+@pytest.mark.parametrize(
+    "M, N, block_M, block_N, dtype",
+    [
+        (1024, 1024, 128, 128, "float16"),
+    ],
+)
+def test_comm_all_gather_axis_last_all_lower(M, N, block_M, block_N, dtype):
+    func_str = """
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(R_shared[0, 0], 2, 128, 128), 16384, 0, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(R_shared[0, 128], 2, 128, 128), 16384, 1, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(R_shared[0, 256], 2, 128, 128), 16384, 2, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(R_shared[0, 384], 2, 128, 128), 16384, 3, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(R_shared[0, 512], 2, 128, 128), 16384, 4, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(R_shared[0, 640], 2, 128, 128), 16384, 5, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(R_shared[0, 768], 2, 128, 128), 16384, 6, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(R_shared[0, 896], 2, 128, 128), 16384, 7, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(R_shared[0, 1024], 2, 128, 128), 16384, 8, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(R_shared[0, 1152], 2, 128, 128), 16384, 9, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(R_shared[0, 1280], 2, 128, 128), 16384, 10, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(R_shared[0, 1408], 2, 128, 128), 16384, 11, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(R_shared[0, 1536], 2, 128, 128), 16384, 12, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(R_shared[0, 1664], 2, 128, 128), 16384, 13, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(R_shared[0, 1792], 2, 128, 128), 16384, 14, 0)
+            T.broadcast_(T.region(A_shared[0, 0], 1, 128, 128), T.region(R_shared[0, 1920], 2, 128, 128), 16384, 15, 0)
+            T.broadcast_(T.region(R_shared[0, 0], 1, 128, 512), T.region(R_shared[0, 0], 2, 128, 512), 65536, 0, 1)
+            T.broadcast_(T.region(R_shared[0, 512], 1, 128, 512), T.region(R_shared[0, 512], 2, 128, 512), 65536, 4, 1)
+            T.broadcast_(T.region(R_shared[0, 1024], 1, 128, 512), T.region(R_shared[0, 1024], 2, 128, 512), 65536, 8, 1)
+            T.broadcast_(T.region(R_shared[0, 1536], 1, 128, 512), T.region(R_shared[0, 1536], 2, 128, 512), 65536, 12, 1)
+            T.broadcast_(T.region(R_shared[0, 0], 1, 128, 512), T.region(R_shared[0, 0], 2, 128, 512), 65536, 1, 1)
+            T.broadcast_(T.region(R_shared[0, 512], 1, 128, 512), T.region(R_shared[0, 512], 2, 128, 512), 65536, 5, 1)
+            T.broadcast_(T.region(R_shared[0, 1024], 1, 128, 512), T.region(R_shared[0, 1024], 2, 128, 512), 65536, 9, 1)
+            T.broadcast_(T.region(R_shared[0, 1536], 1, 128, 512), T.region(R_shared[0, 1536], 2, 128, 512), 65536, 13, 1)
+            T.broadcast_(T.region(R_shared[0, 0], 1, 128, 512), T.region(R_shared[0, 0], 2, 128, 512), 65536, 2, 1)
+            T.broadcast_(T.region(R_shared[0, 512], 1, 128, 512), T.region(R_shared[0, 512], 2, 128, 512), 65536, 6, 1)
+            T.broadcast_(T.region(R_shared[0, 1024], 1, 128, 512), T.region(R_shared[0, 1024], 2, 128, 512), 65536, 10, 1)
+            T.broadcast_(T.region(R_shared[0, 1536], 1, 128, 512), T.region(R_shared[0, 1536], 2, 128, 512), 65536, 14, 1)
+            T.broadcast_(T.region(R_shared[0, 0], 1, 128, 512), T.region(R_shared[0, 0], 2, 128, 512), 65536, 3, 1)
+            T.broadcast_(T.region(R_shared[0, 512], 1, 128, 512), T.region(R_shared[0, 512], 2, 128, 512), 65536, 7, 1)
+            T.broadcast_(T.region(R_shared[0, 1024], 1, 128, 512), T.region(R_shared[0, 1024], 2, 128, 512), 65536, 11, 1)
+            T.broadcast_(T.region(R_shared[0, 1536], 1, 128, 512), T.region(R_shared[0, 1536], 2, 128, 512), 65536, 15, 1)""".strip()
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, N), dtype),
+    ):
+        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=128) as (bx, by):
+            A_shared = T.alloc_shared([block_M, block_N], dtype, scope="shared.rsram")
+            # All direction (K = 16) gathered along last axis: [block_M, 16 * block_N]
+            R_shared = T.alloc_shared([block_M, 16 * block_N], dtype, scope="shared.rsram")
+            T.copy(A[by * block_M, bx * block_N], A_shared)
+
+            T.comm.all_gather(A_shared, R_shared, direction="all", axis=-1)
 
     mod = tvm.IRModule({"main": main})
     target = determine_target("Sunmmio", return_object=True)
@@ -290,4 +462,7 @@ if __name__ == "__main__":
     test_comm_broadcast_lower(1024, 1024, 128, 128, "float16", "float")
     test_comm_put_lower(1024, 1024, 128, 128, "float16", "float")
     test_comm_all_gather_lower(1024, 1024, 128, 128, "float16", "float")
+    test_comm_all_gather_axis0_all_lower(1024, 1024, 128, 128, "float16")
+    test_comm_all_gather_axis_last_horizontal_lower(1024, 1024, 128, 128, "float16")
+    test_comm_all_gather_axis_last_all_lower(1024, 1024, 128, 128, "float16")
     # test_comm_all_reduce_lower(1024 * 128, 1024 * 128, 1024, 1024, "float16", "float")

--- a/tilelang/language/comm.py
+++ b/tilelang/language/comm.py
@@ -336,9 +336,7 @@ def all_gather(
         expected_recv_shape = [recv_num] + list(send_buffer.shape)
     else:
         ndim = len(send_buffer.shape)
-        assert isinstance(axis, int) and -ndim <= axis < ndim, (
-            f"axis {axis} out of range for send buffer with {ndim} dimensions."
-        )
+        assert isinstance(axis, int) and -ndim <= axis < ndim, f"axis {axis} out of range for send buffer with {ndim} dimensions."
         normalized_axis = axis if axis >= 0 else axis + ndim
         assert normalized_axis == 0 or normalized_axis == ndim - 1, (
             f"Only axis=0 or axis=-1 (last dim) are currently supported, got axis={axis} "

--- a/tilelang/language/comm.py
+++ b/tilelang/language/comm.py
@@ -200,13 +200,11 @@ def broadcast(
     src_region = to_buffer_region(src)
     dst_region = to_buffer_region(dst)
     src_core_id = core_tuple_to_id(src_core)
-    dst_offset = 0  # Always 0 for now
 
     args = (
         src_region,
         dst_region,
         size,
-        dst_offset,
         src_core_id,
         DIRECTION_MAP[direction.lower()],
     )
@@ -280,6 +278,7 @@ def all_gather(
     recv_buffer: T.Buffer,
     direction: Literal["horizontal", "h", "vertical", "v", "all", "a"] = "all",
     size: int = -1,
+    axis: int | None = None,
 ):
     """Perform an all-gather operation from a send buffer to a receive buffer
     by emitting the TIR intrinsic tl.tileop.comm_allgather.
@@ -294,6 +293,14 @@ def all_gather(
         and "all" (or "a") for all cores.
     size : int
         Number of elements to send from each core. If -1, the entire send buffer is used.
+    axis : int, optional
+        Axis along which gathered data is concatenated. When ``axis`` is ``None``
+        (default), a new leading axis is introduced and ``recv_buffer`` must have
+        shape ``[K, *send_buffer.shape]`` where ``K`` is the number of contributing
+        cores. When ``axis`` is an integer, gathered data is concatenated along
+        that existing axis: ``recv_buffer.shape[axis] == K * send_buffer.shape[axis]``
+        and all other dimensions match ``send_buffer``. Only ``axis=0`` and
+        ``axis=-1`` (the last dim) are currently supported.
     Returns
     -------
     tir.Call
@@ -301,6 +308,10 @@ def all_gather(
     Examples
     --------
     >>> all_gather(A_local, C_local, direction="horizontal")
+    >>> # send [d0, d1], 4-col mesh, axis=0 -> recv [4*d0, d1]
+    >>> all_gather(A_local, R_local, direction="horizontal", axis=0)
+    >>> # send [d0, d1], 4-col mesh, axis=-1 -> recv [d0, 4*d1]
+    >>> all_gather(A_local, R_local, direction="horizontal", axis=-1)
     """
     assert direction.lower() in DIRECTION_MAP, f"Invalid direction string: {direction}"
 
@@ -317,7 +328,26 @@ def all_gather(
     elif direction.lower() in ["all", "a"]:
         recv_num = mesh_shape["nrow"] * mesh_shape["ncol"]
 
-    expected_recv_shape = [recv_num] + list(send_buffer.shape)
+    # Sentinel -1 in the wire format means "no axis specified" (legacy
+    # new-leading-axis semantics). User-facing axis is normalized to a
+    # non-negative index before being forwarded.
+    if axis is None:
+        axis_arg = -1
+        expected_recv_shape = [recv_num] + list(send_buffer.shape)
+    else:
+        ndim = len(send_buffer.shape)
+        assert isinstance(axis, int) and -ndim <= axis < ndim, (
+            f"axis {axis} out of range for send buffer with {ndim} dimensions."
+        )
+        normalized_axis = axis if axis >= 0 else axis + ndim
+        assert normalized_axis == 0 or normalized_axis == ndim - 1, (
+            f"Only axis=0 or axis=-1 (last dim) are currently supported, got axis={axis} "
+            f"(normalized to {normalized_axis}) for {ndim}-D send buffer."
+        )
+        axis_arg = normalized_axis
+        expected_recv_shape = list(send_buffer.shape)
+        expected_recv_shape[normalized_axis] = recv_num * send_buffer.shape[normalized_axis]
+
     assert list(recv_buffer.shape) == expected_recv_shape, (
         f"Receive buffer shape must be {expected_recv_shape} to hold gathered data from {recv_num} cores, but got {recv_buffer.shape}."
     )
@@ -336,6 +366,7 @@ def all_gather(
         recv_buffer_region,
         DIRECTION_MAP[direction.lower()],
         size,
+        axis_arg,
     )
     return tir.call_intrin("handle", tir.op.Op.get("tl.tileop.comm_allgather"), *args)
 


### PR DESCRIPTION
1. Add axis argument for T.comm.all gather, so as to support `[d0, d1]` gathered to `[d0, world_size * d1]`
2. Remove dst offset argument from Broadcast Op