### PR TITLE
[Feature][Codegen] Add  aligned 1d store support in Tile loops 

### DIFF
--- a/mlir_codegen/test_fill_sunmmio.py
+++ b/mlir_codegen/test_fill_sunmmio.py
@@ -49,6 +49,65 @@ def fill_tiled_test(B, M, N, block_B, block_M, block_N, tile_size, index_map, dt
     return main
 
 
+PYTEST_FILL_CONFIG = dict(
+    B=16,
+    M=256,
+    N=128,
+    block_B=16,
+    block_M=256,
+    block_N=128,
+    tile_size=(32, 32),
+    index_map=(-2, -1),
+)
+
+
+def build_pytest_fill_case(dtype="float16"):
+    return fill_tiled_test(dtype=dtype, **PYTEST_FILL_CONFIG)
+
+
+def compile_fill_case(func, log_dir):
+    log_dir = os.fspath(log_dir)
+    os.makedirs(log_dir, exist_ok=True)
+
+    host_mod, device_mod = compile_test(
+        func,
+        out_idx=[0],
+        target="Sunmmio",
+        log_pass_output=True,
+        log_dir=log_dir,
+    )
+    save_final_ast(log_dir, device_mod, echo=False)
+
+    target = determine_target("Sunmmio", return_object=True)
+    mlir_mod = tvm.get_global_func("target.build.tilelang_sunmmio_without_compile")(device_mod, target, "suvm")
+    mlir_source = mlir_mod.inspect_source()
+    mlir_path = save_final_mlir(log_dir, mlir_source, echo=False)
+    verify_final_mlir(log_dir, mlir_path)
+
+    return {
+        "host_mod": host_mod,
+        "device_mod": device_mod,
+        "log_dir": log_dir,
+        "mlir_source": mlir_source,
+        "mlir_path": mlir_path,
+    }
+
+
+def test_fill_lowers_to_tile_fill_and_tile_store(tmp_path):
+    result = compile_fill_case(build_pytest_fill_case(), tmp_path / "fill_lowering")
+    mlir_source = result["mlir_source"]
+    assert "suvm.tile.fill" in mlir_source
+    assert "suvm.tile.store" in mlir_source
+
+
+def test_fill_should_write_back_to_global_memory(tmp_path):
+    result = compile_fill_case(build_pytest_fill_case(), tmp_path / "fill_writeback")
+    mlir_source = result["mlir_source"]
+    assert "get_partitioned_tile_view %arg0" in mlir_source
+    assert "suvm.copy_async" in mlir_source
+    assert '{sunmmio.fake = "call"}' not in mlir_source
+
+
 B = 64
 M = 512
 N = 1024

--- a/mlir_codegen/test_fill_sunmmio.py
+++ b/mlir_codegen/test_fill_sunmmio.py
@@ -51,8 +51,9 @@ func.show()
 #     jit_kernel = tilelang.compile(func, target="Sunmmio", verbose=True)
 # except Exception as e:
 #     print(e)
-log_dir = "/home/cedu/projects/Tilelang-Mesh/tilelang_mesh/mlir_codegen/logs_fill_sunmmio"
 import os
+
+log_dir = os.path.join(os.path.dirname(__file__), "logs_fill_sunmmio")
 
 os.makedirs(log_dir, exist_ok=True)
 host_mod, device_mod = compile_test(func, out_idx=[2], target="Sunmmio", log_pass_output=True, log_dir=log_dir)

--- a/mlir_codegen/test_fill_sunmmio.py
+++ b/mlir_codegen/test_fill_sunmmio.py
@@ -1,5 +1,6 @@
 import tilelang
 import tilelang.language as T
+from tilelang.carver.arch import driver
 from tilelang.utils.target import determine_target
 from compile_pipeline import compile_test
 from sunmmio_test_utils import save_final_ast, save_final_mlir, verify_final_mlir
@@ -8,29 +9,42 @@ tilelang.env.disable_cache()
 
 
 def fill_tiled_test(B, M, N, block_B, block_M, block_N, tile_size, index_map, dtype="float16"):
+    device_mesh_config = driver.get_sunmmio_device_mesh_config()
+    nrows, ncols = device_mesh_config
+    ncores = nrows * ncols
+    grid_b = T.ceildiv(B, block_B)
+    grid_m = T.ceildiv(M, block_M)
+    grid_n = T.ceildiv(N, block_N)
+
     @T.prim_func
     def main(A: T.Tensor((B, M, N), dtype)):
-        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), T.ceildiv(B, block_B), threads=1) as (bx, by, bz):
+        with T.Kernel(ncores) as _cid:
             A_shared = T.alloc_shared((block_B, block_M, block_N), dtype)
             # T.annotate_tileview({A_shared: make_tileview(A_shared, tile_size, index_map)})
 
-            # 1. Fill the entire buffer
-            T.fill(A_shared, T.float16(1.0))
+            for bz in T.serial(grid_b):
+                for by in T.serial(grid_m):
+                    for bx in T.serial(grid_n):
+                        if (bz * grid_m * grid_n + by * grid_n + bx) % ncores == _cid:
+                            # 1. Fill the entire buffer
+                            T.fill(A_shared, T.float16(1.0))
 
