### PR TITLE
[Fix] Fix buffer_decl mismatch after split_host_device

### DIFF
--- a/src/transform/split_host_device.cc
+++ b/src/transform/split_host_device.cc
@@ -328,6 +328,62 @@ private:
     return RemapSimpleAttrValue(value, var_remap, remap_buffer);
   }
 
+  class BufferRefReplacer : public tir::StmtExprMutator {
+  public:
+    explicit BufferRefReplacer(Map<tir::Buffer, tir::Buffer> buffer_remap)
+        : buffer_remap_(std::move(buffer_remap)) {}
+
+  private:
+    tir::Buffer RemapBuffer(const tir::Buffer &buffer) {
+      if (buffer_remap_.count(buffer)) {
+        return buffer_remap_[buffer];
+      }
+      return buffer;
+    }
+
+    PrimExpr VisitExpr_(const tir::BufferLoadNode *op) final {
+      tir::BufferLoad load =
+          Downcast<tir::BufferLoad>(tir::StmtExprMutator::VisitExpr_(op));
+      tir::Buffer new_buffer = RemapBuffer(load->buffer);
+      if (!new_buffer.same_as(load->buffer)) {
+        load.CopyOnWrite()->buffer = new_buffer;
+      }
+      return load;
+    }
+
+    tir::Stmt VisitStmt_(const tir::BufferStoreNode *op) final {
+      tir::BufferStore store =
+          Downcast<tir::BufferStore>(tir::StmtExprMutator::VisitStmt_(op));
+      tir::Buffer new_buffer = RemapBuffer(store->buffer);
+      if (!new_buffer.same_as(store->buffer)) {
+        store.CopyOnWrite()->buffer = new_buffer;
+      }
+      return store;
+    }
+
+    tir::Stmt VisitStmt_(const tir::DeclBufferNode *op) final {
+      tir::DeclBuffer decl =
+          Downcast<tir::DeclBuffer>(tir::StmtExprMutator::VisitStmt_(op));
+      tir::Buffer new_buffer = RemapBuffer(decl->buffer);
+      if (!new_buffer.same_as(decl->buffer)) {
+        decl.CopyOnWrite()->buffer = new_buffer;
+      }
+      return decl;
+    }
+
+    tir::Stmt VisitStmt_(const tir::BufferRealizeNode *op) final {
+      tir::BufferRealize realize =
+          Downcast<tir::BufferRealize>(tir::StmtExprMutator::VisitStmt_(op));
+      tir::Buffer new_buffer = RemapBuffer(realize->buffer);
+      if (!new_buffer.same_as(realize->buffer)) {
+        realize.CopyOnWrite()->buffer = new_buffer;
+      }
+      return realize;
+    }
+
+    Map<tir::Buffer, tir::Buffer> buffer_remap_;
+  };
+
   tir::Stmt SplitDeviceFunc(tir::Stmt body, tvm::Target device_target) {
     // First, analyze undefined variables in the device body
     auto [old_params, buffers_to_declare] =
@@ -364,9 +420,6 @@ private:
       var_remap.Set(old_var, new_var);
       name_to_var[old_var->name_hint] = new_var;
     }
-
-    // Substitute old variables with new ones in the body
-    body = tir::Substitute(body, var_remap);
 
     // Remap buffers to use new variables.  Keep a cache so DeclBuffer and
     // function attributes that reference the same old Buffer also share the
@@ -406,6 +459,14 @@ private:
       new_buffers_to_declare.push_back(remap_buffer(buf));
     }
     buffers_to_declare = new_buffers_to_declare;
+
+    // Remap buffer references explicitly before substituting Vars.  The
+    // remapped buffers already contain the new parameter Vars, so Substitute
+    // will not create a second set of remapped Buffer objects.
+    body = BufferRefReplacer(buffer_remap)(body);
+
+    // Substitute old variables with new ones in the body
+    body = tir::Substitute(body, var_remap);
 
     // CodeGenCPU is used for some device-side targets, such as
     // "ext_dev", and expects to be able to return a int32_t status

