### PR TITLE
Add SunMMIO TIR Compile Pipeline and Codegen Validation Tests

### DIFF
--- a/src/target/sunmmio/codegen_sunmmio.cc
+++ b/src/target/sunmmio/codegen_sunmmio.cc
@@ -110,6 +110,11 @@ void ApplyDebugRsramTailPadding(SunMMIOType *memtensor_type) {
   if (memtensor_type->shape.size() < 2) {
     return;
   }
+  if (!memtensor_type->layout_hshape.empty() ||
+      !memtensor_type->layout_hstride.empty() ||
+      !memtensor_type->layout_dim_levels.empty()) {
+    return;
+  }
 
   std::vector<int64_t> layout_hshape;
   layout_hshape.reserve(memtensor_type->shape.size());

--- a/src/target/sunmmio/codegen_sunmmio.h
+++ b/src/target/sunmmio/codegen_sunmmio.h
@@ -124,6 +124,11 @@ public:
                                      const SunMMIOType &tile_type, int64_t axis,
                                      DataType dtype) = 0;
 
+  virtual SunMMIOValue TileBroadcast(const std::string &result_name,
+                                     const SunMMIOValue &tile,
+                                     const SunMMIOType &tile_type,
+                                     DataType dtype) = 0;
+
   virtual SunMMIOValue TileSlice(const std::string &result_name,
                                  const SunMMIOValue &tile,
                                  const std::vector<SunMMIOValue> &offsets,

--- a/src/target/sunmmio/sunmmio_codegen_tiles_loop.cc
+++ b/src/target/sunmmio/sunmmio_codegen_tiles_loop.cc
@@ -638,24 +638,23 @@ bool CodeGenTileLangSunMMIO::TryLowerTilesScope(const tir::ForNode *op) {
             break;
           }
         }
-        ICHECK(unit_dim.has_value())
-            << "Cannot promote 1D reduce writeback access to a 2D unit tile "
-               "view without a spare memtensor dimension";
-        int64_t existing_dim = access.tiled_dims[0];
-        // Keep tile_view dimensions in memtensor/layout order.  For reduce axis
-        // 1 this intentionally creates a row-major 1xN view instead of a Nx1
-        // view with tiled_dims=[data_dim, unit_dim]; RHS unit-vector tiles are
-        // re-oriented later with squeeze/unsqueeze when needed.
-        if (*unit_dim < existing_dim) {
-          access.tiled_dims.insert(access.tiled_dims.begin(), *unit_dim);
-          access.tile_axes.insert(access.tile_axes.begin(), unit_axis);
-          access.tile_shape.insert(access.tile_shape.begin(), 1);
-        } else {
-          access.tiled_dims.push_back(*unit_dim);
-          access.tile_axes.push_back(unit_axis);
-          access.tile_shape.push_back(1);
+        if (unit_dim.has_value()) {
+          int64_t existing_dim = access.tiled_dims[0];
+          // Keep tile_view dimensions in memtensor/layout order.  For reduce
+          // axis 1 this intentionally creates a row-major 1xN view instead of
+          // a Nx1 view with tiled_dims=[data_dim, unit_dim]; RHS unit-vector
+          // tiles are re-oriented later with squeeze/unsqueeze when needed.
+          if (*unit_dim < existing_dim) {
+            access.tiled_dims.insert(access.tiled_dims.begin(), *unit_dim);
+            access.tile_axes.insert(access.tile_axes.begin(), unit_axis);
+            access.tile_shape.insert(access.tile_shape.begin(), 1);
+          } else {
+            access.tiled_dims.push_back(*unit_dim);
+            access.tile_axes.push_back(unit_axis);
+            access.tile_shape.push_back(1);
+          }
+          access.promoted_unit_tile_view = true;
         }
-        access.promoted_unit_tile_view = true;
       }
     }
 
@@ -972,6 +971,19 @@ bool CodeGenTileLangSunMMIO::TryLowerTilesScope(const tir::ForNode *op) {
     return dtype.is_float() || dtype.is_bfloat16();
   };
 