-            # 2. Fill a region of the buffer (e.g., first half of M dimension)
-            # Region: A_shared[0:block_B, 0:block_M//2, 0:block_N]
-            # Since block_M=256, block_M//2 = 128. tile_size[0]=32, so 128 is divisible by 32.
-            # This should generate a loop over 4 tiles (128/32).
-            T.fill(A_shared[0:block_B, 0 : block_M // 2, 0:block_N], T.float16(2.0))
+                            # 2. Fill a region of the buffer (e.g., first half of M dimension)
+                            T.fill(A_shared[0:block_B, 0 : block_M // 2, 0:block_N], T.float16(2.0))
 
-            # 3. Fill a region with offset (e.g., second half of M dimension)
-            # Region: A_shared[0:block_B, block_M//2:block_M, 0:block_N]
-            # Offset is 128 (4 tiles), extent is 128 (4 tiles).
-            T.fill(A_shared[0:block_B, block_M // 2 : block_M, 0:block_N], T.float16(3.0))
+                            # 3. Fill a region with offset (e.g., second half of M dimension)
+                            T.fill(A_shared[0:block_B, block_M // 2 : block_M, 0:block_N], T.float16(3.0))
 
-            T.clear(A_shared)
+                            T.clear(A_shared)
 
-            T.copy(A_shared, A[bz * block_B : (bz + 1) * block_B, by * block_M : (by + 1) * block_M, bx * block_N : (bx + 1) * block_N])
+                            T.copy(
+                                A_shared,
+                                A[
+                                    bz * block_B : (bz + 1) * block_B,
+                                    by * block_M : (by + 1) * block_M,
+                                    bx * block_N : (bx + 1) * block_N,
+                                ],
+                            )
 
     return main
 

--- a/mlir_codegen/test_reduce_sunmmio.py
+++ b/mlir_codegen/test_reduce_sunmmio.py
@@ -70,6 +70,7 @@ import os
 
 import tilelang
 import tilelang.language as T
+from tilelang.carver.arch import driver
 from compile_pipeline import compile_test
 from sunmmio_test_utils import save_final_ast, save_final_mlir, verify_final_mlir
 from tilelang.utils.target import determine_target
@@ -145,30 +146,112 @@ def reduce_tiled_test(
 ):
     out_shape_full = (B, M) if reduce_axis == 2 else (B, N) if reduce_axis == 1 else (M, N)
     out_shape_block = (block_B, block_M) if reduce_axis == 2 else (block_B, block_N) if reduce_axis == 1 else (block_M, block_N)
+    device_mesh_config = driver.get_sunmmio_device_mesh_config()
+    nrows, ncols = device_mesh_config
+    ncores = nrows * ncols
+    grid_b = T.ceildiv(B, block_B)
+    grid_m = T.ceildiv(M, block_M)
+    grid_n = T.ceildiv(N, block_N)
 
     @T.prim_func
     def main(A: T.Tensor((B, M, N), dtype), Out: T.Tensor(out_shape_full, dtype)):
-        with T.Kernel(
-            T.ceildiv(N, block_N) if reduce_axis != 2 else T.ceildiv(M, block_M),
-            T.ceildiv(B, block_B) if reduce_axis != 0 else T.ceildiv(M, block_M),
-            threads=128,
-        ) as (bx, bz):
+        with T.Kernel(ncores) as _cid:
             A_shared = T.alloc_shared((block_B, block_M, block_N), dtype, scope="shared.rsram")
             Out_shared = T.alloc_shared(out_shape_block, dtype, scope="shared.rsram")
 
-            if reduce_axis != 0:
-                T.copy(A[bz * block_B : (bz + 1) * block_B, 0:block_M, 0:block_N], A_shared)
-            else:
-                T.copy(A[0:block_B, 0:block_M, 0:block_N], A_shared)
-
-            T.reduce_abssum(A_shared, Out_shared, dim=reduce_axis, clear=clear)
-
             if reduce_axis == 2:
-                T.copy(Out_shared, Out[bz * block_B : (bz + 1) * block_B, 0:block_M])
+                for bz in T.serial(grid_b):
+                    for by in T.serial(grid_m):
+                        if (bz * grid_m + by) % ncores == _cid:
+                            if clear:
+                                T.fill(Out_shared, 0)
+                            else:
+                                T.copy(
+                                    Out[
+                                        bz * block_B : (bz + 1) * block_B,
+                                        by * block_M : (by + 1) * block_M,
+                                    ],
+                                    Out_shared,
+                                )
+                            for bx in T.serial(grid_n):
+                                T.copy(
+                                    A[
+                                        bz * block_B : (bz + 1) * block_B,
+                                        by * block_M : (by + 1) * block_M,
+                                        bx * block_N : (bx + 1) * block_N,
+                                    ],
+                                    A_shared,
+                                )
+                                T.reduce_abssum(A_shared, Out_shared, dim=reduce_axis, clear=False)
+                            T.copy(
+                                Out_shared,
+                                Out[
+                                    bz * block_B : (bz + 1) * block_B,
+                                    by * block_M : (by + 1) * block_M,
+                                ],
+                            )
             elif reduce_axis == 1:
-                T.copy(Out_shared, Out[bz * block_B : (bz + 1) * block_B, 0:block_N])
+                for bz in T.serial(grid_b):
+                    for bx in T.serial(grid_n):
+                        if (bz * grid_n + bx) % ncores == _cid:
+                            if clear:
+                                T.fill(Out_shared, 0)
+                            else:
+                                T.copy(
+                                    Out[
+                                        bz * block_B : (bz + 1) * block_B,
+                                        bx * block_N : (bx + 1) * block_N,
+                                    ],
+                                    Out_shared,
+                                )
+                            for by in T.serial(grid_m):
+                                T.copy(
+                                    A[
+                                        bz * block_B : (bz + 1) * block_B,
+                                        by * block_M : (by + 1) * block_M,
+                                        bx * block_N : (bx + 1) * block_N,
+                                    ],
+                                    A_shared,
+                                )
+                                T.reduce_abssum(A_shared, Out_shared, dim=reduce_axis, clear=False)
+                            T.copy(
+                                Out_shared,
+                                Out[
+                                    bz * block_B : (bz + 1) * block_B,
+                                    bx * block_N : (bx + 1) * block_N,
+                                ],
+                            )
             else:
-                T.copy(Out_shared, Out[0:block_M, 0:block_N])
+                for by in T.serial(grid_m):
+                    for bx in T.serial(grid_n):
+                        if (by * grid_n + bx) % ncores == _cid:
+                            if clear:
+                                T.fill(Out_shared, 0)
+                            else:
+                                T.copy(
+                                    Out[
+                                        by * block_M : (by + 1) * block_M,
+                                        bx * block_N : (bx + 1) * block_N,
+                                    ],
+                                    Out_shared,
+                                )
+                            for bz in T.serial(grid_b):
+                                T.copy(
+                                    A[
+                                        bz * block_B : (bz + 1) * block_B,
+                                        by * block_M : (by + 1) * block_M,
+                                        bx * block_N : (bx + 1) * block_N,
+                                    ],
+                                    A_shared,
+                                )
+                                T.reduce_abssum(A_shared, Out_shared, dim=reduce_axis, clear=False)
+                            T.copy(
+                                Out_shared,
+                                Out[
+                                    by * block_M : (by + 1) * block_M,
+                                    bx * block_N : (bx + 1) * block_N,
+                                ],
+                            )
 
     return main
 

--- a/mlir_codegen/test_reduce_sunmmio.py
+++ b/mlir_codegen/test_reduce_sunmmio.py
@@ -67,7 +67,9 @@
 """
 
 import os
+import re
 
+import pytest
 import tilelang
 import tilelang.language as T
 from tilelang.carver.arch import driver
@@ -113,7 +115,28 @@ def clear_label(clear):
     return "clear_true" if clear else "clear_false"
 
 
-def reduce_kernel_builder(shape, reduce_axis, dtype="float16", clear=True):
+def apply_reduce_op(reduce_op, buffer, out, reduce_axis, clear):
+    if reduce_op == "sum":
+        T.reduce_sum(buffer, out, dim=reduce_axis, clear=clear)
+    elif reduce_op == "abssum":
+        T.reduce_abssum(buffer, out, dim=reduce_axis, clear=clear)
+    elif reduce_op == "max":
+        T.reduce_max(buffer, out, dim=reduce_axis, clear=clear)
+    elif reduce_op == "absmax":
+        T.reduce_absmax(buffer, out, dim=reduce_axis, clear=clear)
+    elif reduce_op == "min":
+        T.reduce_min(buffer, out, dim=reduce_axis, clear=clear)
+    elif reduce_op == "bitand":
+        T.reduce_bitand(buffer, out, dim=reduce_axis, clear=clear)
+    elif reduce_op == "bitor":
+        T.reduce_bitor(buffer, out, dim=reduce_axis, clear=clear)
+    elif reduce_op == "bitxor":
+        T.reduce_bitxor(buffer, out, dim=reduce_axis, clear=clear)
+    else:
+        raise ValueError(f"Unsupported TL_REDUCE_OP={reduce_op!r}")
+
+
+def reduce_kernel_builder(shape, reduce_axis, dtype="float16", clear=True, reduce_op="sum"):
     out_shape = list(shape[:reduce_axis]) + list(shape[reduce_axis + 1 :])
     if not out_shape:
         out_shape = [1]
@@ -125,7 +148,7 @@ def reduce_kernel_builder(shape, reduce_axis, dtype="float16", clear=True):
             Out_shared = T.alloc_shared(out_shape, dtype, scope="shared.rsram")
 
             T.copy(A, A_shared)
-            T.reduce_sum(A_shared, Out_shared, dim=reduce_axis, clear=clear)
+            apply_reduce_op(reduce_op, A_shared, Out_shared, reduce_axis, clear)
             T.copy(Out_shared, Out)
 
     return main
@@ -143,6 +166,7 @@ def reduce_tiled_test(
     reduce_axis,
     dtype="float16",
     clear=False,
+    reduce_op="abssum",
 ):
     out_shape_full = (B, M) if reduce_axis == 2 else (B, N) if reduce_axis == 1 else (M, N)
     out_shape_block = (block_B, block_M) if reduce_axis == 2 else (block_B, block_N) if reduce_axis == 1 else (block_M, block_N)
@@ -182,7 +206,7 @@ def reduce_tiled_test(
                                     ],
                                     A_shared,
                                 )
-                                T.reduce_abssum(A_shared, Out_shared, dim=reduce_axis, clear=False)
+                                apply_reduce_op(reduce_op, A_shared, Out_shared, reduce_axis, clear=False)
                             T.copy(
                                 Out_shared,
                                 Out[
@@ -213,7 +237,7 @@ def reduce_tiled_test(
                                     ],
                                     A_shared,
                                 )
-                                T.reduce_abssum(A_shared, Out_shared, dim=reduce_axis, clear=False)
+                                apply_reduce_op(reduce_op, A_shared, Out_shared, reduce_axis, clear=False)
                             T.copy(
                                 Out_shared,
                                 Out[
@@ -244,7 +268,7 @@ def reduce_tiled_test(
                                     ],
                                     A_shared,
                                 )
-                                T.reduce_abssum(A_shared, Out_shared, dim=reduce_axis, clear=False)
+                                apply_reduce_op(reduce_op, A_shared, Out_shared, reduce_axis, clear=False)
                             T.copy(
                                 Out_shared,
                                 Out[
@@ -259,8 +283,11 @@ def reduce_tiled_test(
 def build_case():
     case = os.environ.get("TL_REDUCE_CASE", "tiled3d")
     dtype = os.environ.get("TL_REDUCE_DTYPE", "float16")
+    reduce_op_env = os.environ.get("TL_REDUCE_OP")
 
     if case == "tiled3d":
+        default_reduce_op = "abssum"
+        reduce_op = reduce_op_env or default_reduce_op
         B, M, N = 64, 512, 1024
         block_B, block_M, block_N = 32, 256, 128
         tile_size = (4, 32)
@@ -279,17 +306,125 @@ def build_case():
             reduce_axis=reduce_axis,
             dtype=dtype,
             clear=clear,
+            reduce_op=reduce_op,
         )
-        label = f"tiled3d_axis{reduce_axis}_{clear_label(clear)}"
+        op_suffix = f"_{reduce_op}" if reduce_op_env is not None else ""
+        label = f"tiled3d{op_suffix}_axis{reduce_axis}_{clear_label(clear)}"
         expected_in_tile = reduce_axis in (1, 2)
         return label, func, expected_in_tile, clear
 
+    default_reduce_op = "sum"
+    reduce_op = reduce_op_env or default_reduce_op
     case_index = int(case)
     shape, reduce_axis, expected_in_tile, clear = REDUCE_TEST_CASES[case_index]
     clear = parse_bool_env("TL_REDUCE_CLEAR", clear)
-    func = reduce_kernel_builder(shape, reduce_axis, dtype=dtype, clear=clear)
-    label = f"shape{case_index}_axis{reduce_axis}_{'x'.join(map(str, shape))}_{clear_label(clear)}"
+    func = reduce_kernel_builder(shape, reduce_axis, dtype=dtype, clear=clear, reduce_op=reduce_op)
+    op_suffix = f"_{reduce_op}" if reduce_op_env is not None else ""
+    label = f"shape{case_index}{op_suffix}_axis{reduce_axis}_{'x'.join(map(str, shape))}_{clear_label(clear)}"
     return label, func, expected_in_tile, clear
+
+
+PYTEST_TILED_REDUCE_CONFIG = dict(
+    B=32,
+    M=256,
+    N=128,
+    block_B=32,
+    block_M=256,
+    block_N=128,
+    tile_size=(4, 32),
+    index_map=(-2, -1),
+    reduce_axis=1,
+    clear=False,
+)
+
+PREVIOUS_OUTPUT_ABS_RE = re.compile(
+    r"suvm\.tile\.load .*-> !suvm\.tile<1x32x[^>]+>\n"
+    r"\s+%[0-9]+ = suvm\.tile\.abs %[0-9]+ : !suvm\.tile<1x32x[^>]+> -> !suvm\.tile<1x32x[^>]+>",
+    re.MULTILINE,
+)
+
+
+def build_pytest_tiled_reduce_case(reduce_op, dtype):
+    return reduce_tiled_test(
+        reduce_op=reduce_op,
+        dtype=dtype,
+        **PYTEST_TILED_REDUCE_CONFIG,
+    )
+
+
+def compile_case(func, log_dir, run_codegen=True):
+    log_dir = os.fspath(log_dir)
+    os.makedirs(log_dir, exist_ok=True)
+
+    host_mod, device_mod = compile_test(
+        func,
+        out_idx=[1],
+        target="Sunmmio",
+        log_pass_output=True,
+        log_dir=log_dir,
+    )
+    save_final_ast(log_dir, device_mod, echo=False)
+
+    result = {
+        "host_mod": host_mod,
+        "device_mod": device_mod,
+        "log_dir": log_dir,
+    }
+
+    if not run_codegen:
+        return result
+
+    target = determine_target("Sunmmio", return_object=True)
+    mlir_mod = tvm.get_global_func("target.build.tilelang_sunmmio_without_compile")(device_mod, target, "suvm")
+    mlir_source = mlir_mod.inspect_source()
+    mlir_path = save_final_mlir(log_dir, mlir_source, echo=False)
+    verify_final_mlir(log_dir, mlir_path)
+    result["mlir_source"] = mlir_source
+    result["mlir_path"] = mlir_path
+    return result
+
+
+@pytest.mark.parametrize(
+    ("reduce_op", "dtype", "reduce_marker", "merge_marker"),
+    [
+        ("sum", "float16", "suvm.tile.reduce  sum", "suvm.tile.addf"),
+        ("max", "float16", "suvm.tile.reduce  max", "suvm.tile.maxf"),
+        ("min", "float16", "suvm.tile.reduce  min", "suvm.tile.minf"),
+    ],
+)
+def test_tiled_clear_false_supported_reductions(tmp_path, reduce_op, dtype, reduce_marker, merge_marker):
+    result = compile_case(
+        build_pytest_tiled_reduce_case(reduce_op=reduce_op, dtype=dtype),
+        tmp_path / f"{reduce_op}_{dtype}",
+    )
+    mlir_source = result["mlir_source"]
+    assert reduce_marker in mlir_source
+    assert merge_marker in mlir_source
+    assert PREVIOUS_OUTPUT_ABS_RE.search(mlir_source) is None
+
+
+@pytest.mark.parametrize(
+    ("reduce_op", "dtype"),
+    [
+        ("abssum", "float16"),
+        ("absmax", "float16"),
+    ],
+)
+def test_tiled_clear_false_absolute_reductions_should_not_abs_previous_output(tmp_path, reduce_op, dtype):
+    result = compile_case(
+        build_pytest_tiled_reduce_case(reduce_op=reduce_op, dtype=dtype),
+        tmp_path / f"{reduce_op}_{dtype}",
+    )
+    assert PREVIOUS_OUTPUT_ABS_RE.search(result["mlir_source"]) is None
+
+
+@pytest.mark.parametrize("reduce_op", ["bitand", "bitor", "bitxor"])
+def test_tiled_clear_false_bitwise_reductions_should_codegen_for_int32(tmp_path, reduce_op):
+    result = compile_case(
+        build_pytest_tiled_reduce_case(reduce_op=reduce_op, dtype="int32"),
+        tmp_path / f"{reduce_op}_int32",
+    )
+    assert "suvm.tile.reduce" in result["mlir_source"]
 
 
 def main():

--- a/mlir_codegen/test_reduce_sunmmio.py
+++ b/mlir_codegen/test_reduce_sunmmio.py
@@ -213,7 +213,7 @@ def main():
     label, func, expected_in_tile, clear = build_case()
     log_root = os.environ.get(
         "TL_REDUCE_LOG_ROOT",
-        "/home/cedu/projects/Tilelang-Mesh/tilelang_mesh/mlir_codegen/logs_reduce_sunmmio",
+        os.path.join(os.path.dirname(__file__), "logs_reduce_sunmmio"),
     )
     log_dir = os.path.join(log_root, label)
     os.makedirs(log_dir, exist_ok=True)

--- a/mlir_codegen/test_tile_ops_sunmmio.py
+++ b/mlir_codegen/test_tile_ops_sunmmio.py
@@ -5,6 +5,7 @@ import tilelang.language as T
 import tvm
 from compile_pipeline import compile_test
 from sunmmio_test_utils import save_final_ast, save_final_mlir, verify_final_mlir
+from tilelang.carver.arch import driver
 from tilelang.utils.target import determine_target
 
 tilelang.env.disable_cache()
@@ -19,71 +20,156 @@ def tile_elementwise_ops_test(
     block_n,
     dtype="float16",
 ):
+    device_mesh_config = driver.get_sunmmio_device_mesh_config()
+    nrows, ncols = device_mesh_config
+    ncores = nrows * ncols
+    grid_b = T.ceildiv(batch, block_b)
+    grid_m = T.ceildiv(m, block_m)
+    grid_n = T.ceildiv(n, block_n)
+
     @T.prim_func
     def main(
         A: T.Tensor((batch, m, n), dtype),
         B: T.Tensor((batch, m, n), dtype),
         C: T.Tensor((batch, m, n), dtype),
     ):
-        with T.Kernel(
-            T.ceildiv(n, block_n),
-            T.ceildiv(m, block_m),
-            T.ceildiv(batch, block_b),
-            threads=1,
-        ) as (bx, by, bz):
+        with T.Kernel(ncores) as _cid:
             A_shared = T.alloc_shared((block_b, block_m, block_n), dtype)
             B_shared = T.alloc_shared((block_b, block_m, block_n), dtype)
             C_shared = T.alloc_shared((block_b, block_m, block_n), dtype)
 
-            T.copy(
-                A[
-                    bz * block_b : (bz + 1) * block_b,
-                    by * block_m : (by + 1) * block_m,
-                    bx * block_n : (bx + 1) * block_n,
-                ],
-                A_shared,
-            )
-            T.copy(
-                B[
-                    bz * block_b : (bz + 1) * block_b,
-                    by * block_m : (by + 1) * block_m,
-                    bx * block_n : (bx + 1) * block_n,
-                ],
-                B_shared,
-            )
+            for bz in T.serial(grid_b):
+                for by in T.serial(grid_m):
+                    for bx in T.serial(grid_n):
+                        if (bz * grid_m * grid_n + by * grid_n + bx) % ncores == _cid:
+                            T.copy(
+                                A[
+                                    bz * block_b : (bz + 1) * block_b,
+                                    by * block_m : (by + 1) * block_m,
+                                    bx * block_n : (bx + 1) * block_n,
+                                ],
+                                A_shared,
+                            )
+                            T.copy(
+                                B[
+                                    bz * block_b : (bz + 1) * block_b,
+                                    by * block_m : (by + 1) * block_m,
+                                    bx * block_n : (bx + 1) * block_n,
+                                ],
+                                B_shared,
+                            )
 
-            for b, i, j in T.Tiles(A_shared, parallel=True):
-                x = T.max(A_shared[b, i, j], B_shared[b, i, j])
-                y = T.min(x, T.exp(B_shared[b, i, j]))
-                z = T.log(T.abs(y) + T.float32(1.0))
-                C_shared[b, i, j] = T.if_then_else(
-                    z > T.float32(0.5),
-                    T.rsqrt(z + T.float32(1.0)),
-                    T.ieee_frcp(z + T.float32(2.0)),
-                )
+                            for b, i, j in T.Tiles(A_shared, parallel=True):
+                                x = T.max(A_shared[b, i, j], B_shared[b, i, j])
+                                y = T.min(x, T.exp(B_shared[b, i, j]))
+                                z = T.log(T.abs(y) + T.float32(1.0))
+                                C_shared[b, i, j] = T.if_then_else(
+                                    z > T.float32(0.5),
+                                    T.rsqrt(z + T.float32(1.0)),
+                                    T.ieee_frcp(z + T.float32(2.0)),
+                                )
 
-            for b, i, j in T.Tiles(A_shared, parallel=True):
-                neg_a = T.float32(0.0) - T.Cast("float32", A_shared[b, i, j])
-                rem_b = T.fmod(T.Cast("float32", B_shared[b, i, j]), T.float32(3.0))
-                C_shared[b, i, j] = (
-                    T.ceil(C_shared[b, i, j])
-                    + T.floor(A_shared[b, i, j])
-                    + T.round(B_shared[b, i, j])
-                    + T.trunc(A_shared[b, i, j])
-                    + neg_a
-                    + rem_b
-                )
+                            for b, i, j in T.Tiles(A_shared, parallel=True):
+                                neg_a = T.float32(0.0) - T.Cast("float32", A_shared[b, i, j])
+                                rem_b = T.fmod(T.Cast("float32", B_shared[b, i, j]), T.float32(3.0))
+                                C_shared[b, i, j] = (
+                                    T.ceil(C_shared[b, i, j])
+                                    + T.floor(A_shared[b, i, j])
+                                    + T.round(B_shared[b, i, j])
+                                    + T.trunc(A_shared[b, i, j])
+                                    + neg_a
+                                    + rem_b
+                                )
 
-            T.copy(
-                C_shared,
-                C[
-                    bz * block_b : (bz + 1) * block_b,
-                    by * block_m : (by + 1) * block_m,
-                    bx * block_n : (bx + 1) * block_n,
-                ],
-            )
+                            T.copy(
+                                C_shared,
+                                C[
+                                    bz * block_b : (bz + 1) * block_b,
+                                    by * block_m : (by + 1) * block_m,
+                                    bx * block_n : (bx + 1) * block_n,
+                                ],
+                            )
 
     return main
+
+
+PYTEST_TILE_OPS_CONFIG = dict(
+    batch=2,
+    m=256,
+    n=128,
+    block_b=2,
+    block_m=256,
+    block_n=128,
+    dtype="float16",
+)
+
+REQUIRED_TILE_OPS = [
+    "suvm.tile.abs",
+    "suvm.tile.ceil",
+    "suvm.tile.cmpf",
+    "suvm.tile.floor",
+    "suvm.tile.ln",
+    "suvm.tile.maxf",
+    "suvm.tile.minf",
+    "suvm.tile.neg",
+    "suvm.tile.recip",
+    "suvm.tile.remf",
+    "suvm.tile.round",
+    "suvm.tile.rsqrt",
+    "suvm.tile.select",
+    "suvm.tile.trunc",
+]
+
+
+def build_pytest_tile_ops_case():
+    return tile_elementwise_ops_test(**PYTEST_TILE_OPS_CONFIG)
+
+
+def compile_tile_ops_case(func, log_dir):
+    log_dir = os.fspath(log_dir)
+    os.makedirs(log_dir, exist_ok=True)
+
+    _, device_mod = compile_test(
+        func,
+        out_idx=[2],
+        target="Sunmmio",
+        log_pass_output=True,
+        log_dir=log_dir,
+    )
+    save_final_ast(log_dir, device_mod, echo=False)
+
+    target = determine_target("Sunmmio", return_object=True)
+    mlir_mod = tvm.get_global_func("target.build.tilelang_sunmmio_without_compile")(device_mod, target, "suvm")
+    mlir_source = mlir_mod.inspect_source()
+    mlir_path = save_final_mlir(log_dir, mlir_source, echo=False)
+    verify_final_mlir(log_dir, mlir_path)
+
+    return {
+        "device_mod": device_mod,
+        "log_dir": log_dir,
+        "mlir_source": mlir_source,
+        "mlir_path": mlir_path,
+    }
+
+
+def test_tile_ops_lower_core_tile_math(tmp_path):
+    result = compile_tile_ops_case(build_pytest_tile_ops_case(), tmp_path / "tile_ops_core_math")
+    missing_ops = [op for op in REQUIRED_TILE_OPS if op not in result["mlir_source"]]
+    assert not missing_ops, f"Missing expected tile ops: {missing_ops}"
+
+
+def test_tile_ops_should_not_use_fake_tile_addf(tmp_path):
+    result = compile_tile_ops_case(build_pytest_tile_ops_case(), tmp_path / "tile_ops_no_fake_add")
+    assert "fake_tile_addf" not in result["mlir_source"]
+
+
+def test_tile_ops_should_copy_between_global_and_rsram(tmp_path):
+    result = compile_tile_ops_case(build_pytest_tile_ops_case(), tmp_path / "tile_ops_copy_paths")
+    mlir_source = result["mlir_source"]
+    assert "get_partitioned_tile_view %arg0" in mlir_source
+    assert "get_partitioned_tile_view %arg1" in mlir_source
+    assert "get_partitioned_tile_view %arg2" in mlir_source
+    assert "suvm.copy_async" in mlir_source
 
 
 def main():
@@ -106,23 +192,7 @@ def main():
     target = determine_target("Sunmmio", return_object=True)
     mlir_mod = tvm.get_global_func("target.build.tilelang_sunmmio_without_compile")(device_mod, target, "suvm")
     mlir_source = mlir_mod.inspect_source()
-    required_ops = [
-        "suvm.tile.abs",
-        "suvm.tile.ceil",
-        "suvm.tile.cmpf",
-        "suvm.tile.floor",
-        "suvm.tile.ln",
-        "suvm.tile.maxf",
-        "suvm.tile.minf",
-        "suvm.tile.neg",
-        "suvm.tile.recip",
-        "suvm.tile.remf",
-        "suvm.tile.round",
-        "suvm.tile.rsqrt",
-        "suvm.tile.select",
-        "suvm.tile.trunc",
-    ]
-    missing_ops = [op for op in required_ops if op not in mlir_source]
+    missing_ops = [op for op in REQUIRED_TILE_OPS if op not in mlir_source]
     assert not missing_ops, f"Missing expected tile ops: {missing_ops}"
     mlir_path = save_final_mlir(log_dir, mlir_source, echo=True)
     verify_final_mlir(log_dir, mlir_path)

--- a/mlir_codegen/test_tile_ops_sunmmio.py
+++ b/mlir_codegen/test_tile_ops_sunmmio.py
@@ -90,7 +90,7 @@ def main():
     func = tile_elementwise_ops_test(2, 256, 128, 2, 256, 128)
     log_dir = os.environ.get(
         "TL_TILE_OPS_LOG_DIR",
-        "/home/cedu/projects/Tilelang-Mesh/tilelang_mesh/mlir_codegen/logs_tile_ops_sunmmio",
+        os.path.join(os.path.dirname(__file__), "logs_tile_ops_sunmmio"),
     )
     os.makedirs(log_dir, exist_ok=True)
 

--- a/mlir_codegen/test_tiles_sunmmio.py
+++ b/mlir_codegen/test_tiles_sunmmio.py
@@ -127,8 +127,9 @@ func = test_1d_tiles(M, block_M, tile_size, index_map, "bfloat16", "bfloat16")
 func.show()
 
 
-log_dir = "/home/cedu/projects/Tilelang-Mesh/tilelang_mesh/mlir_codegen/logs_tiles_sunmmio"
 import os
+
+log_dir = os.path.join(os.path.dirname(__file__), "logs_tiles_sunmmio")
 
 os.makedirs(log_dir, exist_ok=True)
 host_mod, device_mod = compile_test(func, out_idx=[2], target="Sunmmio", log_pass_output=True, log_dir=log_dir)

--- a/src/target/sunmmio/codegen_sunmmio.h
+++ b/src/target/sunmmio/codegen_sunmmio.h
@@ -130,6 +130,13 @@ public:
                                  const SunMMIOType &tile_type,
                                  DataType dtype) = 0;
 
+  virtual SunMMIOValue TileInsertSlice(const std::string &result_name,
+                                       const SunMMIOValue &base,
+                                       const SunMMIOValue &slice,
+                                       const std::vector<SunMMIOValue> &offsets,
+                                       const SunMMIOType &result_type,
+                                       DataType dtype) = 0;
+
   virtual SunMMIOValue TileRectMask(const std::string &result_name,
                                     const SunMMIOValue &valid_rows,
                                     const SunMMIOValue &valid_cols,

--- a/src/target/sunmmio/sunmmio_codegen_tiles_loop.cc
+++ b/src/target/sunmmio/sunmmio_codegen_tiles_loop.cc
@@ -1242,6 +1242,97 @@ bool CodeGenTileLangSunMMIO::TryLowerTilesScope(const tir::ForNode *op) {
     return sliced_tile;
   };
 
+  auto store_aligned_1d_tile = [&](const TileAccessInfo &access,
+                                   const SunMMIOValue &value,
+                                   TileBlockState *state) {
+    ICHECK(access.requires_aligned_1d_load);
+    ICHECK_EQ(access.tiled_dims.size(), 1U)
+        << "64B-aligned 1D tile store expects exactly one tiled dimension";
+
+    int64_t dtype_bytes = static_cast<int64_t>(
+        CanonicalizeSuvmDType(access.buffer->dtype).bytes());
+    int64_t tiled_dim = access.tiled_dims[0];
+    ICHECK_LT(tiled_dim, static_cast<int64_t>(access.partition_indices.size()));
+    SunMMIOValue tile_index =
+        EnsureIndex(access.partition_indices[static_cast<size_t>(tiled_dim)]);
+    SunMMIOValue tile_extent = make_index_const(access.tile_shape[0]);
+    SunMMIOValue elem_size = make_index_const(dtype_bytes);
+    SunMMIOValue aligned_bytes = make_index_const(access.aligned_load_bytes);
+
+    SunMMIOValue base_elem = mul_index(tile_index, tile_extent);
+    SunMMIOValue base_bytes = mul_index(base_elem, elem_size);
+    SunMMIOValue region_index = div_index(base_bytes, aligned_bytes);
+    SunMMIOValue offset_bytes = mod_index(base_bytes, aligned_bytes);
+    SunMMIOValue offset_elems = div_index(offset_bytes, elem_size);
+
+    const BufferBinding &binding = LookupBuffer(access.buffer);
+    SunMMIOValue memtensor{
+        CanonicalizeSuvmDType(access.buffer->dtype).with_lanes(1),
+        binding.handle, binding.buffer_type};
+
+    std::vector<SunMMIOValue> aligned_partition_indices =
+        access.partition_indices;
+    aligned_partition_indices[static_cast<size_t>(tiled_dim)] = region_index;
+
+    SunMMIOType aligned_view_type =
+        MakeTileViewType(access.buffer->dtype, {access.aligned_load_elems});
+    SunMMIOValue aligned_view = builder_->GetPartitionedTileView(
+        NewValueName(), memtensor, aligned_partition_indices, {tiled_dim},
+        aligned_view_type,
+        CanonicalizeSuvmDType(access.buffer->dtype).with_lanes(1));
+    SunMMIOType aligned_tile_type =
+        MakeTileType(access.buffer->dtype, {access.aligned_load_elems});
+    SunMMIOValue aligned_tile = builder_->TileLoad(
+        NewValueName(), aligned_view, aligned_tile_type, std::nullopt,
+        std::nullopt,
+        CanonicalizeSuvmDType(access.buffer->dtype).with_lanes(1));
+    SunMMIOType aligned_2d_type =
+        MakeTileType(access.buffer->dtype, access.aligned_load_shape);
+    SunMMIOValue aligned_2d_tile = builder_->TileUnsqueeze(
+        NewValueName(), aligned_tile, aligned_2d_type, access.unsqueeze_axis,
+        CanonicalizeSuvmDType(access.buffer->dtype).with_lanes(1));
+
+    SunMMIOValue src_slice = value;
+    if (src_slice.type.shape.size() == 1) {
+      SunMMIOType slice_2d_type =
+          MakeTileType(access.buffer->dtype,
+                       access.unsqueeze_axis == 1
+                           ? std::vector<int64_t>{access.tile_shape[0], 1}
+                           : std::vector<int64_t>{1, access.tile_shape[0]});
+      src_slice =
+          builder_->TileUnsqueeze(NewValueName(), src_slice, slice_2d_type,
+                                  access.unsqueeze_axis, slice_2d_type.dtype);
+    } else {
+      src_slice = reorient_unit_tile_to_shape(
+          src_slice, access.unsqueeze_axis == 1
+                         ? std::vector<int64_t>{access.tile_shape[0], 1}
+                         : std::vector<int64_t>{1, access.tile_shape[0]});
+    }
+
+    std::vector<SunMMIOValue> slice_offsets;
+    slice_offsets.reserve(2);
+    if (access.aligned_load_axis == 0) {
+      slice_offsets.push_back(offset_elems);
+      slice_offsets.push_back(make_index_const(0));
+    } else {
+      slice_offsets.push_back(make_index_const(0));
+      slice_offsets.push_back(offset_elems);
+    }
+
+    SunMMIOValue merged_tile = builder_->TileInsertSlice(
+        NewValueName(), aligned_2d_tile, src_slice, slice_offsets,
+        aligned_2d_type,
+        CanonicalizeSuvmDType(access.buffer->dtype).with_lanes(1));
+
+    SunMMIOType aligned_store_view_type =
+        MakeTileViewType(access.buffer->dtype, access.aligned_load_shape);
+    SunMMIOValue aligned_store_view = builder_->GetPartitionedTileView(
+        NewValueName(), memtensor, aligned_partition_indices, {tiled_dim},
+        aligned_store_view_type,
+        CanonicalizeSuvmDType(access.buffer->dtype).with_lanes(1));
+    builder_->TileStore(merged_tile, aligned_store_view, std::nullopt);
+  };
+
   auto build_tail_mask_info = [&](TileBlockState *state) -> TailMaskInfo {
     (void)state;
     ICHECK(scope.tail_predicate.defined());
@@ -1751,9 +1842,13 @@ bool CodeGenTileLangSunMMIO::TryLowerTilesScope(const tir::ForNode *op) {
       }
       std::optional<int64_t> forced_unit_axis =
           find_local_unit_axis_in_expr(store->value, state);
+      TileAccessInfo natural_access =
+          analyze_access(store->buffer, store->indices, state);
+      bool use_forced_unit_axis = forced_unit_axis.has_value() &&
+                                  !natural_access.requires_aligned_1d_load;
       std::optional<int64_t> saved_forced_axis;
       bool had_saved_forced_axis = false;
-      if (forced_unit_axis.has_value()) {
+      if (use_forced_unit_axis) {
         // Lower the target load/store in the same 2D unit-tile shape as the
         // local in-tile reduce result, avoiding fake 1D load/squeeze/store.
         auto saved_it = state->local_unit_tile_axes.find(store->buffer.get());
@@ -1764,7 +1859,9 @@ bool CodeGenTileLangSunMMIO::TryLowerTilesScope(const tir::ForNode *op) {
         state->local_unit_tile_axes[store->buffer.get()] = *forced_unit_axis;
       }
       TileAccessInfo access =
-          analyze_access(store->buffer, store->indices, state);
+          use_forced_unit_axis
+              ? analyze_access(store->buffer, store->indices, state)
+              : natural_access;
       SunMMIOValue rhs = normalize_for_store(
           access,
           lower_expr(
@@ -1783,13 +1880,17 @@ bool CodeGenTileLangSunMMIO::TryLowerTilesScope(const tir::ForNode *op) {
             NewValueName(), mask.value(), rhs, old_tile, dst_tile_type,
             CanonicalizeSuvmDType(store->buffer->dtype).with_lanes(1));
       }
-      builder_->TileStore(rhs, dst_view, std::nullopt);
+      if (access.requires_aligned_1d_load) {
+        store_aligned_1d_tile(access, rhs, state);
+      } else {
+        builder_->TileStore(rhs, dst_view, std::nullopt);
+      }
       if (access.promoted_unit_tile_view) {
         state->current_tile_values.erase(store->buffer.get());
       } else {
         state->current_tile_values[store->buffer.get()] = rhs;
       }
-      if (forced_unit_axis.has_value()) {
+      if (use_forced_unit_axis) {
         if (had_saved_forced_axis) {
           state->local_unit_tile_axes[store->buffer.get()] = *saved_forced_axis;
         } else {

--- a/src/target/sunmmio/sunmmio_codegen_tiles_loop.cc
+++ b/src/target/sunmmio/sunmmio_codegen_tiles_loop.cc
@@ -395,6 +395,10 @@ MatchTiledIndex(const PrimExpr &index, const Var &exec, const Var &interior,
   if (seen_interior && seen_exec && const_offset % tile_extent == 0) {
     return TiledIndexMatch{const_offset / tile_extent, true};
   }
+  if (allow_standalone_interior && seen_interior && !seen_exec &&
+      const_offset % tile_extent == 0) {
+    return TiledIndexMatch{const_offset / tile_extent, false};
+  }
   return std::nullopt;
 }
 
@@ -597,11 +601,16 @@ bool CodeGenTileLangSunMMIO::TryLowerTilesScope(const tir::ForNode *op) {
               NewValueName(), logical_offsets[dim],
               SunMMIOType{SunMMIOType::Kind::kIndex, DataType::Int(32), 1, {}},
               DataType::Int(32));
-          exec_index = builder_->Binary(
-              NewValueName(), BinaryOp::kAdd, ArithmeticFlavor::kIndex,
-              exec_index, offset,
-              SunMMIOType{SunMMIOType::Kind::kIndex, DataType::Int(32), 1, {}},
-              DataType::Int(32));
+          exec_index = logical_uses_execution_index[dim]
+                           ? builder_->Binary(
+                                 NewValueName(), BinaryOp::kAdd,
+                                 ArithmeticFlavor::kIndex, exec_index, offset,
+                                 SunMMIOType{SunMMIOType::Kind::kIndex,
+                                             DataType::Int(32),
+                                             1,
+                                             {}},
+                                 DataType::Int(32))
+                           : offset;
         }
         access.partition_indices.push_back(exec_index);
       } else {
@@ -1144,7 +1153,24 @@ bool CodeGenTileLangSunMMIO::TryLowerTilesScope(const tir::ForNode *op) {
         DataType::Int(32));
   };
 
+  auto get_const_index_value =
+      [&](const SunMMIOValue &value) -> std::optional<int64_t> {
+    mlir::Value mlir_value = mlir_ctx->LookupMLIRValue(value.value);
+    if (!mlir_value) {
+      return std::nullopt;
+    }
+    if (auto cst = mlir::getConstantIntValue(mlir_value)) {
+      return static_cast<int64_t>(*cst);
+    }
+    return std::nullopt;
+  };
+
   auto add_index = [&](const SunMMIOValue &lhs, const SunMMIOValue &rhs) {
+    auto lhs_cst = get_const_index_value(lhs);
+    auto rhs_cst = get_const_index_value(rhs);
+    if (lhs_cst.has_value() && rhs_cst.has_value()) {
+      return make_index_const(*lhs_cst + *rhs_cst);
+    }
     return builder_->Binary(
         NewValueName(), BinaryOp::kAdd, ArithmeticFlavor::kIndex, lhs, rhs,
         SunMMIOType{SunMMIOType::Kind::kIndex, DataType::Int(32), 1, {}},
@@ -1152,6 +1178,11 @@ bool CodeGenTileLangSunMMIO::TryLowerTilesScope(const tir::ForNode *op) {
   };
 
   auto mul_index = [&](const SunMMIOValue &lhs, const SunMMIOValue &rhs) {
+    auto lhs_cst = get_const_index_value(lhs);
+    auto rhs_cst = get_const_index_value(rhs);
+    if (lhs_cst.has_value() && rhs_cst.has_value()) {
+      return make_index_const(*lhs_cst * *rhs_cst);
+    }
     return builder_->Binary(
         NewValueName(), BinaryOp::kMul, ArithmeticFlavor::kIndex, lhs, rhs,
         SunMMIOType{SunMMIOType::Kind::kIndex, DataType::Int(32), 1, {}},
@@ -1159,6 +1190,12 @@ bool CodeGenTileLangSunMMIO::TryLowerTilesScope(const tir::ForNode *op) {
   };
 
   auto div_index = [&](const SunMMIOValue &lhs, const SunMMIOValue &rhs) {
+    auto lhs_cst = get_const_index_value(lhs);
+    auto rhs_cst = get_const_index_value(rhs);
+    if (lhs_cst.has_value() && rhs_cst.has_value()) {
+      ICHECK_NE(*rhs_cst, 0) << "index division by zero in aligned 1D lowering";
+      return make_index_const(*lhs_cst / *rhs_cst);
+    }
     return builder_->Binary(
         NewValueName(), BinaryOp::kDiv, ArithmeticFlavor::kIndex, lhs, rhs,
         SunMMIOType{SunMMIOType::Kind::kIndex, DataType::Int(32), 1, {}},
@@ -1166,6 +1203,12 @@ bool CodeGenTileLangSunMMIO::TryLowerTilesScope(const tir::ForNode *op) {
   };
 
   auto mod_index = [&](const SunMMIOValue &lhs, const SunMMIOValue &rhs) {
+    auto lhs_cst = get_const_index_value(lhs);
+    auto rhs_cst = get_const_index_value(rhs);
+    if (lhs_cst.has_value() && rhs_cst.has_value()) {
+      ICHECK_NE(*rhs_cst, 0) << "index modulo by zero in aligned 1D lowering";
+      return make_index_const(*lhs_cst % *rhs_cst);
+    }
     return builder_->Binary(
         NewValueName(), BinaryOp::kMod, ArithmeticFlavor::kIndex, lhs, rhs,
         SunMMIOType{SunMMIOType::Kind::kIndex, DataType::Int(32), 1, {}},

--- a/src/target/sunmmio/sunmmio_mlir_builder.cc
+++ b/src/target/sunmmio/sunmmio_mlir_builder.cc
@@ -175,6 +175,14 @@ SuvmSunmmioBuilder::TileSlice(const std::string &result_name,
   return tile_->TileSlice(result_name, tile, offsets, tile_type, dtype);
 }
 
+SunMMIOValue SuvmSunmmioBuilder::TileInsertSlice(
+    const std::string &result_name, const SunMMIOValue &base,
+    const SunMMIOValue &slice, const std::vector<SunMMIOValue> &offsets,
+    const SunMMIOType &result_type, DataType dtype) {
+  return tile_->TileInsertSlice(result_name, base, slice, offsets, result_type,
+                                dtype);
+}
+
 SunMMIOValue SuvmSunmmioBuilder::TileRectMask(const std::string &result_name,
                                               const SunMMIOValue &valid_rows,
                                               const SunMMIOValue &valid_cols,

--- a/src/target/sunmmio/sunmmio_mlir_builder.h
+++ b/src/target/sunmmio/sunmmio_mlir_builder.h
@@ -101,6 +101,13 @@ public:
                          const std::vector<SunMMIOValue> &offsets,
                          const SunMMIOType &tile_type, DataType dtype) final;
 
+  SunMMIOValue TileInsertSlice(const std::string &result_name,
+                               const SunMMIOValue &base,
+                               const SunMMIOValue &slice,
+                               const std::vector<SunMMIOValue> &offsets,
+                               const SunMMIOType &result_type,
+                               DataType dtype) final;
+
   SunMMIOValue TileRectMask(const std::string &result_name,
                             const SunMMIOValue &valid_rows,
                             const SunMMIOValue &valid_cols,

--- a/src/target/sunmmio/sunmmio_mlir_tile_op.cc
+++ b/src/target/sunmmio/sunmmio_mlir_tile_op.cc
@@ -134,7 +134,9 @@ SunMMIOValue SunmmioMlirTileOp::GetPartitionedTileView(
     DataType dtype) {
   mlir::Type result_type = MapMlirType(ctx_, view_type);
   mlir::Value view_value;
-  if (view_type.shape.size() == 2) {
+  bool supports_real_2d_view =
+      view_type.shape.size() == 2 && memtensor.type.shape.size() >= 2;
+  if (supports_real_2d_view) {
     mlir::Value memtensor_value =
         ctx_.LookupOrCreateFakeValue(memtensor, "fake_missing_memtensor");
     mlir::OperationState st(MapMlirLoc(ctx_), "suvm.get_partitioned_tile_view");
@@ -151,10 +153,17 @@ SunMMIOValue SunmmioMlirTileOp::GetPartitionedTileView(
     st.addTypes(result_type);
     view_value = ctx_.builder.create(st)->getResult(0);
   } else {
-    LOG(WARNING)
-        << "Using provisional 1D tile_view placeholder for clean v4 Tiles "
-           "lowering; replace with real SUVM 1D tile_view once dialect "
-           "support lands";
+    if (view_type.shape.size() == 2) {
+      LOG(WARNING)
+          << "Using provisional 2D tile_view placeholder for unsupported "
+             "rank-1/unit-tile adaptation in clean v4 Tiles lowering; replace "
+             "with real SUVM tile_view once dialect support lands";
+    } else {
+      LOG(WARNING)
+          << "Using provisional 1D tile_view placeholder for clean v4 Tiles "
+             "lowering; replace with real SUVM 1D tile_view once dialect "
+             "support lands";
+    }
     std::vector<mlir::Value> operands;
     operands.reserve(1 + indices.size());
     operands.push_back(
@@ -597,6 +606,53 @@ SunmmioMlirTileOp::TileSlice(const std::string &result_name,
     ctx_.BindMLIRValue(result_name, tile_value);
   }
   return SunMMIOValue{dtype, result_name, tile_type};
+}
+
+SunMMIOValue SunmmioMlirTileOp::TileInsertSlice(
+    const std::string &result_name, const SunMMIOValue &base,
+    const SunMMIOValue &slice, const std::vector<SunMMIOValue> &offsets,
+    const SunMMIOType &result_type, DataType dtype) {
+  mlir::Type result_mlir_type = MapMlirType(ctx_, result_type);
+  mlir::Value base_value =
+      ctx_.LookupOrCreateFakeValue(base, "fake_missing_tile_insert_slice_base");
+  mlir::Value slice_value = ctx_.LookupOrCreateFakeValue(
+      slice, "fake_missing_tile_insert_slice_slice");
+  std::vector<mlir::Value> operands;
+  operands.reserve(2 + offsets.size());
+  operands.push_back(base_value);
+  operands.push_back(slice_value);
+  SunmmioMlirType type(ctx_);
+  for (const SunMMIOValue &offset : offsets) {
+    operands.push_back(type.EnsureIndex(type.ResolveValueOrCreatePlaceholder(
+        offset, ctx_.builder.getIndexType())));
+  }
+  mlir::Value tile_value = CreateTypedPlaceholderWithOperands(
+      ctx_, result_mlir_type, operands, "fake_tile_insert_slice");
+  if (mlir::Operation *def = tile_value.getDefiningOp()) {
+    llvm::SmallVector<int64_t, 4> static_offsets;
+    bool has_static_offsets = true;
+    for (const SunMMIOValue &offset : offsets) {
+      mlir::Value offset_value = ctx_.LookupMLIRValue(offset.value);
+      if (!offset_value) {
+        has_static_offsets = false;
+        break;
+      }
+      if (auto cst = mlir::getConstantIntValue(offset_value)) {
+        static_offsets.push_back(*cst);
+      } else {
+        has_static_offsets = false;
+        break;
+      }
+    }
+    if (has_static_offsets) {
+      def->setAttr("offsets",
+                   ctx_.builder.getDenseI64ArrayAttr(static_offsets));
+    }
+  }
+  if (!result_name.empty()) {
+    ctx_.BindMLIRValue(result_name, tile_value);
+  }
+  return SunMMIOValue{dtype, result_name, result_type};
 }
 
 SunMMIOValue SunmmioMlirTileOp::TileAxisMask(const std::string &result_name,

--- a/src/target/sunmmio/sunmmio_mlir_tile_op.cc
+++ b/src/target/sunmmio/sunmmio_mlir_tile_op.cc
@@ -523,17 +523,13 @@ SunMMIOValue SunmmioMlirTileOp::TileUnsqueeze(const std::string &result_name,
                                               const SunMMIOType &tile_type,
                                               int64_t axis, DataType dtype) {
   mlir::Type result_type = MapMlirType(ctx_, tile_type);
-  LOG(WARNING)
-      << "Using provisional tile.unsqueeze placeholder in clean v4 Tiles "
-         "lowering; replace with real SUVM tile.unsqueeze once dialect "
-         "support lands";
   mlir::Value input =
       ctx_.LookupOrCreateFakeValue(tile, "fake_missing_tile_unsqueeze_src");
-  mlir::Value tile_value = CreateTypedPlaceholderWithOperands(
-      ctx_, result_type, {input}, "fake_tile_unsqueeze");
-  if (mlir::Operation *def = tile_value.getDefiningOp()) {
-    def->setAttr("axis", ctx_.builder.getI64IntegerAttr(axis));
-  }
+  mlir::OperationState st(MapMlirLoc(ctx_), "suvm.tile.unsqueeze");
+  st.addOperands(input);
+  st.addAttribute("axes", ctx_.builder.getDenseI64ArrayAttr({axis}));
+  st.addTypes(result_type);
+  mlir::Value tile_value = ctx_.builder.create(st)->getResult(0);
   if (!result_name.empty()) {
     ctx_.BindMLIRValue(result_name, tile_value);
   }
@@ -626,28 +622,41 @@ SunMMIOValue SunmmioMlirTileOp::TileInsertSlice(
     operands.push_back(type.EnsureIndex(type.ResolveValueOrCreatePlaceholder(
         offset, ctx_.builder.getIndexType())));
   }
-  mlir::Value tile_value = CreateTypedPlaceholderWithOperands(
-      ctx_, result_mlir_type, operands, "fake_tile_insert_slice");
-  if (mlir::Operation *def = tile_value.getDefiningOp()) {
-    llvm::SmallVector<int64_t, 4> static_offsets;
-    bool has_static_offsets = true;
-    for (const SunMMIOValue &offset : offsets) {
-      mlir::Value offset_value = ctx_.LookupMLIRValue(offset.value);
-      if (!offset_value) {
-        has_static_offsets = false;
-        break;
-      }
-      if (auto cst = mlir::getConstantIntValue(offset_value)) {
-        static_offsets.push_back(*cst);
-      } else {
-        has_static_offsets = false;
-        break;
-      }
+  llvm::SmallVector<int64_t, 4> static_offsets;
+  bool has_static_offsets = true;
+  for (const SunMMIOValue &offset : offsets) {
+    mlir::Value offset_value = ctx_.LookupMLIRValue(offset.value);
+    if (!offset_value) {
+      has_static_offsets = false;
+      break;
     }
-    if (has_static_offsets) {
-      def->setAttr("offsets",
-                   ctx_.builder.getDenseI64ArrayAttr(static_offsets));
+    if (auto cst = mlir::getConstantIntValue(offset_value)) {
+      static_offsets.push_back(*cst);
+    } else {
+      has_static_offsets = false;
+      break;
     }
+  }
+
+  mlir::Value tile_value;
+  if (has_static_offsets) {
+    llvm::SmallVector<int64_t, 4> sizes;
+    for (const PrimExpr &dim : slice.type.shape) {
+      const auto *imm = dim.as<IntImmNode>();
+      ICHECK(imm)
+          << "tile.insert_slice currently expects static slice result shape";
+      sizes.push_back(static_cast<int64_t>(imm->value));
+    }
+    mlir::OperationState st(MapMlirLoc(ctx_), "suvm.tile.insert_slice");
+    st.addOperands({slice_value, base_value});
+    st.addAttribute("offsets",
+                    ctx_.builder.getDenseI64ArrayAttr(static_offsets));
+    st.addAttribute("sizes", ctx_.builder.getDenseI64ArrayAttr(sizes));
+    st.addTypes(result_mlir_type);
+    tile_value = ctx_.builder.create(st)->getResult(0);
+  } else {
+    tile_value = CreateTypedPlaceholderWithOperands(
+        ctx_, result_mlir_type, operands, "fake_tile_insert_slice");
   }
   if (!result_name.empty()) {
     ctx_.BindMLIRValue(result_name, tile_value);
@@ -840,17 +849,13 @@ SunMMIOValue SunmmioMlirTileOp::TileSqueeze(const std::string &result_name,
                                             const SunMMIOType &tile_type,
                                             int64_t axis, DataType dtype) {
   mlir::Type result_type = MapMlirType(ctx_, tile_type);
-  LOG(WARNING)
-      << "Using provisional tile.squeeze placeholder in clean v4 Tiles "
-         "lowering; replace with real SUVM tile.squeeze once dialect "
-         "support lands";
   mlir::Value input =
       ctx_.LookupOrCreateFakeValue(tile, "fake_missing_tile_squeeze_src");
-  mlir::Value tile_value = CreateTypedPlaceholderWithOperands(
-      ctx_, result_type, {input}, "fake_tile_squeeze");
-  if (mlir::Operation *def = tile_value.getDefiningOp()) {
-    def->setAttr("axis", ctx_.builder.getI64IntegerAttr(axis));
-  }
+  mlir::OperationState st(MapMlirLoc(ctx_), "suvm.tile.squeeze");
+  st.addOperands(input);
+  st.addAttribute("axes", ctx_.builder.getDenseI64ArrayAttr({axis}));
+  st.addTypes(result_type);
+  mlir::Value tile_value = ctx_.builder.create(st)->getResult(0);
   if (!result_name.empty()) {
     ctx_.BindMLIRValue(result_name, tile_value);
   }
@@ -860,15 +865,18 @@ SunMMIOValue SunmmioMlirTileOp::TileSqueeze(const std::string &result_name,
 void SunmmioMlirTileOp::TileStore(const SunMMIOValue &value,
                                   const SunMMIOValue &tile_view,
                                   const std::optional<SunMMIOValue> &mask) {
-  if (value.type.shape.size() != 2 || tile_view.type.shape.size() != 2) {
+  mlir::Value base =
+      ctx_.LookupOrCreateFakeValue(tile_view, "fake_missing_tile_store_view");
+  bool fake_view_boundary =
+      base.getDefiningOp() && base.getDefiningOp()->hasAttr("sunmmio.fake");
+  if (value.type.shape.size() != 2 || tile_view.type.shape.size() != 2 ||
+      fake_view_boundary) {
     LOG(WARNING)
-        << "Using provisional 1D tile.store placeholder in clean v4 Tiles "
-           "lowering; replace with real SUVM 1D tile.store once dialect "
-           "support lands";
+        << "Using provisional tile.store placeholder in clean v4 Tiles "
+           "lowering when the tile_view boundary is still fake or 1D support "
+           "is unavailable";
     mlir::Value data =
         ctx_.LookupOrCreateFakeValue(value, "fake_missing_tile_store_value");
-    mlir::Value base =
-        ctx_.LookupOrCreateFakeValue(tile_view, "fake_missing_tile_store_view");
     mlir::OperationState st(MapMlirLoc(ctx_),
                             "builtin.unrealized_conversion_cast");
     st.addOperands({data, base});
@@ -880,8 +888,6 @@ void SunmmioMlirTileOp::TileStore(const SunMMIOValue &value,
   }
   mlir::Value data =
       ctx_.LookupOrCreateFakeValue(value, "fake_missing_tile_store_value");
-  mlir::Value base =
-      ctx_.LookupOrCreateFakeValue(tile_view, "fake_missing_tile_store_view");
   mlir::Value mask_value;
   if (mask.has_value()) {
     mask_value = ctx_.LookupOrCreateFakeValue(mask.value(),

--- a/src/target/sunmmio/sunmmio_mlir_tile_op.h
+++ b/src/target/sunmmio/sunmmio_mlir_tile_op.h
@@ -55,6 +55,12 @@ public:
                          const std::vector<SunMMIOValue> &offsets,
                          const SunMMIOType &tile_type, DataType dtype);
 
+  SunMMIOValue TileInsertSlice(const std::string &result_name,
+                               const SunMMIOValue &base,
+                               const SunMMIOValue &slice,
+                               const std::vector<SunMMIOValue> &offsets,
+                               const SunMMIOType &result_type, DataType dtype);
+
   SunMMIOValue TileRectMask(const std::string &result_name,
                             const SunMMIOValue &valid_rows,
                             const SunMMIOValue &valid_cols,

--- a/testing/python/target/test_sunmmio_codegen_tiles_aligned_store.py
+++ b/testing/python/target/test_sunmmio_codegen_tiles_aligned_store.py
@@ -1,0 +1,97 @@
+from tilelang import tvm
+from tilelang.utils.target import determine_target
+
+
+def _to_device_kernel_func(func):
+    return func.with_attr("global_symbol", "main").with_attr("calling_conv", int(tvm.ir.CallingConv.DEVICE_KERNEL_LAUNCH))
+
+
+def _build_sunmmio_source_from_stmt(stmt):
+    target = determine_target("Sunmmio", return_object=True)
+    func = _to_device_kernel_func(tvm.tir.PrimFunc([], stmt))
+    mod = tvm.IRModule({"main": func})
+    builder = tvm.ffi.get_global_func("target.build.tilelang_sunmmio_without_compile")
+    return builder(mod, target, "suvm").inspect_source()
+
+
+def _make_tile_valued_aligned_store_stmt():
+    bf16 = tvm.ir.PrimType("bfloat16")
+    one = tvm.tir.IntImm("bool", 1)
+
+    a_data = tvm.tir.Var("A_shared_data", tvm.ir.PointerType(bf16, "shared.rsram"))
+    b_data = tvm.tir.Var("B_shared_data", tvm.ir.PointerType(bf16, "shared.rsram"))
+    out_data = tvm.tir.Var("Out_shared_data", tvm.ir.PointerType(bf16, "shared.rsram"))
+
+    a_buf = tvm.tir.decl_buffer((64,), "bfloat16", name="A_shared", data=a_data, scope="shared.rsram")
+    b_buf = tvm.tir.decl_buffer((64,), "bfloat16", name="B_shared", data=b_data, scope="shared.rsram")
+    out_buf = tvm.tir.decl_buffer((64,), "bfloat16", name="Out_shared", data=out_data, scope="shared.rsram")
+
+    tile_i = tvm.tir.Var("tile_i", "int32")
+    ki = tvm.tir.Var("ki", "int32")
+    tile_base = tvm.tir.Mul(tile_i, tvm.tir.IntImm("int32", 8))
+    elem_index = tvm.tir.Add(tile_base, ki)
+
+    # These 1D tiled loads are lowered through the regular tile access path,
+    # so the add result is a logical tile value rather than a scalar.
+    value = tvm.tir.Add(
+        tvm.tir.BufferLoad(a_buf, [elem_index]),
+        tvm.tir.BufferLoad(b_buf, [elem_index]),
+    )
+    store = tvm.tir.BufferStore(out_buf, value, [elem_index])
+
+    inner = tvm.tir.For(
+        ki,
+        0,
+        8,
+        tvm.tir.ForKind.SERIAL,
+        store,
+        annotations={
+            "tile.interior": tvm.tir.IntImm("int32", 1),
+            "tile.interior_axis": tvm.tir.IntImm("int32", 0),
+        },
+    )
+
+    outer = tvm.tir.For(
+        tile_i,
+        0,
+        8,
+        tvm.tir.ForKind.SERIAL,
+        inner,
+        annotations={
+            "tile.domain": [tvm.tir.IntImm("int32", 64)],
+            "tile.execution_axis": tvm.tir.IntImm("int32", 0),
+            "tile.execution_domain_axes": [tvm.tir.IntImm("int32", 0)],
+            "tile.scope_entry": tvm.tir.IntImm("int32", 1),
+            "tile.tile_size": [tvm.tir.IntImm("int32", 8)],
+        },
+    )
+
+    return tvm.tir.DeclBuffer(
+        a_buf,
+        tvm.tir.DeclBuffer(
+            b_buf,
+            tvm.tir.DeclBuffer(
+                out_buf,
+                tvm.tir.Allocate(
+                    a_data,
+                    "bfloat16",
+                    [64],
+                    one,
+                    tvm.tir.Allocate(
+                        b_data,
+                        "bfloat16",
+                        [64],
+                        one,
+                        tvm.tir.Allocate(out_data, "bfloat16", [64], one, outer),
+                    ),
+                ),
+            ),
+        ),
+    )
+
+
+def test_sunmmio_codegen_aligned_1d_store_uses_insert_slice_bridge():
+    src = _build_sunmmio_source_from_stmt(_make_tile_valued_aligned_store_stmt())
+    assert "fake_tile_insert_slice" in src
+    assert "fake_tile_load" in src
+    assert "fake_tile_unsqueeze" in src

--- a/testing/python/target/test_sunmmio_codegen_tiles_aligned_store.py
+++ b/testing/python/target/test_sunmmio_codegen_tiles_aligned_store.py
@@ -14,7 +14,7 @@ def _build_sunmmio_source_from_stmt(stmt):
     return builder(mod, target, "suvm").inspect_source()
 
 
-def _make_tile_valued_aligned_store_stmt():
+def _make_nonzero_offset_aligned_store_stmt():
     bf16 = tvm.ir.PrimType("bfloat16")
     one = tvm.tir.IntImm("bool", 1)
 
@@ -28,16 +28,13 @@ def _make_tile_valued_aligned_store_stmt():
 
     tile_i = tvm.tir.Var("tile_i", "int32")
     ki = tvm.tir.Var("ki", "int32")
-    tile_base = tvm.tir.Mul(tile_i, tvm.tir.IntImm("int32", 8))
-    elem_index = tvm.tir.Add(tile_base, ki)
+    base = tvm.tir.IntImm("int32", 8)
 
-    # These 1D tiled loads are lowered through the regular tile access path,
-    # so the add result is a logical tile value rather than a scalar.
     value = tvm.tir.Add(
-        tvm.tir.BufferLoad(a_buf, [elem_index]),
-        tvm.tir.BufferLoad(b_buf, [elem_index]),
+        tvm.tir.BufferLoad(a_buf, [ki + base]),
+        tvm.tir.BufferLoad(b_buf, [ki + base]),
     )
-    store = tvm.tir.BufferStore(out_buf, value, [elem_index])
+    store = tvm.tir.BufferStore(out_buf, value, [ki + base])
 
     inner = tvm.tir.For(
         ki,
@@ -54,11 +51,11 @@ def _make_tile_valued_aligned_store_stmt():
     outer = tvm.tir.For(
         tile_i,
         0,
-        8,
+        1,
         tvm.tir.ForKind.SERIAL,
         inner,
         annotations={
-            "tile.domain": [tvm.tir.IntImm("int32", 64)],
+            "tile.domain": [tvm.tir.IntImm("int32", 8)],
             "tile.execution_axis": tvm.tir.IntImm("int32", 0),
             "tile.execution_domain_axes": [tvm.tir.IntImm("int32", 0)],
             "tile.scope_entry": tvm.tir.IntImm("int32", 1),
@@ -90,8 +87,10 @@ def _make_tile_valued_aligned_store_stmt():
     )
 
 
-def test_sunmmio_codegen_aligned_1d_store_uses_insert_slice_bridge():
-    src = _build_sunmmio_source_from_stmt(_make_tile_valued_aligned_store_stmt())
-    assert "fake_tile_insert_slice" in src
-    assert "fake_tile_load" in src
-    assert "fake_tile_unsqueeze" in src
+def test_sunmmio_codegen_aligned_1d_store_uses_nonzero_insert_slice_offset():
+    src = _build_sunmmio_source_from_stmt(_make_nonzero_offset_aligned_store_stmt())
+    assert "suvm.tile.insert_slice" in src
+    assert "suvm.tile.unsqueeze" in src
+    assert "fake_partitioned_tile_view" in src
+    assert "fake_tile_store" in src
+    assert "offsets = array<i64: 8, 0>" in src


### PR DESCRIPTION
## Summary

This PR adds support for the aligned 1D store path in SunMMIO tile-loop codegen and adds a target-side regression test for it.

In the final state of this branch:
- aligned 1D tiled stores are lowered through the aligned backing-region path
- the internal tile transform sequence uses real SUVM ops where supported
- a dedicated regression test covers the nonzero-offset aligned store case

## Main Changes

### Add aligned 1D store support
This PR adds the aligned 1D store lowering path for SunMMIO tile-loop codegen.

The lowering:
- computes the aligned backing region for a 1D tiled store
- computes the subrange offset inside that aligned region
- loads the aligned destination tile
- inserts the logical store slice into the aligned tile
- stores the merged tile back

### Add regression test
This PR adds/updates a target-side regression test for aligned 1D store lowering:

- `testing/python/target/test_sunmmio_codegen_tiles_aligned_store.py`

The test checks a nonzero-offset case and verifies the generated MLIR contains the expected aligned-store structure, including:
- real `suvm.tile.unsqueeze`
- real `suvm.tile.insert_slice`
- nonzero insert offset (`offsets = array<i64: 8, 0>`)
- the expected fake store boundary where the tile view is still not fully real

## Notes

The final store boundary for this path is still fake today because the adapted rank-1 memtensor tile-view boundary is not fully real yet. This is expected for the current implementation and avoids emitting verifier-invalid MLIR.

## Testing

```bash
cmake --build build
/opt/miniconda3/bin/conda run -n tl pytest -q testing/python/target/test_sunmmio_codegen_tiles_aligned_store.py