--- a/testing/python/transform/test_tilelang_transform_sunmmio_split_host_device.py
+++ b/testing/python/transform/test_tilelang_transform_sunmmio_split_host_device.py
@@ -54,6 +54,28 @@ def get_param_by_name(func, name):
     return None
 
 
+def collect_declared_buffers(stmt):
+    buffers = []
+
+    def visit(node):
+        if isinstance(node, tir.DeclBuffer):
+            buffers.append(node.buffer)
+
+    tir.stmt_functor.post_order_visit(stmt, visit)
+    return buffers
+
+
+def collect_accessed_buffers(stmt):
+    buffers = []
+
+    def visit(node):
+        if isinstance(node, (tir.BufferLoad, tir.BufferStore)):
+            buffers.append(node.buffer)
+
+    tir.stmt_functor.post_order_visit(stmt, visit)
+    return buffers
+
+
 def run_sunmmio_split(mod, *, hoist=False):
     target = make_sunmmio_target_with_host()
     with tvm.target.Target(target):
@@ -130,6 +152,47 @@ def test_sunmmio_split_host_device_preserves_cute_layout_attr_type():
     assert list(remapped_layout.mode_shape) == list(layout.mode_shape)
     assert list(remapped_layout.mode_stride) == list(layout.mode_stride)
     assert list(remapped_layout.dim_levels) == list(layout.dim_levels)
+
+
+def test_sunmmio_split_host_device_decl_body_and_attrs_use_same_buffer():
+    @T.prim_func
+    def before(A: T.Buffer((16, 16), "float32")):
+        with T.Kernel(1):
+            A[0, 0] = A[0, 0]
+
+    func = before.with_attr("global_symbol", "main")
+    buffer = func.buffer_map[func.params[0]]
+    layout = CuteLayout([16, 16], [4, 4, 16], [64, 16, 1], [2, 1])._inner
+    func = (
+        func.with_attr("layout_map", {buffer: layout})
+        .with_attr("buffer_attr", buffer)
+        .with_attr("tl.device_func_attr_keys", ["layout_map", "buffer_attr"])
+    )
+
+    mod = run_sunmmio_split(tvm.IRModule.from_expr(func))
+    device_func = get_device_func(mod)
+
+    layout_buffer = next(iter(device_func.attrs["layout_map"].keys()))
+    attr_buffer = device_func.attrs["buffer_attr"]
+    assert isinstance(layout_buffer, tir.Buffer)
+    assert isinstance(attr_buffer, tir.Buffer)
+    assert layout_buffer.same_as(attr_buffer)
+
+    declared_buffers = collect_declared_buffers(device_func.body)
+    accessed_buffers = collect_accessed_buffers(device_func.body)
+    assert declared_buffers, "Expected device body to declare parameter buffers"
+    assert accessed_buffers, "Expected device body to access the parameter buffer"
+
+    declared_attr_buffers = [buffer for buffer in declared_buffers if buffer.name == attr_buffer.name]
+    accessed_attr_buffers = [buffer for buffer in accessed_buffers if buffer.name == attr_buffer.name]
+    assert declared_attr_buffers, "Expected DeclBuffer for the func_attr buffer"
+    assert accessed_attr_buffers, "Expected body accesses for the func_attr buffer"
+    assert all(buffer.same_as(attr_buffer) for buffer in declared_attr_buffers), (
+        "func_attr buffer should be the same object as every same-name DeclBuffer buffer"
+    )
+    assert all(buffer.same_as(attr_buffer) for buffer in accessed_attr_buffers), (
+        "func_attr buffer should be the same object as every same-name body access buffer"
+    )
 
 
 def test_sunmmio_split_host_device_remaps_marked_simple_attrs():


### PR DESCRIPTION
## Summary

Fix a bug after `split_host_device`.

Before this change, the buffer in `buffer_decl` inside `device_kernel` could be different from the buffer that was actually used by the device kernel.

This PR makes sure they use the same buffer.

## Tests

Added a regression test for this case.