+  auto arithmetic_flavor_for_dtype = [](DataType dtype) {
+    if (dtype.is_float() || dtype.is_bfloat16()) {
+      return ArithmeticFlavor::kFloat;
+    }
+    if (dtype.is_uint()) {
+      return ArithmeticFlavor::kUnsignedInt;
+    }
+    if (dtype.is_bool()) {
+      return ArithmeticFlavor::kBool;
+    }
+    return ArithmeticFlavor::kSignedInt;
+  };
+
   auto is_tile_compare_operand = [](const SunMMIOValue &lhs,
                                     const SunMMIOValue &rhs) {
     return IsTileLike(lhs) || IsTileLike(rhs);
@@ -1060,6 +1072,20 @@ bool CodeGenTileLangSunMMIO::TryLowerTilesScope(const tir::ForNode *op) {
     if (src_shape.size() == 2 && dst_shape.size() == 2) {
       std::optional<int64_t> src_unit_axis = unit_axis_for_2d_shape(src_shape);
       std::optional<int64_t> dst_unit_axis = unit_axis_for_2d_shape(dst_shape);
+      if (src_unit_axis.has_value()) {
+        bool can_broadcast = true;
+        for (size_t i = 0; i < src_shape.size(); ++i) {
+          if (src_shape[i] != dst_shape[i] && src_shape[i] != 1) {
+            can_broadcast = false;
+            break;
+          }
+        }
+        if (can_broadcast) {
+          SunMMIOType dst_type = MakeTileType(value.dtype, dst_shape);
+          return builder_->TileBroadcast(NewValueName(), value, dst_type,
+                                         value.dtype);
+        }
+      }
       if (src_unit_axis.has_value() && dst_unit_axis.has_value() &&
           unit_vector_extent(src_shape, *src_unit_axis) ==
               unit_vector_extent(dst_shape, *dst_unit_axis)) {
@@ -1446,8 +1472,11 @@ bool CodeGenTileLangSunMMIO::TryLowerTilesScope(const tir::ForNode *op) {
       if (IsScalarLike(lhs) && IsScalarLike(rhs)) {
         SunMMIOType result_type{
             SunMMIOType::Kind::kScalar, result_dtype, 1, {}};
-        return builder_->Binary(NewValueName(), op, ArithmeticFlavor::kFloat,
-                                lhs, rhs, result_type, result_dtype);
+        lhs = EnsureType(lhs, result_type, result_dtype);
+        rhs = EnsureType(rhs, result_type, result_dtype);
+        return builder_->Binary(NewValueName(), op,
+                                arithmetic_flavor_for_dtype(result_dtype), lhs,
+                                rhs, result_type, result_dtype);
       }
       std::vector<int64_t> result_shape;
       if (IsTileLike(lhs)) {
@@ -1613,6 +1642,12 @@ bool CodeGenTileLangSunMMIO::TryLowerTilesScope(const tir::ForNode *op) {
     }
     if (const auto *call = expr.as<CallNode>()) {
       const auto *op_node = call->op.as<OpNode>();
+      if (op_node && op_node->name == "tl.infinity") {
+        DataType dtype = CanonicalizeSuvmDType(call->dtype).with_lanes(1);
+        SunMMIOType scalar_type{SunMMIOType::Kind::kScalar, dtype, 1, {}};
+        return builder_->ConstantFloat(NewValueName(), "inf", scalar_type,
+                                       dtype);
+      }
       if (op_node && call->args.size() >= 3 &&
           op_node->name == "tir.if_then_else") {
         return emit_select(call->args[0], call->args[1], call->args[2],
@@ -1620,6 +1655,11 @@ bool CodeGenTileLangSunMMIO::TryLowerTilesScope(const tir::ForNode *op) {
       }
       if (op_node && call->args.size() == 1 && op_node->name == "tir.exp") {
         return emit_unary(TileUnaryOp::kExp, call->args[0], call->dtype);
+      }
+      if (op_node && call->args.size() == 1 && op_node->name == "tir.exp2") {
+        PrimExpr scaled_arg = call->args[0] * FloatImm(call->args[0].dtype(),
+                                                       0.69314718055994530942);
+        return emit_unary(TileUnaryOp::kExp, scaled_arg, call->dtype);
       }
       if (op_node && call->args.size() == 1 &&
           (op_node->name == "tir.fabs" || op_node->name == "tir.abs")) {

--- a/src/target/sunmmio/sunmmio_mlir_builder.cc
+++ b/src/target/sunmmio/sunmmio_mlir_builder.cc
@@ -167,6 +167,13 @@ SunMMIOValue SuvmSunmmioBuilder::TileUnsqueeze(const std::string &result_name,
   return tile_->TileUnsqueeze(result_name, tile, tile_type, axis, dtype);
 }
 
+SunMMIOValue SuvmSunmmioBuilder::TileBroadcast(const std::string &result_name,
+                                               const SunMMIOValue &tile,
+                                               const SunMMIOType &tile_type,
+                                               DataType dtype) {
+  return tile_->TileBroadcast(result_name, tile, tile_type, dtype);
+}
+
 SunMMIOValue
 SuvmSunmmioBuilder::TileSlice(const std::string &result_name,
                               const SunMMIOValue &tile,

--- a/src/target/sunmmio/sunmmio_mlir_builder.h
+++ b/src/target/sunmmio/sunmmio_mlir_builder.h
@@ -96,6 +96,11 @@ public:
                              const SunMMIOType &tile_type, int64_t axis,
                              DataType dtype) final;
 
+  SunMMIOValue TileBroadcast(const std::string &result_name,
+                             const SunMMIOValue &tile,
+                             const SunMMIOType &tile_type,
+                             DataType dtype) final;
+
   SunMMIOValue TileSlice(const std::string &result_name,
                          const SunMMIOValue &tile,
                          const std::vector<SunMMIOValue> &offsets,

--- a/src/target/sunmmio/sunmmio_mlir_tile_op.cc
+++ b/src/target/sunmmio/sunmmio_mlir_tile_op.cc
@@ -531,6 +531,23 @@ SunMMIOValue SunmmioMlirTileOp::TileUnsqueeze(const std::string &result_name,
   return SunMMIOValue{dtype, result_name, tile_type};
 }
 
+SunMMIOValue SunmmioMlirTileOp::TileBroadcast(const std::string &result_name,
+                                              const SunMMIOValue &tile,
+                                              const SunMMIOType &tile_type,
+                                              DataType dtype) {
+  mlir::Type result_type = MapMlirType(ctx_, tile_type);
+  mlir::Value input =
+      ctx_.LookupOrCreateFakeValue(tile, "fake_missing_tile_broadcast_src");
+  mlir::Value tile_value =
+      mlir::suvm::TileBroadcastOp::create(ctx_.builder, MapMlirLoc(ctx_),
+                                          result_type, input)
+          .getResult();
+  if (!result_name.empty()) {
+    ctx_.BindMLIRValue(result_name, tile_value);
+  }
+  return SunMMIOValue{dtype, result_name, tile_type};
+}
+
 SunMMIOValue
 SunmmioMlirTileOp::TileSlice(const std::string &result_name,
                              const SunMMIOValue &tile,

--- a/src/target/sunmmio/sunmmio_mlir_tile_op.h
+++ b/src/target/sunmmio/sunmmio_mlir_tile_op.h
@@ -50,6 +50,10 @@ public:
                              const SunMMIOType &tile_type, int64_t axis,
                              DataType dtype);
 
+  SunMMIOValue TileBroadcast(const std::string &result_name,
+                             const SunMMIOValue &tile,
+                             const SunMMIOType &tile_type, DataType dtype);
+
   SunMMIOValue TileSlice(const std::string &result_name,
                          const SunMMIOValue &tile,
                          const std::vector<SunMMIOValue> &offsets,

--- a/testing/python/target/compile_pipeline.py
+++ b/testing/python/target/compile_pipeline.py
@@ -1,0 +1,597 @@
+import os
+import re
+import warnings
+import tilelang
+from tilelang import tvm
+from tilelang.transform import PassConfigKey
+from tilelang.utils.target import determine_target
+from typing import Any, Literal, Callable
+from tvm.target import Target
+from tilelang.language.eager import PrimFunc
+from tvm import tir, IRModule
+from tvm.ir import CallingConv
+from tilelang.engine.param import KernelParam
+from tilelang.transform import PassContext
+from tilelang.contrib.nvcc import have_tma
+from tilelang.utils.target import target_is_sunmmio
+from tilelang.jit.adapter.utils import is_cuda_target
+
+
+def allow_warp_specialized(pass_ctx: PassContext | None = None, target: Target | None = None) -> bool:
+    if pass_ctx is None:
+        pass_ctx = tilelang.transform.get_pass_context()
+    if (not is_cuda_target(target)) or (not have_tma(target)):
+        return False
+    disable_warp_specialized = pass_ctx.config.get("tl.disable_warp_specialized", False)
+    return not disable_warp_specialized
+
+
+def allow_tma_and_warp_specialized(pass_ctx: PassContext | None = None, target: Target | None = None) -> bool:
+    if pass_ctx is None:
+        pass_ctx = tilelang.transform.get_pass_context()
+    if not have_tma(target):
+        return False
+    disable_tma_lower = pass_ctx.config.get("tl.disable_tma_lower", False)
+    return not disable_tma_lower and allow_warp_specialized(pass_ctx=pass_ctx, target=target)
+
+
+def allow_fence_proxy(target: Target | None = None) -> bool:
+    return have_tma(target)
+
+
+def allow_vectorize(pass_ctx: PassContext | None = None) -> bool:
+    if pass_ctx is None:
+        pass_ctx = tilelang.transform.get_pass_context()
+    disable_vectorize = pass_ctx.config.get("tir.disable_vectorize", False)
+    return not disable_vectorize
+
+
+def allow_global_thread_synchronization(pass_ctx: PassContext | None = None) -> bool:
+    if pass_ctx is None:
+        pass_ctx = tilelang.transform.get_pass_context()
+    enable_global_thread_sync = pass_ctx.config.get("tir.detect_global_barrier", False)
+    return enable_global_thread_sync
+
+
+def should_enable_aggressive_merge(pass_ctx: PassContext | None = None, target: Target | None = None) -> bool:
+    if pass_ctx is None:
+        pass_ctx = tilelang.transform.get_pass_context()
+    enable_aggressive_merge = bool(pass_ctx.config.get(tilelang.PassConfigKey.TL_ENABLE_AGGRESSIVE_SHARED_MEMORY_MERGE, False))
+    if allow_warp_specialized(pass_ctx=pass_ctx, target=target):
+        enable_aggressive_merge = False
+    return enable_aggressive_merge
+
+
+def should_force_let_inline(pass_ctx: PassContext | None = None) -> bool:
+    if pass_ctx is None:
+        pass_ctx = tilelang.transform.get_pass_context()
+    return bool(pass_ctx and pass_ctx.config.get(tilelang.PassConfigKey.TL_FORCE_LET_INLINE, False))
+
+
+def should_enable_ast_print(pass_ctx: PassContext | None = None) -> bool:
+    if pass_ctx is None:
+        pass_ctx = tilelang.transform.get_pass_context()
+    return bool(pass_ctx and pass_ctx.config.get(tilelang.PassConfigKey.TL_AST_PRINT_ENABLE, False))
+
+
+def should_enable_layout_visual(pass_ctx: PassContext | None = None) -> bool:
+    if pass_ctx is None:
+        pass_ctx = tilelang.transform.get_pass_context()
+    enabled = pass_ctx.config.get(tilelang.PassConfigKey.TL_LAYOUT_VISUALIZATION_ENABLE, False)
+    return enabled
+
+
+def should_enable_race_check(pass_ctx: PassContext | None = None) -> bool:
+    if pass_ctx is None:
+        pass_ctx = tilelang.transform.get_pass_context()
+    enabled = not pass_ctx.config.get(tilelang.PassConfigKey.TL_DISABLE_DATA_RACE_CHECK, False)
+    return enabled
+
+
+def get_layout_visual_formats(pass_ctx: PassContext | None = None) -> list[str]:
+    if pass_ctx is None:
+        pass_ctx = tilelang.transform.get_pass_context()
+    formats_value = pass_ctx.config.get(tilelang.PassConfigKey.TL_LAYOUT_VISUALIZATION_FORMATS, "")
+    if not formats_value:
+        return ["txt"]
+
+    formats_str = formats_value.strip().lower()
+    valid_formats = ["txt", "png", "pdf", "svg", "all"]
+
+    if formats_str == "all":
+        return ["txt", "png", "pdf", "svg"]
+
+    if "," in formats_str:
+        formats_list = [f.strip() for f in formats_str.split(",")]
+    else:
+        formats_list = [formats_str]
+
+    invalid_formats = [f for f in formats_list if f not in valid_formats]
+    if invalid_formats:
+        raise ValueError(
+            f"Invalid formats for TL_LAYOUT_VISUALIZATION_FORMATS: {invalid_formats}. "
+            f"Valid formats are: {valid_formats}. "
+            f"You can choose one of the valid formats or a comma-separated list of formats.(e.g., 'txt,png,pdf')"
+        )
+    return formats_list
+
+
+def LayoutVisual(mod: IRModule) -> None:
+    if should_enable_layout_visual():
+        formats = get_layout_visual_formats()
+        tilelang.analysis.LayoutVisual(formats=formats)(mod)
+
+
+def is_cpu_device_backend(target: Target):
+    return target.kind.name == "c"
+
+
+def has_device_kernel_launch(attrs) -> bool:
+    """Check if the attributes indicate a device kernel launch."""
+    return bool(attrs and "calling_conv" in attrs and attrs["calling_conv"] == CallingConv.DEVICE_KERNEL_LAUNCH)
+
+
+def is_device_call_c_device(func: tir.PrimFunc):
+    attrs = func.attrs
+    calling_conv = attrs.get("calling_conv", CallingConv.DEFAULT)
+    is_cpacked = calling_conv == CallingConv.C_PACKED_FUNC
+
+    # Check if it's a C target
+    if "target" in attrs and attrs["target"].kind.name == "c" and not is_cpacked:
+        return True
+
+    return has_device_kernel_launch(attrs)
+
+
+def is_device_call(func: tir.PrimFunc):
+    return has_device_kernel_launch(func.attrs)
+
+
+def get_device_call(is_device_c: bool = False) -> Callable[[tir.PrimFunc], bool]:
+    return is_device_call_c_device if is_device_c else is_device_call
+
+
+def get_host_call(is_device_c: bool = False) -> Callable[[tir.PrimFunc], bool]:
+    return lambda func: not get_device_call(is_device_c)(func)
+
+
+def is_sunmmio_call(func: tir.PrimFunc):
+    attrs = func.attrs
+    return bool(attrs and "target" in attrs and target_is_sunmmio(attrs["target"]))
+
+
+def get_device_call_sunmmio() -> Callable[[tir.PrimFunc], bool]:
+    return is_sunmmio_call
+
+
+def get_host_call_sunmmio() -> Callable[[tir.PrimFunc], bool]:
+    return lambda func: not is_sunmmio_call(func)
+
+
+def extrac_params(func: tir.PrimFunc) -> list[KernelParam]:
+    tensor_types = []
+    for var in func.params:
+        if var in func.buffer_map:
+            tensor_types.append(KernelParam.from_buffer(func.buffer_map[var]))
+        else:
+            tensor_types.append(KernelParam.from_var(var))
+    return tensor_types
+
+
+def canon_target_host(target: str | Target, target_host: str | Target | None):
+    if not target_host:
+        target_host = "llvm" if tvm.runtime.enabled("llvm") else "c"
+    return target_host
+
+
+def PreLowerSemanticCheck(mod: IRModule) -> None:
+    if should_enable_ast_print():
+        tilelang.analysis.ASTPrinter()(mod)
+    tilelang.analysis.NestedLoopChecker()(mod)
+    tilelang.analysis.FragmentLoopChecker()(mod)
+
+
+def pass_test(mod: IRModule, pass_name: str, test_config: dict[str, Any]) -> None:
+    if pass_name in test_config:
+        test_info = test_config[pass_name]
+        print(f"testing {pass_name}")
+        if "script_expected" in test_info:
+            expect = test_info["script_expected"]
+            if isinstance(expect, str):
+                expect = [expect.strip()]
+            elif isinstance(expect, list):
+                for lines in expect:
+                    assert isinstance(lines, str), f"Invalid type for script_expected: {type(lines)}"
+                expect = [lines.strip() for lines in expect]
+            else:
+                raise ValueError(f"Invalid type for script_expected: {type(expect)}")
+            script = mod.script(show_meta=True).strip()
+            error_msg = f"The generated script of {pass_name} does not match the expected output."
+            if "show_generated_script" in test_info and test_info["show_generated_script"]:
+                error_msg = error_msg + f"\nGenerated script:\n{script}"
+            for lines in expect:
+                if lines not in script:
+                    warnings.warn(error_msg, stacklevel=2)
+
+        if "formal_verify" in test_info:
+            formal_verify = test_info["formal_verify"]
+            if isinstance(formal_verify, list):
+                for test_func in formal_verify:
+                    test_func(mod)
+            else:
+                formal_verify(mod)
+
+
+def LowerAndLegalize_sunmmio_test(
+    mod: IRModule,
+    target: Target,
+    test_config: dict[str, Any] | None = None,
+    log_pass_output: bool = False,
+    show_meta: bool = False,
+    log_dir: str = "./",
+    log_passes: list[str] | None = None,
+) -> IRModule:
+    if test_config is None:
+        test_config = {}
+    out_file = os.path.join(log_dir, "passes_lower_and_legalize.log")
+    if log_pass_output:
+        print(f"Logging pass output in LowerAndLegalize to {out_file}")
+        with open(out_file, "w") as f:
+            f.write("\n'=== Initial Mod ==='\n")
+            if log_passes is None:
+                f.write(mod.script(show_meta=show_meta).strip() + "\n\n")
+
+    def pass_output_process(mod: IRModule, pass_name: str, test_config: dict[str, Any]) -> None:
+        if log_pass_output and (log_passes is None or pass_name in log_passes):
+            with open(out_file, "a") as f:
+                f.write(f"'=== After Pass {pass_name} ==='\n")
+                f.write(mod.script(show_meta=show_meta).strip() + "\n\n")
+        pass_test(mod, pass_name, test_config)
+
+    mod = tir.transform.BindTarget(target)(mod)
+    pass_output_process(mod, "BindTarget", test_config)
+
+    if should_force_let_inline():
+        mod = tilelang.transform.LetInline()(mod)
+        pass_output_process(mod, "LetInline", test_config)
+
+    # mod = tilelang.transform.AddWrapperForSingleBufStore()(mod)
+    mod = tilelang.transform.LegalizeNegativeIndex()(mod)
+    pass_output_process(mod, "LegalizeNegativeIndex", test_config)
+
+    # if should_enable_race_check():
+    #     mod = tilelang.transform.VerifyParallelLoop()(mod)
+    mod = tilelang.transform.InjectAssumes()(mod)
+    pass_output_process(mod, "InjectAssumes", test_config)
+
+    mod = tilelang.transform.Simplify()(mod)
+    pass_output_process(mod, "Simplify_lower_1", test_config)
+
+    mod = tilelang.transform.InferSramScope()(mod)
+    pass_output_process(mod, "InferSramScope", test_config)
+
+    mod = tilelang.transform.LegalizeSunmmioDataPath()(mod)
+    pass_output_process(mod, "LegalizeSunmmioDataPath", test_config)
+
+    # mod = tilelang.transform.LayoutReducer()(mod)
+    mod = tilelang.transform.SunmmioLayoutInference()(mod)
+    pass_output_process(mod, "SunmmioLayoutInference", test_config)
+
+    LayoutVisual(mod)
+    mod = tilelang.transform.LowerTileOp()(mod)
+    pass_output_process(mod, "LowerTileOp", test_config)
+
+    mod = tilelang.transform.LegalizeTilesLoop()(mod)
+    pass_output_process(mod, "LegalizeTilesLoop", test_config)
+
+    mod = tilelang.transform.TilesLoop()(mod)
+    pass_output_process(mod, "TilesLoop", test_config)
+
+    # mod = tilelang.transform.LowerL2Persistent()(mod)
+    # mod = tilelang.transform.DecoupleTypeCast()(mod)
+    # pass_output_process(mod, "DecoupleTypeCast", test_config)
+
+    mod = tilelang.transform.LegalizeVectorizedLoop()(mod)
+    pass_output_process(mod, "LegalizeVectorizedLoop", test_config)
+
+    mod = tilelang.transform.LegalizeSafeMemoryAccess()(mod)
+    pass_output_process(mod, "LegalizeSafeMemoryAccess", test_config)
+
+    mod = tilelang.transform.LowerAccessPtr()(mod)
+    pass_output_process(mod, "LowerAccessPtr", test_config)
+
+    mod = tilelang.transform.Simplify()(mod)
+    pass_output_process(mod, "Simplify_lower_2", test_config)
+
+    mod = tilelang.transform.HoistNonRestrictParams()(mod)
+    pass_output_process(mod, "HoistNonRestrictParams", test_config)
+
+    mod = tilelang.transform.HoistBlockAnnotationsToFuncAttrs()(mod)
+    pass_output_process(mod, "HoistBlockAnnotationsToFuncAttrs", test_config)
+
+    return mod
+
+
+def OptimizeForSunmmio_test(
+    mod: IRModule,
+    target: Target,
+    test_config: dict[str, Any] | None = None,
+    log_pass_output: bool = False,
+    show_meta: bool = False,
+    log_dir: str = "./",
+    log_passes: list[str] | None = None,
+) -> IRModule:
+    if test_config is None:
+        test_config = {}
+    out_file = os.path.join(log_dir, "passes_optimize_for_sunmmio.log")
+    if log_pass_output:
+        print(f"Logging pass output in OptimizeForSunmmio to {out_file}")
+        with open(out_file, "w") as f:
+            f.write("\n'=== Initial Mod ==='\n")
+            if log_passes is None:
+                f.write(mod.script(show_meta=show_meta).strip() + "\n\n")
+
+    def pass_output_process(mod: IRModule, pass_name: str, test_config: dict[str, Any]) -> None:
+        if log_pass_output and (log_passes is None or pass_name in log_passes):
+            with open(out_file, "a") as f:
+                f.write(f"'=== After Pass {pass_name} ==='\n")
+                f.write(mod.script(show_meta=show_meta).strip() + "\n\n")
+        pass_test(mod, pass_name, test_config)
+
+    mod = tilelang.transform.IfStmtBinding()(mod)
+    pass_output_process(mod, "IfStmtBinding", test_config)
+
+    mod = tilelang.transform.SunmmioPipelinePlanning(debug=False)(mod)
+    pass_output_process(mod, "SunmmioPipelinePlanning", test_config)
+
+    mod = tilelang.transform.InjectSunmmioPipeline()(mod)
+    pass_output_process(mod, "InjectSunmmioPipeline", test_config)
+
+    # mod = tilelang.transform.PlanAndUpdateBufferAllocationLocation()(mod)
+    # pass_output_process(mod, "PlanAndUpdateBufferAllocationLocation", test_config)
+
+    mod = tilelang.transform.LowerOpaqueBlock()(mod)
+    pass_output_process(mod, "LowerOpaqueBlock", test_config)
+
+    mod = tilelang.transform.Simplify()(mod)
+    pass_output_process(mod, "Simplify_optimize_1", test_config)
+
+    mod = tir.transform.NarrowDataType(32)(mod)
+    pass_output_process(mod, "NarrowDataType", test_config)
+
+    # mod = tilelang.transform.FlattenBuffer()(mod)
+    # pass_output_process(mod, "FlattenBuffer", test_config)
+
+    mod = tilelang.transform.ConfigIndexBitwidth()(mod)
+    pass_output_process(mod, "ConfigIndexBitwidth", test_config)
+
+    mod = tir.transform.Simplify()(mod)
+    pass_output_process(mod, "Simplify_optimize_2", test_config)
+
+    # mod = tilelang.transform.VectorizeLoop(enable_vectorize=True)(mod)
+    # pass_output_process(mod, "VectorizeLoop", test_config)
+
+    # mod = tilelang.transform.StorageRewrite()(mod)
+    # pass_output_process(mod, "StorageRewrite", test_config)
+
+    mod = tilelang.transform.LoopUnswitching()(mod)
+    pass_output_process(mod, "LoopUnswitching", test_config)
+
+    mod = tir.transform.UnrollLoop()(mod)
+    pass_output_process(mod, "UnrollLoop", test_config)
+
+    mod = tir.transform.RenormalizeSplitPattern()(mod)
+    pass_output_process(mod, "RenormalizeSplitPattern", test_config)
+
+    mod = tir.transform.Simplify()(mod)
+    pass_output_process(mod, "Simplify_optimize_3", test_config)
+
+    # return
+    mod = tir.transform.RemoveNoOp()(mod)
+    pass_output_process(mod, "RemoveNoOp", test_config)
+
+    mod = tir.transform.HoistIfThenElse()(mod)
+    pass_output_process(mod, "HoistIfThenElse", test_config)
+
+    mod = tir.transform.VerifyMemory()(mod)
+    pass_output_process(mod, "VerifyMemory", test_config)
+
+    mod = tir.transform.AnnotateEntryFunc()(mod)
+    pass_output_process(mod, "AnnotateEntryFunc", test_config)
+
+    mod = tilelang.transform.AnnotateDeviceRegions()(mod)
+    pass_output_process(mod, "AnnotateDeviceRegions", test_config)
+
+    mod = tilelang.transform.SplitHostDevice()(mod)
+    pass_output_process(mod, "SplitHostDevice", test_config)
+
+    mod = tilelang.transform.AnnotateReadOnlyParams()(mod)
+    pass_output_process(mod, "AnnotateReadOnlyParams", test_config)
+
+    mod = tilelang.transform.MergeIfStmt()(mod)
+    pass_output_process(mod, "MergeIfStmt", test_config)
+
+    mod = tilelang.transform.InjectSunmmioSync()(mod)
+    pass_output_process(mod, "InjectSunmmioSync", test_config)
+
+    mod = tilelang.transform.MakePackedAPI()(mod)
+    pass_output_process(mod, "MakePackedAPI", test_config)
+
+    mod = tilelang.transform.Simplify()(mod)
+    pass_output_process(mod, "Simplify_optimize_4", test_config)
+
+    mod = tilelang.transform.LowerDeviceKernelLaunch()(mod)
+    pass_output_process(mod, "LowerDeviceKernelLaunch", test_config)
+
+    return mod
+
+
+def process_passes_output(log_dir, filenames, remove_header=False):
+    def clean_header(text):
+        if not remove_header:
+            return text
+        # Header to remove:
+        # # from tvm.script import ir as I
+        # # from tvm.script import tir as T
+        #
+        # @I.ir_module
+        header_pattern = r"# from tvm\.script import ir as I\s*\n# from tvm\.script import tir as T\s*\n\s*\n@I\.ir_module\s*\n"
+        text = re.sub(header_pattern, "", text)
+
+        # Metadata omitted comment to remove
+        meta_pattern = r"\n\s*\n# Metadata omitted\. Use show_meta=True in script\(\) method to show it\.\s*\n\n"
+        text = re.sub(meta_pattern, "\n", text)
+        return text
+
+    for filename in filenames:
+        log_file = os.path.join(log_dir, filename)
+        if not os.path.exists(log_file):
+            continue
+
+        with open(log_file, "r") as f:
+            content = f.read()
+
+        # Split by the "=== After Pass ... ===" or "=== Initial Mod ===" markers
+        # We need to capture the markers to keep them
+        pattern = r"('(?:=== Initial Mod ===|=== After Pass [^=]+ ===)')"
+        parts = re.split(pattern, content)
+
+        if len(parts) < 3:
+            continue
+
+        new_parts = [parts[0]]
+        # Always keep the first pass (Initial Mod)
+        new_parts.append(parts[1])
+        new_parts.append("\n" + clean_header(parts[2]).strip() + "\n")
+
+        last_content = parts[2].strip()
+
+        for i in range(3, len(parts), 2):
+            header = parts[i]
+            current_content = parts[i + 1]
+
+            # Compare current content with last content
+            if current_content.strip() == last_content:
+                new_parts.append(header)
+                new_parts.append("\nNo change.\n")
+            else:
+                new_parts.append(header)
+                new_parts.append("\n" + clean_header(current_content).strip() + "\n")
+                last_content = current_content.strip()
+
+        with open(log_file, "w") as f:
+            f.write("".join(new_parts))
+
+
+def compile_test(
+    func: PrimFunc = None,
+    out_idx: list[int] | int | None = None,
+    execution_backend: (Literal["auto", "dlpack", "tvm_ffi", "cython", "nvrtc", "torch", "cutedsl"] | None) = None,
+    target: str | Target | None = None,
+    target_host: str | Target | None = None,
+    pass_configs: dict[str, Any] | None = None,
+    compile_flags: list[str] | str | None = None,
+    test_config: dict[str, Any] | None = None,
+    log_pass_output: bool = False,
+    show_meta: bool = False,
+    log_dir: str = "./",
+    remove_header: bool = False,
+    log_passes: list[str] | None = None,
+):
+    """
+    Compile the given TileLang PrimFunc with TVM and return the host_mod and device_mod.
+    This function mimics tilelang.jit.compile but exposes the intermediate TIR modules.
+    It manually implements the lower logic to avoid failing at codegen step.
+
+    Returns:
+        tuple: (host_mod, device_mod) corresponding to the modules generated in lower.log
+    """
+    if test_config is None:
+        test_config = {}
+
+    for pass_name in test_config:
+        for key in test_config[pass_name]:
+            assert key in [
+                "script_expected",
+                "show_generated_script",
+                "formal_verify",
+            ], f"wrong key :{key} for pass {pass_name}"
+
+    if execution_backend is None:
+        execution_backend = "tvm_ffi"
+
+    if execution_backend == "auto":
+        execution_backend = "tvm_ffi"
+
+    if pass_configs is None:
+        pass_configs = {}
+
+    if compile_flags is not None:
+        compile_flags_cfg = pass_configs.get(PassConfigKey.TL_DEVICE_COMPILE_FLAGS)
+        pass_configs[PassConfigKey.TL_DEVICE_COMPILE_FLAGS] = (
+            compile_flags_cfg + compile_flags if compile_flags_cfg is not None else compile_flags
+        )
+
+    # Determine target
+    target = determine_target(target, return_object=True)
+
+    # Custom Lower implementation
+    func_or_mod = func
+
+    mod = func_or_mod
+    if isinstance(func_or_mod, tir.PrimFunc):
+        func = func_or_mod
+        mod = tvm.IRModule({func.attrs["global_symbol"]: func})
+
+    if isinstance(target, str):
+        target = determine_target(target)
+
+    target_host = canon_target_host(target, target_host)
+
+    target_host = tvm.target.Target.canon_target(target_host)
+    target = tvm.target.Target(target, target_host)
+
+    if target_is_sunmmio(target):
+        _is_host_call = get_host_call_sunmmio()
+        _is_device_call = get_device_call_sunmmio()
+    else:
+        _is_host_call = get_host_call(is_device_c=is_cpu_device_backend(target))
+        _is_device_call = get_device_call(is_device_c=is_cpu_device_backend(target))
+
+    with tvm.transform.PassContext(opt_level=3, config=pass_configs), target:
+        # Before lowering, do semantic check
+        PreLowerSemanticCheck(mod)
+
+        if log_pass_output:
+            os.makedirs(log_dir, exist_ok=True)
+
+        # Phase 1: Lower and legalize the IR module
+        mod = LowerAndLegalize_sunmmio_test(mod, target, test_config, log_pass_output, show_meta, log_dir, log_passes)
+
+        # Phase 2: Optimize the IR for the target
+        mod = OptimizeForSunmmio_test(mod, target, test_config, log_pass_output, show_meta, log_dir, log_passes)
+        host_mod = tir.transform.Filter(_is_host_call)(mod)
+        device_mod = tir.transform.Filter(_is_device_call)(mod)
+
+        out_file = os.path.join(log_dir, "passes_optimize_for_sunmmio.log")
+
+        def _log_pass(pass_name, m):
+            if log_pass_output and (log_passes is None or pass_name in log_passes):
+                with open(out_file, "a") as f:
+                    f.write(f"'=== After Pass {pass_name} ==='\n")
+                    f.write(m.script(show_meta=show_meta).strip() + "\n\n")
+
+        _log_pass("HostMod", host_mod)
+        pass_test(host_mod, "HostMod", test_config)
+
+        _log_pass("DeviceMod", device_mod)
+        pass_test(device_mod, "DeviceMod", test_config)
+
+        if log_pass_output:
+            process_passes_output(
+                log_dir,
+                ["passes_lower_and_legalize.log", "passes_optimize_for_sunmmio.log"],
+                remove_header=remove_header,
+            )
+
+        return host_mod, device_mod

--- a/testing/python/target/sunmmio_codegen_validation_utils.py
+++ b/testing/python/target/sunmmio_codegen_validation_utils.py
@@ -1,0 +1,166 @@
+import os
+import subprocess
+from collections.abc import Sequence
+from pathlib import Path
+
+import pytest
+from compile_pipeline import compile_test
+from tilelang.utils.target import SUNMMIO_TARGET_DESC
+from tilelang import tvm as tvm
+from tilelang.utils.target import determine_target
+
+
+CODEGEN_BACKEND = "suvm"
+NPUIR_OPT_ENV = "NPUIR_OPT"
+PRINT_ENV = "SUNMMIO_TEST_PRINT"
+BASE_EXPECTED_TOKENS = (
+    "module",
+    "suvm.device_arch",
+    "func.func @",
+)
+
+
+def _env_flag(name: str, default: bool = False) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.lower() in ("1", "true", "yes", "on")
+
+
+def _print_enabled(value: bool | None) -> bool:
+    if value is not None:
+        return value
+    return _env_flag(PRINT_ENV)
+
+
+def _repo_root() -> Path:
+    path = Path(__file__).resolve()
+    for parent in path.parents:
+        if (parent / "CMakeLists.txt").exists() and (parent / "3rdparty" / "NPU-IR").exists():
+            return parent
+    raise RuntimeError(f"failed to locate repo root from {path}")
+
+
+def find_npuir_opt() -> Path:
+    candidates = []
+    if os.getenv(NPUIR_OPT_ENV):
+        candidates.append(Path(os.environ[NPUIR_OPT_ENV]))
+    candidates.append(_repo_root() / "build" / "bin" / "npuir-opt")
+
+    for candidate in candidates:
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            return candidate
+
+    candidate_text = "\n".join(str(candidate) for candidate in candidates)
+    pytest.fail(f"npuir-opt executable not found. Checked:\n{candidate_text}")
+
+
+def assert_source_contains(src: str, tokens: Sequence[str]) -> None:
+    missing = [token for token in tokens if token not in src]
+    assert not missing, f"missing expected SUVM MLIR tokens: {missing}\n{src}"
+
+
+def lower_sunmmio_kernel_to_device_tir(
+    kernel,
+    *,
+    print_ir: bool | None = None,
+):
+    target = tvm.target.Target(SUNMMIO_TARGET_DESC)
+    _, device_mod = compile_test(kernel, target=target, remove_header=True)
+
+    assert isinstance(device_mod, tvm.IRModule)
+    assert device_mod.get_global_vars()
+    script = device_mod.script()
+    assert script.strip()
+
+    if _print_enabled(print_ir):
+        print("===================== Lowered SunMMIO Device TIR =====================")
+        print(script)
+
+    return device_mod
+
+
+def codegen_sunmmio_suvm_mlir(
+    device_mod,
+    *,
+    expected_tokens: Sequence[str] = (),
+    print_ir: bool | None = None,
+) -> str:
+    target = determine_target("Sunmmio", return_object=True)
+    builder = tvm.ffi.get_global_func("target.build.tilelang_sunmmio_without_compile")
+    runtime_mod = builder(device_mod, target, CODEGEN_BACKEND)
+    src = runtime_mod.inspect_source()
+
+    assert src.strip()
+    assert_source_contains(src, (*BASE_EXPECTED_TOKENS, *expected_tokens))
+
+    if _print_enabled(print_ir):
+        print("===================== SunMMIO SUVM MLIR =====================")
+        print(src)
+
+    return src
+
+
+def validate_suvm_mlir_with_npuir_opt(
+    src: str,
+    tmp_path: Path,
+    *,
+    mlir_filename: str = "generated_suvm.mlir",
+    opt_args: Sequence[str] = ("-suvm-device-validate",),
+    print_output: bool | None = None,
+):
+    npuir_opt = find_npuir_opt()
+    mlir_path = Path(tmp_path) / mlir_filename
+    mlir_path.write_text(src, encoding="utf-8")
+
+    command = [str(npuir_opt), str(mlir_path), *opt_args]
+    result = subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    if _print_enabled(print_output):
+        print("===================== npuir-opt command =====================")
+        print(" ".join(command))
+        print("===================== npuir-opt stderr =====================")
+        print(result.stderr)
+
+    assert result.returncode == 0, (
+        "npuir-opt SUVM validation failed\n"
+        f"command: {' '.join(command)}\n"
+        f"mlir: {mlir_path}\n"
+        f"stdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
+    )
+    return result
+
+
+def validate_sunmmio_codegen_with_npuir_opt(
+    kernel,
+    tmp_path: Path,
+    *,
+    mlir_filename: str = "generated_suvm.mlir",
+    expected_tokens: Sequence[str] = (),
+    opt_args: Sequence[str] = ("-suvm-device-validate",),
+    print_ir: bool | None = None,
+    print_opt: bool | None = None,
+) -> str:
+    device_mod = lower_sunmmio_kernel_to_device_tir(
+        kernel,
+        print_ir=print_ir,
+    )
+    src = codegen_sunmmio_suvm_mlir(
+        device_mod,
+        expected_tokens=expected_tokens,
+        print_ir=print_ir,
+    )
+    validate_suvm_mlir_with_npuir_opt(
+        src,
+        tmp_path,
+        mlir_filename=mlir_filename,
+        opt_args=opt_args,
+        print_output=print_opt,
+    )
+    return src

--- a/testing/python/target/test_sunmmio_codegen_allocate_copy_expr_opt_validate.py
+++ b/testing/python/target/test_sunmmio_codegen_allocate_copy_expr_opt_validate.py
@@ -1,0 +1,341 @@
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+from tilelang import tvm as tvm
+from tilelang.carver.arch import driver
+from tilelang.layout import make_zz_layout
+from tilelang.utils.target import determine_target
+
+from sunmmio_codegen_validation_utils import (
+    assert_source_contains,
+    validate_suvm_mlir_with_npuir_opt,
+    validate_sunmmio_codegen_with_npuir_opt,
+)
+
+
+tilelang.env.disable_cache()
+
+# Debug logs from this file:
+import os
+
+# print flag
+os.environ["SUNMMIO_TEST_PRINT"] = "1"
+
+
+def basic_allocate_copy_mma_kernel(
+    M=32,
+    N=32,
+    K=32,
+    block_M=32,
+    block_N=32,
+    block_K=32,
+    dtype=T.float16,
+):
+    device_mesh_config = driver.get_sunmmio_device_mesh_config()
+    nrows, ncols = device_mesh_config
+    ncores = nrows * ncols
+    grid_m = T.ceildiv(M, block_M)
+    grid_n = T.ceildiv(N, block_N)
+
+    shard_policy = T.MeshShardingPolicy(x=1, y=0)
+    A_layout = make_zz_layout((M, K))
+    B_layout = make_zz_layout((K, N))
+    C_layout = make_zz_layout((M, N))
+
+    @T.prim_func
+    def main(
+        A: T.MeshTensor((M, K), shard_policy, device_mesh_config, dtype, layout=A_layout),  # type: ignore
+        B: T.MeshTensor((K, N), shard_policy, device_mesh_config, dtype, layout=B_layout),  # type: ignore
+        C: T.MeshTensor((M, N), shard_policy, device_mesh_config, dtype, layout=C_layout),  # type: ignore
+    ):
+        with T.Kernel(ncores) as _cid:
+            A_shared = T.alloc_shared((block_M, block_K), dtype)
+            B_shared = T.alloc_shared((block_K, block_N), dtype)
+            C_shared = T.alloc_shared((block_M, block_N), dtype)
+
+            for by in T.serial(grid_m):
+                for bx in T.serial(grid_n):
+                    T.copy(A[by * block_M, 0], A_shared)
+                    T.copy(B[0, bx * block_N], B_shared)
+                    T.gemm(A_shared, B_shared, C_shared, transpose_B=True)
+                    T.copy(C_shared, C[by * block_M, bx * block_N])
+
+    return main
+
+
+def allocate_dma_copy_kernel_plus(
+    M=512,
+    N=512,
+    K=256,
+    block_M=32,
+    block_N=32,
+    block_K=32,
+    dtype=T.float16,
+):
+    device_mesh_config = driver.get_sunmmio_device_mesh_config()
+    nrows, ncols = device_mesh_config
+    ncores = nrows * ncols
+    grid_n = T.ceildiv(K, block_K)
+
+    shard_policy = T.MeshShardingPolicy(x=1, y=0)
+    A_layout = make_zz_layout((M, K))
+    C_layout = make_zz_layout((M, N))
+
+    @T.prim_func
+    def main(
+        A: T.MeshTensor((M, K), shard_policy, device_mesh_config, dtype, layout=A_layout),  # type: ignore
+        C: T.MeshTensor((M, N), shard_policy, device_mesh_config, dtype, layout=C_layout),  # type: ignore
+    ):
+        with T.Kernel(ncores) as _cid:
+            A_shared = T.alloc_shared((block_M, block_K), dtype)
+            B_shared = T.alloc_shared((block_K, block_N), dtype)
+            C_shared = T.alloc_shared((block_M, block_N), dtype)
+
+            for bx in T.serial(grid_n):
+                # Index exprs: add/mul/rem/min/max on DMA copy paths.
+                ko = (bx + bx) % grid_n
+                m_tile = bx * block_M
+                n_tile = bx * block_N
+                m_offset = m_tile + T.min(bx, 1)
+                n_offset = n_tile + T.max(bx - 1, 0)
+
+                T.copy(A[m_offset, ko * block_K], A_shared)
+                T.copy(A[ko * block_K, n_offset], B_shared)
+                T.gemm(A_shared, B_shared, C_shared, transpose_B=True)
+                T.copy(C_shared, C[m_offset, n_offset])
+
+    return main
+
+
+def offset_region_copy_kernel_plus(
+    M=512,
+    N=512,
+    block_M=64,
+    block_N=64,
+    tile_M=32,
+    tile_N=32,
+    dtype=T.float16,
+):
+    device_mesh_config = driver.get_sunmmio_device_mesh_config()
+    nrows, ncols = device_mesh_config
+    ncores = nrows * ncols
+    grid_m = T.ceildiv(M, block_M)
+    grid_n = T.ceildiv(N, block_N)
+
+    shard_policy = T.MeshShardingPolicy(x=1, y=0)
+    A_layout = make_zz_layout((M, N))
+    B_layout = make_zz_layout((M, N))
+
+    @T.prim_func
+    def main(
+        A: T.MeshTensor((M, N), shard_policy, device_mesh_config, dtype, layout=A_layout),  # type: ignore
+        B: T.MeshTensor((M, N), shard_policy, device_mesh_config, dtype, layout=B_layout),  # type: ignore
+    ):
+        with T.Kernel(ncores) as _cid:
+            A_rsram = T.alloc_shared((block_M, block_N), dtype, scope="shared.rsram")
+
+            for by in T.serial(grid_m):
+                for bx in T.serial(grid_n):
+                    # Integer exprs: add/sub/mul/div/rem for copy offsets.
+                    sum_idx = bx + by
+                    diff_idx = bx - by
+                    scaled_idx = sum_idx * 3 + 1
+                    div_idx = scaled_idx // 2
+                    mod_idx = div_idx % 7
+
+                    # Bool exprs: cmp/and/or/not feeding selects.
+                    lt_cmp = bx < by + 2
+                    le_cmp = by <= bx + 1
+                    ne_cmp = bx != by
+                    eq_cmp = bx == by
+                    gt_cmp = bx > by - 1
+                    ge_cmp = by >= bx - 1
+                    not_lt_le = T.Not(lt_cmp and le_cmp)
+                    row_cond = (lt_cmp and le_cmp) or (ne_cmp and not_lt_le)
+                    col_cond = gt_cmp or ge_cmp
+
+                    # Region exprs: select/min/max in tile-view indices.
+                    row_delta = T.Select(
+                        row_cond,
+                        T.Select(eq_cmp, T.min(mod_idx, 7), T.min(mod_idx + 1, 7)),
+                        T.max(diff_idx, 0),
+                    )
+                    col_delta = T.Select(
+                        col_cond,
+                        T.max((sum_idx * 5) % 11, 0),
+                        T.min(by + 3, 7),
+                    )
+                    src_row = by * block_M + 8 + row_delta
+                    src_col = bx * block_N + 8 + col_delta
+                    rsram_row = 8 + T.min(row_delta, 7)
+                    rsram_col = 8 + T.min(col_delta, 7)
+
+                    T.copy(
+                        A[src_row : src_row + tile_M, src_col : src_col + tile_N],
+                        A_rsram[rsram_row : rsram_row + tile_M, rsram_col : rsram_col + tile_N],
+                    )
+                    T.copy(
+                        A_rsram[rsram_row : rsram_row + tile_M, rsram_col : rsram_col + tile_N],
+                        B[src_row : src_row + tile_M, src_col : src_col + tile_N],
+                    )
+
+    return main
+
+
+def make_non_tile_expr_stmt():
+    i = tvm.tir.Var("i", "int32")
+    j = tvm.tir.Var("j", "int32")
+    v = tvm.tir.Var("v", "int32")
+
+    one = tvm.tir.IntImm("int32", 1)
+    two = tvm.tir.IntImm("int32", 2)
+    three = tvm.tir.IntImm("int32", 3)
+    four = tvm.tir.IntImm("int32", 4)
+
+    int_expr = tvm.tir.Max(
+        tvm.tir.Min(
+            tvm.tir.FloorMod(
+                tvm.tir.FloorDiv(
+                    tvm.tir.Sub(tvm.tir.Mul(tvm.tir.Add(i, j), three), one),
+                    two,
+                ),
+                four,
+            ),
+            tvm.tir.Add(i, four),
+        ),
+        j,
+    )
+    div_mod_expr = tvm.tir.Mod(tvm.tir.Div(tvm.tir.Add(i, four), two), three)
+    cond = tvm.tir.And(
+        tvm.tir.LT(i, four),
+        tvm.tir.Or(tvm.tir.GE(j, one), tvm.tir.Not(tvm.tir.EQ(i, j))),
+    )
+    select_expr = tvm.tir.Select(cond, tvm.tir.Add(i, j), tvm.tir.Sub(i, j))
+    float_expr = tvm.tir.Div(
+        tvm.tir.Mul(
+            tvm.tir.Add(
+                tvm.tir.Cast("float32", tvm.tir.IntImm("int32", 7)),
+                tvm.tir.FloatImm("float32", 1.5),
+            ),
+            tvm.tir.FloatImm("float32", 2.0),
+        ),
+        tvm.tir.FloatImm("float32", 3.0),
+    )
+    let_expr = tvm.tir.Let(
+        v,
+        tvm.tir.Add(i, j),
+        tvm.tir.Max(v, tvm.tir.IntImm("int32", 0)),
+    )
+    let_stmt = tvm.tir.LetStmt(
+        v,
+        tvm.tir.Sub(i, j),
+        tvm.tir.Evaluate(tvm.tir.Min(v, tvm.tir.IntImm("int32", 8))),
+    )
+
+    then_stmt = tvm.tir.SeqStmt(
+        [
+            tvm.tir.Evaluate(int_expr),
+            tvm.tir.Evaluate(select_expr),
+            tvm.tir.Evaluate(float_expr),
+            tvm.tir.Evaluate(let_expr),
+            let_stmt,
+        ]
+    )
+    else_stmt = tvm.tir.Evaluate(div_mod_expr)
+    inner = tvm.tir.IfThenElse(cond, then_stmt, else_stmt)
+    inner_loop = tvm.tir.For(j, 0, 4, tvm.tir.ForKind.SERIAL, inner)
+    return tvm.tir.For(i, 0, 8, tvm.tir.ForKind.SERIAL, inner_loop)
+
+
+def build_sunmmio_source_from_stmt(stmt):
+    target = determine_target("Sunmmio", return_object=True)
+    func = tvm.tir.PrimFunc([], stmt).with_attr("global_symbol", "main")
+    func = func.with_attr("calling_conv", int(tvm.ir.CallingConv.DEVICE_KERNEL_LAUNCH))
+    mod = tvm.IRModule({"main": func})
+    builder = tvm.ffi.get_global_func("target.build.tilelang_sunmmio_without_compile")
+    return builder(mod, target, "suvm").inspect_source()
+
+
+def test_basic_allocate_copy_mma_codegen_validates_with_npuir_opt(tmp_path):
+    validate_sunmmio_codegen_with_npuir_opt(
+        basic_allocate_copy_mma_kernel(),
+        tmp_path,
+        mlir_filename="basic_allocate_copy_mma_suvm.mlir",
+        expected_tokens=("suvm.alloc", "suvm.copy_async", "suvm.tc.mma"),
+    )
+
+
+def test_allocate_dma_copy_codegen_validates_with_npuir_opt(tmp_path):
+    validate_sunmmio_codegen_with_npuir_opt(
+        allocate_dma_copy_kernel_plus(),
+        tmp_path,
+        mlir_filename="allocate_dma_copy_suvm.mlir",
+        expected_tokens=("suvm.copy_async", "suvm.tc.mma"),
+    )
+
+
+def test_offset_region_copy_codegen_validates_with_npuir_opt(tmp_path):
+    src = validate_sunmmio_codegen_with_npuir_opt(
+        offset_region_copy_kernel_plus(),
+        tmp_path,
+        mlir_filename="offset_region_copy_suvm.mlir",
+        expected_tokens=("suvm.copy_async", "suvm.get_partitioned_tile_view"),
+    )
+    assert_source_contains(
+        src,
+        (
+            "arith.index_cast",
+            "arith.addi",
+            "arith.subi",
+            "arith.muli",
+            "arith.divsi",
+            "arith.remsi",
+            "arith.cmpi eq",
+            "arith.cmpi ne",
+            "arith.cmpi slt",
+            "arith.cmpi sle",
+            "arith.andi",
+            "arith.ori",
+            "arith.xori",
+            "arith.select",
+            "arith.minsi",
+            "arith.maxsi",
+        ),
+    )
+
+
+def test_non_tile_expr_codegen_validates_with_npuir_opt(tmp_path):
+    src = build_sunmmio_source_from_stmt(make_non_tile_expr_stmt())
+    assert_source_contains(
+        src,
+        (
+            "scf.for",
+            "scf.if",
+            "arith.index_cast",
+            "arith.addi",
+            "arith.subi",
+            "arith.muli",
+            "arith.divsi",
+            "arith.remsi",
+            "arith.cmpi",
+            "arith.andi",
+            "arith.ori",
+            "arith.xori",
+            "arith.select",
+            "arith.sitofp",
+            "arith.addf",
+            "arith.mulf",
+            "arith.divf",
+            "arith.minsi",
+            "arith.maxsi",
+        ),
+    )
+    validate_suvm_mlir_with_npuir_opt(
+        src,
+        tmp_path,
+        mlir_filename="non_tile_expr_suvm.mlir",
+    )
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/testing/python/target/test_sunmmio_codegen_fill_opt_validate.py
+++ b/testing/python/target/test_sunmmio_codegen_fill_opt_validate.py
@@ -1,0 +1,123 @@
+import os
+
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+from tilelang.carver.arch import driver
+
+from sunmmio_codegen_validation_utils import validate_sunmmio_codegen_with_npuir_opt
+
+
+tilelang.env.disable_cache()
+os.environ["SUNMMIO_TEST_PRINT"] = "0"
+
+LOOSE_OPT_ARGS = ("--verify-each",)
+
+
+def validate_sunmmio_codegen_loose(kernel, tmp_path, *, mlir_filename, expected_tokens=()):
+    return validate_sunmmio_codegen_with_npuir_opt(
+        kernel,
+        tmp_path,
+        mlir_filename=mlir_filename,
+        expected_tokens=expected_tokens,
+        opt_args=LOOSE_OPT_ARGS,
+    )
+
+
+def fill_tiled_test(
+    b=64,
+    m=512,
+    n=1024,
+    block_b=16,
+    block_m=256,
+    block_n=128,
+    dtype="float16",
+):
+    device_mesh_config = driver.get_sunmmio_device_mesh_config()
+    nrows, ncols = device_mesh_config
+    ncores = nrows * ncols
+    grid_b = T.ceildiv(b, block_b)
+    grid_m = T.ceildiv(m, block_m)
+    grid_n = T.ceildiv(n, block_n)
+
+    @T.prim_func
+    def main(A: T.Tensor((b, m, n), dtype)):
+        with T.Kernel(ncores):
+            A_shared = T.alloc_shared((block_b, block_m, block_n), dtype)
+
+            for bz in T.serial(grid_b):
+                for by in T.serial(grid_m):
+                    for bx in T.serial(grid_n):
+                        T.fill(A_shared, T.float16(1.0))
+                        T.fill(A_shared[0:block_b, 0 : block_m // 2, 0:block_n], T.float16(2.0))
+                        T.fill(A_shared[0:block_b, block_m // 2 : block_m, 0:block_n], T.float16(3.0))
+                        T.clear(A_shared)
+                        T.copy(
+                            A_shared,
+                            A[
+                                bz * block_b : (bz + 1) * block_b,
+                                by * block_m : (by + 1) * block_m,
+                                bx * block_n : (bx + 1) * block_n,
+                            ],
+                        )
+
+    return main
+
+
+def fill_tiled_2d_test(
+    m=512,
+    n=1024,
+    block_m=256,
+    block_n=512,
+    dtype="float16",
+):
+    device_mesh_config = driver.get_sunmmio_device_mesh_config()
+    nrows, ncols = device_mesh_config
+    ncores = nrows * ncols
+    grid_m = T.ceildiv(m, block_m)
+    grid_n = T.ceildiv(n, block_n)
+
+    @T.prim_func
+    def main(A: T.Tensor((m, n), dtype)):
+        with T.Kernel(ncores):
+            A_shared = T.alloc_shared((block_m, block_n), dtype)
+
+            for by in T.serial(grid_m):
+                for bx in T.serial(grid_n):
+                    T.fill(A_shared, T.float16(1.0))
+                    T.fill(A_shared[0 : block_m // 2, 0:block_n], T.float16(2.0))
+                    T.fill(A_shared[block_m // 2 : block_m, 0:block_n], T.float16(3.0))
+                    T.clear(A_shared)
+                    T.copy(
+                        A_shared,
+                        A[
+                            by * block_m : (by + 1) * block_m,
+                            bx * block_n : (bx + 1) * block_n,
+                        ],
+                    )
+
+    return main
+
+
+def test_fill_tiled_2d_codegen_validates_with_npuir_opt(tmp_path):
+    src = validate_sunmmio_codegen_with_npuir_opt(
+        fill_tiled_2d_test(),
+        tmp_path,
+        mlir_filename="fill_tiled_2d_suvm.mlir",
+        expected_tokens=("suvm.copy_async", "suvm.tile.fill"),
+    )
+    assert src.count("suvm.tile.fill") >= 4
+
+
+def test_fill_tiled_codegen_validates_loose_with_npuir_opt(tmp_path):
+    src = validate_sunmmio_codegen_loose(
+        fill_tiled_test(),
+        tmp_path,
+        mlir_filename="fill_tiled_suvm.mlir",
+        expected_tokens=("suvm.tile.fill",),
+    )
+    assert src.count("suvm.tile.fill") >= 4
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/testing/python/target/test_sunmmio_codegen_flash_attention_gqa_fwd_bhsd_opt_validate.py
+++ b/testing/python/target/test_sunmmio_codegen_flash_attention_gqa_fwd_bhsd_opt_validate.py
@@ -1,0 +1,132 @@
+import os
+
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+from tilelang.carver.arch import driver
+from tilelang.layout import make_zz_layout
+
+from sunmmio_codegen_validation_utils import (
+    assert_source_contains,
+    validate_sunmmio_codegen_with_npuir_opt,
+)
+
+
+tilelang.env.disable_cache()
+os.environ["SUNMMIO_TEST_PRINT"] = "1"
+
+
+def flashattn_gqa_fwd_bhsd(
+    batch=1,
+    heads=4,
+    seq_len=128,
+    dim=64,
+    groups=1,
+    block_M=64,
+    block_N=64,
+    num_stages=0,
+):
+    scale = (1.0 / dim) ** 0.5 * 1.44269504
+    head_kv = heads // groups
+    q_shape = [batch, seq_len, heads, dim]
+    kv_shape = [batch, seq_len, head_kv, dim]
+    dtype = T.bfloat16
+    accum_dtype = T.float32
+
+    shard_policy = T.MeshShardingPolicy(y=0, x=2)
+    device_mesh_config = driver.get_sunmmio_device_mesh_config()
+    nrows, ncols = device_mesh_config
+    ncores = nrows * ncols
+
+    Q_layout = make_zz_layout(q_shape, [1, 3], (32, 32))
+    K_layout = make_zz_layout(kv_shape, [1, 3], (32, 32))
+    V_layout = make_zz_layout(kv_shape, [1, 3], (32, 32))
+    O_layout = make_zz_layout(q_shape, [1, 3], (32, 32))
+
+    @T.prim_func
+    def main(
+        Q: T.MeshTensor(q_shape, shard_policy, device_mesh_config, dtype, layout=Q_layout),  # type: ignore
+        K: T.MeshTensor(kv_shape, shard_policy, device_mesh_config, dtype, layout=K_layout),  # type: ignore
+        V: T.MeshTensor(kv_shape, shard_policy, device_mesh_config, dtype, layout=V_layout),  # type: ignore
+        Output: T.MeshTensor(q_shape, shard_policy, device_mesh_config, dtype, layout=O_layout),  # type: ignore
+    ):
+        with T.Kernel(ncores) as _cid:
+            sharded_batch = Q.shape[0]
+            sharded_heads = Q.shape[2]
+
+            Q_shared = T.alloc_shared([block_M, dim], dtype)
+            K_shared = T.alloc_shared([block_N, dim], dtype)
+            V_shared = T.alloc_shared([block_N, dim], dtype)
+            O_shared = T.alloc_shared([block_M, dim], dtype)
+            acc_s = T.alloc_shared([block_M, block_N], accum_dtype, scope="shared.rsram")
+            acc_s_cast_local = T.alloc_shared([block_M, block_N], dtype)
+            acc_s_cast = T.alloc_shared([block_M, block_N], dtype)
+            acc_o = T.alloc_shared([block_M, dim], accum_dtype)
+            scores_max = T.alloc_shared([block_M], accum_dtype)
+            scores_max_prev = T.alloc_shared([block_M], accum_dtype)
+            scores_scale = T.alloc_shared([block_M], accum_dtype)
+            scores_sum = T.alloc_shared([block_M], accum_dtype)
+            logsum = T.alloc_shared([block_M], accum_dtype)
+
+            for bz in T.serial(sharded_batch):
+                for by in T.serial(sharded_heads):
+                    for bx in T.serial(T.ceildiv(seq_len, block_M)):
+                        T.copy(Q[bz, bx * block_M : (bx + 1) * block_M, by, :], Q_shared)
+                        T.fill(acc_o, 0)
+                        T.fill(logsum, 0)
+                        T.fill(scores_max, -T.infinity(accum_dtype))
+
+                        loop_range = T.min(T.ceildiv(seq_len, block_N), T.ceildiv((bx + 1) * block_M, block_N))
+                        for k in T.Pipelined(loop_range, num_stages=num_stages):
+                            T.copy(K[bz, k * block_N : (k + 1) * block_N, by // groups, :], K_shared)
+                            for i, j in T.Tiles([block_M, block_N]):
+                                acc_s[i, j] = T.if_then_else(
+                                    bx * block_M + i >= k * block_N + j,
+                                    0,
+                                    -T.infinity(acc_s.dtype),
+                                )
+                            T.gemm(Q_shared, K_shared, acc_s, transpose_B=True)
+
+                            T.copy(scores_max, scores_max_prev)
+                            T.fill(scores_max, -T.infinity(accum_dtype))
+                            T.reduce_max(acc_s, scores_max, dim=1, clear=False)
+                            for i in T.Tiles([block_M]):
+                                scores_max[i] = T.max(scores_max[i], scores_max_prev[i])
+                            for i in T.Tiles([block_M]):
+                                scores_scale[i] = T.exp2(scores_max_prev[i] * scale - scores_max[i] * scale)
+                            for i, j in T.Tiles([block_M, block_N]):
+                                acc_s[i, j] = T.exp2(acc_s[i, j] * scale - scores_max[i] * scale)
+                            T.reduce_sum(acc_s, scores_sum, dim=1)
+                            for i in T.Tiles([block_M]):
+                                logsum[i] = logsum[i] * scores_scale[i] + scores_sum[i]
+                            for i, j in T.Tiles([block_M, block_N]):
+                                acc_s_cast_local[i, j] = acc_s[i, j]
+                            T.copy(acc_s_cast_local, acc_s_cast)
+
+                            for i, j in T.Tiles([block_M, dim]):
+                                acc_o[i, j] *= scores_scale[i]
+
+                            T.copy(V[bz, k * block_N : (k + 1) * block_N, by // groups, :], V_shared)
+                            T.gemm(acc_s_cast, V_shared, acc_o)
+
+                        for i, j in T.Tiles([block_M, dim]):
+                            acc_o[i, j] /= logsum[i]
+                        T.copy(acc_o, O_shared)
+                        T.copy(O_shared, Output[bz, bx * block_M : (bx + 1) * block_M, by, :])
+
+    return main
+
+
+def test_flashattn_gqa_fwd_bhsd_codegen_passes_loose_npuir_opt(tmp_path):
+    src = validate_sunmmio_codegen_with_npuir_opt(
+        flashattn_gqa_fwd_bhsd(),
+        tmp_path,
+        mlir_filename="flashattn_gqa_fwd_bhsd_suvm.mlir",
+        expected_tokens=("suvm.copy_async", "suvm.tc.mma", "suvm.tile.reduce"),
+        opt_args=("--verify-each",),
+    )
+    assert_source_contains(src, ("suvm.tc.mma", "suvm.tile.reduce"))
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/testing/python/target/test_sunmmio_codegen_reduce_opt_validate.py
+++ b/testing/python/target/test_sunmmio_codegen_reduce_opt_validate.py
@@ -1,0 +1,206 @@
+import os
+
+import pytest
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+from tilelang.carver.arch import driver
+
+from sunmmio_codegen_validation_utils import (
+    assert_source_contains,
+    validate_sunmmio_codegen_with_npuir_opt,
+)
+
+
+tilelang.env.disable_cache()
+os.environ["SUNMMIO_TEST_PRINT"] = "1"
+
+
+REDUCE_IN_TILE_CASES = [
+    ((256, 128), 1, True),
+    ((256, 128), 1, False),
+    ((32, 256, 128), 2, True),
+    ((32, 256, 128), 1, False),
+]
+
+LOOSE_OPT_ARGS = ("--verify-each",)
+
+
+def validate_sunmmio_codegen_loose(kernel, tmp_path, *, mlir_filename, expected_tokens=()):
+    return validate_sunmmio_codegen_with_npuir_opt(
+        kernel,
+        tmp_path,
+        mlir_filename=mlir_filename,
+        expected_tokens=expected_tokens,
+        opt_args=LOOSE_OPT_ARGS,
+    )
+
+
+def reduce_kernel_builder(shape, reduce_axis, dtype="float16", clear=True):
+    out_shape = list(shape[:reduce_axis]) + list(shape[reduce_axis + 1 :])
+    if not out_shape:
+        out_shape = [1]
+
+    device_mesh_config = driver.get_sunmmio_device_mesh_config()
+    nrows, ncols = device_mesh_config
+    ncores = nrows * ncols
+
+    @T.prim_func
+    def main(A: T.Tensor(shape, dtype), Out: T.Tensor(out_shape, dtype)):
+        with T.Kernel(ncores):
+            A_shared = T.alloc_shared(shape, dtype, scope="shared.rsram")
+            Out_shared = T.alloc_shared(out_shape, dtype, scope="shared.rsram")
+
+            T.copy(A, A_shared)
+            T.reduce_sum(A_shared, Out_shared, dim=reduce_axis, clear=clear)
+            T.copy(Out_shared, Out)
+
+    return main
+
+
+def reduce_tiled_test(
+    b=64,
+    m=512,
+    n=1024,
+    block_b=32,
+    block_m=256,
+    block_n=128,
+    reduce_axis=1,
+    dtype="float16",
+    clear=False,
+):
+    out_shape_full = (b, m) if reduce_axis == 2 else (b, n) if reduce_axis == 1 else (m, n)
+    out_shape_block = (block_b, block_m) if reduce_axis == 2 else (block_b, block_n) if reduce_axis == 1 else (block_m, block_n)
+
+    device_mesh_config = driver.get_sunmmio_device_mesh_config()
+    nrows, ncols = device_mesh_config
+    ncores = nrows * ncols
+    grid_b = T.ceildiv(b, block_b)
+    grid_m = T.ceildiv(m, block_m)
+    grid_n = T.ceildiv(n, block_n)
+
+    @T.prim_func
+    def main(A: T.Tensor((b, m, n), dtype), Out: T.Tensor(out_shape_full, dtype)):
+        with T.Kernel(ncores):
+            A_shared = T.alloc_shared((block_b, block_m, block_n), dtype, scope="shared.rsram")
+            Out_shared = T.alloc_shared(out_shape_block, dtype, scope="shared.rsram")
+
+            if reduce_axis == 2:
+                for bz in T.serial(grid_b):
+                    for by in T.serial(grid_m):
+                        if clear:
+                            T.fill(Out_shared, 0)
+                        else:
+                            T.copy(
+                                Out[
+                                    bz * block_b : (bz + 1) * block_b,
+                                    by * block_m : (by + 1) * block_m,
+                                ],
+                                Out_shared,
+                            )
+                        for bx in T.serial(grid_n):
+                            T.copy(
+                                A[
+                                    bz * block_b : (bz + 1) * block_b,
+                                    by * block_m : (by + 1) * block_m,
+                                    bx * block_n : (bx + 1) * block_n,
+                                ],
+                                A_shared,
+                            )
+                            T.reduce_abssum(A_shared, Out_shared, dim=reduce_axis, clear=False)
+                        T.copy(
+                            Out_shared,
+                            Out[
+                                bz * block_b : (bz + 1) * block_b,
+                                by * block_m : (by + 1) * block_m,
+                            ],
+                        )
+            elif reduce_axis == 1:
+                for bz in T.serial(grid_b):
+                    for bx in T.serial(grid_n):
+                        if clear:
+                            T.fill(Out_shared, 0)
+                        else:
+                            T.copy(
+                                Out[
+                                    bz * block_b : (bz + 1) * block_b,
+                                    bx * block_n : (bx + 1) * block_n,
+                                ],
+                                Out_shared,
+                            )
+                        for by in T.serial(grid_m):
+                            T.copy(
+                                A[
+                                    bz * block_b : (bz + 1) * block_b,
+                                    by * block_m : (by + 1) * block_m,
+                                    bx * block_n : (bx + 1) * block_n,
+                                ],
+                                A_shared,
+                            )
+                            T.reduce_abssum(A_shared, Out_shared, dim=reduce_axis, clear=False)
+                        T.copy(
+                            Out_shared,
+                            Out[
+                                bz * block_b : (bz + 1) * block_b,
+                                bx * block_n : (bx + 1) * block_n,
+                            ],
+                        )
+            else:
+                for by in T.serial(grid_m):
+                    for bx in T.serial(grid_n):
+                        if clear:
+                            T.fill(Out_shared, 0)
+                        else:
+                            T.copy(
+                                Out[
+                                    by * block_m : (by + 1) * block_m,
+                                    bx * block_n : (bx + 1) * block_n,
+                                ],
+                                Out_shared,
+                            )
+                        for bz in T.serial(grid_b):
+                            T.copy(
+                                A[
+                                    bz * block_b : (bz + 1) * block_b,
+                                    by * block_m : (by + 1) * block_m,
+                                    bx * block_n : (bx + 1) * block_n,
+                                ],
+                                A_shared,
+                            )
+                            T.reduce_abssum(A_shared, Out_shared, dim=reduce_axis, clear=False)
+                        T.copy(
+                            Out_shared,
+                            Out[
+                                by * block_m : (by + 1) * block_m,
+                                bx * block_n : (bx + 1) * block_n,
+                            ],
+                        )
+
+    return main
+
+
+@pytest.mark.parametrize("shape,reduce_axis,clear", REDUCE_IN_TILE_CASES)
+def test_reduce_generic_in_tile_codegen_generates_expected_ops(tmp_path, shape, reduce_axis, clear):
+    shape_label = "x".join(str(dim) for dim in shape)
+    src = validate_sunmmio_codegen_loose(
+        reduce_kernel_builder(shape, reduce_axis, clear=clear),
+        tmp_path,
+        mlir_filename=f"reduce_shape_{shape_label}_axis_{reduce_axis}_suvm.mlir",
+        expected_tokens=("suvm.copy_async", "suvm.tile.reduce"),
+    )
+    assert_source_contains(src, ("suvm.tile.reduce", "sum"))
+
+
+@pytest.mark.parametrize("reduce_axis,clear", [(1, False), (2, True)])
+def test_reduce_tiled_in_tile_codegen_generates_expected_ops(tmp_path, reduce_axis, clear):
+    src = validate_sunmmio_codegen_loose(
+        reduce_tiled_test(reduce_axis=reduce_axis, clear=clear),
+        tmp_path,
+        mlir_filename=f"reduce_tiled_axis_{reduce_axis}_suvm.mlir",
+        expected_tokens=("suvm.copy_async", "suvm.tile.reduce"),
+    )
+    assert_source_contains(src, ("suvm.tile.reduce", "sum"))
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/testing/python/target/test_sunmmio_codegen_tile_ops_opt_validate.py
+++ b/testing/python/target/test_sunmmio_codegen_tile_ops_opt_validate.py
@@ -1,0 +1,242 @@
+import os
+
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+from tilelang.carver.arch import driver
+
+from sunmmio_codegen_validation_utils import (
+    assert_source_contains,
+    validate_sunmmio_codegen_with_npuir_opt,
+)
+
+
+tilelang.env.disable_cache()
+os.environ["SUNMMIO_TEST_PRINT"] = "0"
+
+LOOSE_OPT_ARGS = ("--verify-each",)
+
+
+def validate_sunmmio_codegen_loose(kernel, tmp_path, *, mlir_filename, expected_tokens=()):
+    return validate_sunmmio_codegen_with_npuir_opt(
+        kernel,
+        tmp_path,
+        mlir_filename=mlir_filename,
+        expected_tokens=expected_tokens,
+        opt_args=LOOSE_OPT_ARGS,
+    )
+
+
+def tile_elementwise_ops_test(
+    batch=2,
+    m=256,
+    n=128,
+    block_b=2,
+    block_m=256,
+    block_n=128,
+    dtype="float16",
+):
+    device_mesh_config = driver.get_sunmmio_device_mesh_config()
+    nrows, ncols = device_mesh_config
+    ncores = nrows * ncols
+    grid_b = T.ceildiv(batch, block_b)
+    grid_m = T.ceildiv(m, block_m)
+    grid_n = T.ceildiv(n, block_n)
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((batch, m, n), dtype),
+        B: T.Tensor((batch, m, n), dtype),
+        C: T.Tensor((batch, m, n), dtype),
+    ):
+        with T.Kernel(ncores):
+            A_shared = T.alloc_shared((block_b, block_m, block_n), dtype)
+            B_shared = T.alloc_shared((block_b, block_m, block_n), dtype)
+            C_shared = T.alloc_shared((block_b, block_m, block_n), dtype)
+
+            for bz in T.serial(grid_b):
+                for by in T.serial(grid_m):
+                    for bx in T.serial(grid_n):
+                        T.copy(
+                            A[
+                                bz * block_b : (bz + 1) * block_b,
+                                by * block_m : (by + 1) * block_m,
+                                bx * block_n : (bx + 1) * block_n,
+                            ],
+                            A_shared,
+                        )
+                        T.copy(
+                            B[
+                                bz * block_b : (bz + 1) * block_b,
+                                by * block_m : (by + 1) * block_m,
+                                bx * block_n : (bx + 1) * block_n,
+                            ],
+                            B_shared,
+                        )
+
+                        for b, i, j in T.Tiles(A_shared, parallel=True):
+                            x = T.max(A_shared[b, i, j], B_shared[b, i, j])
+                            y = T.min(x, T.exp(B_shared[b, i, j]))
+                            z = T.log(T.abs(y) + T.float32(1.0))
+                            C_shared[b, i, j] = T.if_then_else(
+                                z > T.float32(0.5),
+                                T.rsqrt(z + T.float32(1.0)),
+                                T.ieee_frcp(z + T.float32(2.0)),
+                            )
+
+                        for b, i, j in T.Tiles(A_shared, parallel=True):
+                            neg_a = T.float32(0.0) - T.Cast("float32", A_shared[b, i, j])
+                            rem_b = T.fmod(T.Cast("float32", B_shared[b, i, j]), T.float32(3.0))
+                            C_shared[b, i, j] = (
+                                T.ceil(C_shared[b, i, j])
+                                + T.floor(A_shared[b, i, j])
+                                + T.round(B_shared[b, i, j])
+                                + T.trunc(A_shared[b, i, j])
+                                + neg_a
+                                + rem_b
+                            )
+
+                        T.copy(
+                            C_shared,
+                            C[
+                                bz * block_b : (bz + 1) * block_b,
+                                by * block_m : (by + 1) * block_m,
+                                bx * block_n : (bx + 1) * block_n,
+                            ],
+                        )
+
+    return main
+
+
+def tile_elementwise_ops_2d_test(
+    m=256,
+    n=1024,
+    block_m=256,
+    block_n=512,
+    dtype="float16",
+):
+    device_mesh_config = driver.get_sunmmio_device_mesh_config()
+    nrows, ncols = device_mesh_config
+    ncores = nrows * ncols
+    grid_m = T.ceildiv(m, block_m)
+    grid_n = T.ceildiv(n, block_n)
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((m, n), dtype),
+        B: T.Tensor((m, n), dtype),
+        C: T.Tensor((m, n), dtype),
+    ):
+        with T.Kernel(ncores):
+            A_shared = T.alloc_shared((block_m, block_n), dtype)
+            B_shared = T.alloc_shared((block_m, block_n), dtype)
+            C_shared = T.alloc_shared((block_m, block_n), dtype)
+
+            for by in T.serial(grid_m):
+                for bx in T.serial(grid_n):
+                    T.copy(
+                        A[
+                            by * block_m : (by + 1) * block_m,
+                            bx * block_n : (bx + 1) * block_n,
+                        ],
+                        A_shared,
+                    )
+                    T.copy(
+                        B[
+                            by * block_m : (by + 1) * block_m,
+                            bx * block_n : (bx + 1) * block_n,
+                        ],
+                        B_shared,
+                    )
+
+                    for i, j in T.Tiles(A_shared, parallel=True):
+                        x = T.max(A_shared[i, j], B_shared[i, j])
+                        y = T.min(x, T.exp(B_shared[i, j]))
+                        z = T.log(T.abs(y) + T.float32(1.0))
+                        C_shared[i, j] = T.if_then_else(
+                            z > T.float32(0.5),
+                            T.rsqrt(z + T.float32(1.0)),
+                            T.ieee_frcp(z + T.float32(2.0)),
+                        )
+
+                    for i, j in T.Tiles(A_shared, parallel=True):
+                        neg_a = T.float32(0.0) - T.Cast("float32", A_shared[i, j])
+                        rem_b = T.fmod(T.Cast("float32", B_shared[i, j]), T.float32(3.0))
+                        C_shared[i, j] = (
+                            T.ceil(C_shared[i, j])
+                            + T.floor(A_shared[i, j])
+                            + T.round(B_shared[i, j])
+                            + T.trunc(A_shared[i, j])
+                            + neg_a
+                            + rem_b
+                        )
+
+                    T.copy(
+                        C_shared,
+                        C[
+                            by * block_m : (by + 1) * block_m,
+                            bx * block_n : (bx + 1) * block_n,
+                        ],
+                    )
+
+    return main
+
+
+def test_tile_elementwise_ops_2d_codegen_validates_with_npuir_opt(tmp_path):
+    src = validate_sunmmio_codegen_with_npuir_opt(
+        tile_elementwise_ops_2d_test(),
+        tmp_path,
+        mlir_filename="tile_elementwise_ops_2d_suvm.mlir",
+        expected_tokens=("suvm.copy_async", "suvm.tile.store"),
+    )
+    assert_source_contains(
+        src,
+        (
+            "suvm.tile.abs",
+            "suvm.tile.ceil",
+            "suvm.tile.cmpf",
+            "suvm.tile.floor",
+            "suvm.tile.ln",
+            "suvm.tile.maxf",
+            "suvm.tile.minf",
+            "suvm.tile.neg",
+            "suvm.tile.recip",
+            "suvm.tile.remf",
+            "suvm.tile.round",
+            "suvm.tile.rsqrt",
+            "suvm.tile.select",
+            "suvm.tile.trunc",
+        ),
+    )
+
+
+def test_tile_elementwise_ops_codegen_validates_loose_with_npuir_opt(tmp_path):
+    src = validate_sunmmio_codegen_loose(
+        tile_elementwise_ops_test(),
+        tmp_path,
+        mlir_filename="tile_elementwise_ops_suvm.mlir",
+        expected_tokens=("suvm.tile.store",),
+    )
+    assert_source_contains(
+        src,
+        (
+            "suvm.tile.abs",
+            "suvm.tile.ceil",
+            "suvm.tile.cmpf",
+            "suvm.tile.floor",
+            "suvm.tile.ln",
+            "suvm.tile.maxf",
+            "suvm.tile.minf",
+            "suvm.tile.neg",
+            "suvm.tile.recip",
+            "suvm.tile.remf",
+            "suvm.tile.round",
+            "suvm.tile.rsqrt",
+            "suvm.tile.select",
+            "suvm.tile.trunc",
+        ),
+    )
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/testing/python/target/test_sunmmio_codegen_tiles_opt_validate.py
+++ b/testing/python/target/test_sunmmio_codegen_tiles_opt_validate.py
@@ -1,0 +1,284 @@
+import os
+
+import pytest
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+from tilelang.carver.arch import driver
+
+from sunmmio_codegen_validation_utils import (
+    assert_source_contains,
+    validate_sunmmio_codegen_with_npuir_opt,
+)
+
+
+tilelang.env.disable_cache()
+os.environ["SUNMMIO_TEST_PRINT"] = "0"
+
+LOOSE_OPT_ARGS = ("--verify-each",)
+
+
+def validate_sunmmio_codegen_loose(kernel, tmp_path, *, mlir_filename, expected_tokens=()):
+    return validate_sunmmio_codegen_with_npuir_opt(
+        kernel,
+        tmp_path,
+        mlir_filename=mlir_filename,
+        expected_tokens=expected_tokens,
+        opt_args=LOOSE_OPT_ARGS,
+    )
+
+
+def dot_mul_tiled_parallel_3d(
+    batch=64,
+    m=512,
+    n=1024,
+    block_b=2,
+    block_m=256,
+    block_n=128,
+    dtype="bfloat16",
+    accum_dtype="bfloat16",
+):
+    device_mesh_config = driver.get_sunmmio_device_mesh_config()
+    nrows, ncols = device_mesh_config
+    ncores = nrows * ncols
+    grid_b = T.ceildiv(batch, block_b)
+    grid_m = T.ceildiv(m, block_m)
+    grid_n = T.ceildiv(n, block_n)
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((batch, m, n), dtype),
+        B: T.Tensor((batch, m, n), dtype),
+        C: T.Tensor((batch, m, n), dtype),
+    ):
+        with T.Kernel(ncores):
+            A_shared = T.alloc_shared((block_b, block_m, block_n), dtype)
+            B_shared = T.alloc_shared((block_b, block_m, block_n), dtype)
+            C_shared = T.alloc_shared((block_b, block_m, block_n), accum_dtype)
+
+            for bz in T.serial(grid_b):
+                for by in T.serial(grid_m):
+                    for bx in T.serial(grid_n):
+                        T.copy(
+                            A[
+                                bz * block_b : (bz + 1) * block_b,
+                                by * block_m : (by + 1) * block_m,
+                                bx * block_n : (bx + 1) * block_n,
+                            ],
+                            A_shared,
+                        )
+                        T.copy(
+                            B[
+                                bz * block_b : (bz + 1) * block_b,
+                                by * block_m : (by + 1) * block_m,
+                                bx * block_n : (bx + 1) * block_n,
+                            ],
+                            B_shared,
+                        )
+
+                        for b, i, j in T.Tiles(A_shared, parallel=True):
+                            A_shared[b, i, j] = A_shared[b, i, j] * T.float32(2.0)
+                            B_shared[b, i, j] = A_shared[b, i, j] * B_shared[b, i, j]
+                            C_shared[b, i, j] = T.exp(A_shared[b, i, j]) + T.exp(B_shared[b, i, j])
+
+                        T.copy(
+                            C_shared,
+                            C[
+                                bz * block_b : (bz + 1) * block_b,
+                                by * block_m : (by + 1) * block_m,
+                                bx * block_n : (bx + 1) * block_n,
+                            ],
+                        )
+
+    return main
+
+
+def dot_mul_tiled_parallel_2d(
+    m=512,
+    n=1024,
+    block_m=256,
+    block_n=512,
+    dtype="bfloat16",
+    accum_dtype="bfloat16",
+):
+    device_mesh_config = driver.get_sunmmio_device_mesh_config()
+    nrows, ncols = device_mesh_config
+    ncores = nrows * ncols
+    grid_m = T.ceildiv(m, block_m)
+    grid_n = T.ceildiv(n, block_n)
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((m, n), dtype),
+        B: T.Tensor((m, n), dtype),
+        C: T.Tensor((m, n), dtype),
+    ):
+        with T.Kernel(ncores):
+            A_shared = T.alloc_shared((block_m, block_n), dtype)
+            B_shared = T.alloc_shared((block_m, block_n), dtype)
+            C_shared = T.alloc_shared((block_m, block_n), accum_dtype)
+
+            for by in T.serial(grid_m):
+                for bx in T.serial(grid_n):
+                    T.copy(
+                        A[
+                            by * block_m : (by + 1) * block_m,
+                            bx * block_n : (bx + 1) * block_n,
+                        ],
+                        A_shared,
+                    )
+                    T.copy(
+                        B[
+                            by * block_m : (by + 1) * block_m,
+                            bx * block_n : (bx + 1) * block_n,
+                        ],
+                        B_shared,
+                    )
+
+                    for i, j in T.Tiles(A_shared, parallel=True):
+                        A_shared[i, j] = A_shared[i, j] * T.float32(2.0)
+                        B_shared[i, j] = A_shared[i, j] * B_shared[i, j]
+                        C_shared[i, j] = T.exp(A_shared[i, j]) + T.exp(B_shared[i, j])
+
+                    T.copy(
+                        C_shared,
+                        C[
+                            by * block_m : (by + 1) * block_m,
+                            bx * block_n : (bx + 1) * block_n,
+                        ],
+                    )
+
+    return main
+
+
+def tiles_broadcast(
+    batch=64,
+    m=512,
+    n=1024,
+    block_b=2,
+    block_m=256,
+    block_n=128,
+    dtype="bfloat16",
+    accum_dtype="bfloat16",
+):
+    device_mesh_config = driver.get_sunmmio_device_mesh_config()
+    nrows, ncols = device_mesh_config
+    ncores = nrows * ncols
+    grid_b = T.ceildiv(batch, block_b)
+    grid_m = T.ceildiv(m, block_m)
+    grid_n = T.ceildiv(n, block_n)
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((batch, m, n), dtype),
+        B: T.Tensor((batch, m, n), dtype),
+        C: T.Tensor((batch, m, n), dtype),
+        D: T.Tensor((m,), dtype),
+    ):
+        with T.Kernel(ncores):
+            A_shared = T.alloc_shared((block_b, block_m, block_n), dtype)
+            B_shared = T.alloc_shared((block_b, block_m, block_n), dtype)
+            C_shared = T.alloc_shared((block_b, block_m, block_n), accum_dtype)
+            D_shared = T.alloc_shared((block_m,), dtype)
+
+            for bz in T.serial(grid_b):
+                for by in T.serial(grid_m):
+                    for bx in T.serial(grid_n):
+                        T.copy(
+                            A[
+                                bz * block_b : (bz + 1) * block_b,
+                                by * block_m : (by + 1) * block_m,
+                                bx * block_n : (bx + 1) * block_n,
+                            ],
+                            A_shared,
+                        )
+                        T.copy(
+                            B[
+                                bz * block_b : (bz + 1) * block_b,
+                                by * block_m : (by + 1) * block_m,
+                                bx * block_n : (bx + 1) * block_n,
+                            ],
+                            B_shared,
+                        )
+                        T.copy(D[by * block_m : (by + 1) * block_m], D_shared)
+
+                        for b, i, j in T.Tiles(A_shared, parallel=True):
+                            A_shared[b, i, j] = A_shared[b, i, j] + D_shared[i]
+                            A_shared[b, i, j] = A_shared[b, i, j] * T.float32(2.0)
+                            C_shared[b, i, j] = A_shared[b, i, j] * B_shared[b, i, j]
+
+                        for b, i, j in T.Tiles(A_shared, parallel=True):
+                            A_shared[b, i, j] = A_shared[b, i, j] + D_shared[j]
+                            A_shared[b, i, j] = A_shared[b, i, j] * T.float32(2.0)
+                            C_shared[b, i, j] = A_shared[b, i, j] * B_shared[b, i, j]
+
+                        T.copy(
+                            C_shared,
+                            C[
+                                bz * block_b : (bz + 1) * block_b,
+                                by * block_m : (by + 1) * block_m,
+                                bx * block_n : (bx + 1) * block_n,
+                            ],
+                        )
+
+    return main
+
+
+def tiles_1d(m=512, block_m=256, dtype="bfloat16", accum_dtype="bfloat16"):
+    device_mesh_config = driver.get_sunmmio_device_mesh_config()
+    nrows, ncols = device_mesh_config
+    ncores = nrows * ncols
+    grid_m = T.ceildiv(m, block_m)
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((m,), dtype),
+        B: T.Tensor((m,), dtype),
+        C: T.Tensor((m,), dtype),
+    ):
+        with T.Kernel(ncores):
+            A_shared = T.alloc_shared((block_m,), dtype)
+            B_shared = T.alloc_shared((block_m,), dtype)
+            C_shared = T.alloc_shared((block_m,), accum_dtype)
+
+            for by in T.serial(grid_m):
+                T.clear(C_shared)
+                T.copy(A[by * block_m : (by + 1) * block_m], A_shared)
+                T.copy(B[by * block_m : (by + 1) * block_m], B_shared)
+                for i in T.Tiles(A_shared, parallel=True):
+                    C_shared[i] = A_shared[i] * B_shared[i]
+                T.copy(C_shared, C[by * block_m : (by + 1) * block_m])
+
+    return main
+
+
+def test_dot_mul_tiled_parallel_2d_codegen_validates_with_npuir_opt(tmp_path):
+    src = validate_sunmmio_codegen_with_npuir_opt(
+        dot_mul_tiled_parallel_2d(),
+        tmp_path,
+        mlir_filename="dot_mul_tiled_parallel_2d_suvm.mlir",
+        expected_tokens=("suvm.copy_async", "suvm.tile.mulf", "suvm.tile.exp"),
+    )
+    assert_source_contains(src, ("suvm.tile.mulf", "suvm.tile.exp"))
+
+
+@pytest.mark.parametrize(
+    "case_name,kernel_factory,expected_tokens",
+    [
+        ("dot_mul_tiled_parallel_3d", dot_mul_tiled_parallel_3d, ("suvm.tile.mulf", "suvm.tile.exp")),
+        ("tiles_broadcast", tiles_broadcast, ("suvm.tile.mulf",)),
+        ("tiles_1d", tiles_1d, ("suvm.tile.mulf",)),
+    ],
+)
+def test_tiles_codegen_validates_loose_with_npuir_opt(tmp_path, case_name, kernel_factory, expected_tokens):
+    src = validate_sunmmio_codegen_loose(
+        kernel_factory(),
+        tmp_path,
+        mlir_filename=f"{case_name}_suvm.mlir",
+        expected_tokens=expected_tokens,
+    )
+    assert_source_contains(src, expected_tokens)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()


### PR DESCRIPTION
## Summary

This PR adds a basic SunMMIO TIR compile and validation flow.

It covers the path from kernel code, to TIR, to SunMMIO codegen, and then to opt validation.

## Changes

- Add a compile pipeline for SunMMIO test cases.
- Add validation helpers for SunMMIO codegen tests.
- Add opt validation tests for:
  - allocate, copy, and MMA
  - tile and tiles
  - fill and reduce
  - flash attention
- Fix tile layout being overwritten in some cases.
- Support missing tile expressions like `T.infinity` and `T.exp2`.
- Fix scalar arithmetic type handling in tile codegen.
- Fix binary ops when left and right values have different types.
- Remove `DecoupleTypeCast` from the compile pipeline because it can create wrong local-scope buffers.
- Add tile broadcast support for unit tile shape handling.

## Tests

Added new Python validation tests under `testing/python/target/`.