### PR TITLE
[Layout] Support dynamic cute layout

### DIFF
--- a/src/layout/cute_layout.cc
+++ b/src/layout/cute_layout.cc
@@ -313,14 +313,38 @@ void CuteLayoutNode::RegisterReflection() {
 // ---------------------------------------------------------------------------
 
 /*!
+ * \brief Decompose a stride into (#symbolic factors, concrete coefficient).
+ *
+ * Layout strides are products of mode shapes (running prefix products), so a
+ * stride is a Mul-tree of IntImm and symbolic (dynamic count) factors.  We
+ * fold the concrete leaves into a coefficient and count the symbolic ones.
+ */
+static void CollectStrideFactors(const PrimExpr &e, int *sym_count,
+                                 int64_t *coeff) {
+  if (const auto *mul = e.as<MulNode>()) {
+    CollectStrideFactors(mul->a, sym_count, coeff);
+    CollectStrideFactors(mul->b, sym_count, coeff);
+    return;
+  }
+  int64_t c;
+  if (cute::tryConstInt(e, &c)) {
+    *coeff *= c;
+  } else {
+    ++(*sym_count);
+  }
+}
+
+/*!
  * \brief Extract the physical ordering (permutation) of modes from strides.
  *
  * For a contiguous CuteLayout, the strides encode the physical ordering:
  * the mode with the smallest stride is physically innermost, etc.
  *
- * Invariant: at most one mode has a symbolic (non-IntImm) stride, and
- * it is always the physically outermost (last in the ordering).  All
- * other strides are concrete and sortable.
+ * The strides form a single nested product chain (each outer stride equals an
+ * inner stride times an inner shape), so even when several are symbolic they
+ * are totally ordered by the key (#symbolic factors, concrete coefficient):
+ * the innermost has the fewest symbolic factors / smallest coefficient.  For
+ * all-concrete layouts this degrades to sorting by stride value.
  *
  * \return A permutation vector: physical_order[0] is the innermost mode
  *         index, physical_order[n-1] is the outermost.
@@ -329,30 +353,25 @@ static std::vector<int> RecoverPhysicalOrder(const CuteLayoutNode *layout) {
   auto strides = layout->GetModeStride();
   int n = strides.size();
 
-  std::vector<int> concrete_modes;
-  std::vector<int> symbolic_modes;
+  std::vector<std::pair<int, int64_t>> keys(n);
   for (int i = 0; i < n; ++i) {
-    if (strides[i].as<IntImmNode>()) {
-      concrete_modes.push_back(i);
-    } else {
-      symbolic_modes.push_back(i);
-    }
+    int sym_count = 0;
+    int64_t coeff = 1;
+    CollectStrideFactors(strides[i], &sym_count, &coeff);
+    keys[i] = {sym_count, coeff};
   }
-  ICHECK_LE(symbolic_modes.size(), 1)
-      << "CuteLayout invariant violated: more than one symbolic stride. "
-      << "Got " << symbolic_modes.size()
-      << " symbolic strides in layout: " << layout->DebugOutput();
 
-  // Sort concrete modes by stride value (ascending = innermost first).
-  std::sort(concrete_modes.begin(), concrete_modes.end(), [&](int a, int b) {
-    return strides[a].as<IntImmNode>()->value <
-           strides[b].as<IntImmNode>()->value;
+  std::vector<int> order(n);
+  for (int i = 0; i < n; ++i)
+    order[i] = i;
+
+  // Innermost first: fewer symbolic factors, then smaller concrete coefficient.
+  std::stable_sort(order.begin(), order.end(), [&](int a, int b) {
+    if (keys[a].first != keys[b].first)
+      return keys[a].first < keys[b].first;
+    return keys[a].second < keys[b].second;
   });
-
-  // Symbolic mode (if any) is the physically outermost — append last.
-  concrete_modes.insert(concrete_modes.end(), symbolic_modes.begin(),
-                        symbolic_modes.end());
-  return concrete_modes;
+  return order;
 }
 
 // ---------------------------------------------------------------------------
@@ -1137,7 +1156,8 @@ TVM_FFI_STATIC_INIT_BLOCK() {
             std::vector<PrimExpr> s(shapes.begin(), shapes.end());
             std::vector<PrimExpr> d(strides.begin(), strides.end());
             cute::CuteAlgebraLayout layout(s, d);
-            auto result = cute::complement(layout, max_idx);
+            auto result = cute::complement(
+                layout, make_const(DataType::Int(32), max_idx));
             auto flatShape = cute::flattenExprTuple(result.shape);
             auto flatStride = cute::flattenExprTuple(result.stride);
             Array<PrimExpr> out_shapes(flatShape.begin(), flatShape.end());

--- a/src/layout/cute_layout_algebra.cc
+++ b/src/layout/cute_layout_algebra.cc
@@ -7,6 +7,7 @@
 
 #include "cute_layout_algebra.h"
 
+#include <tvm/arith/analyzer.h>
 #include <tvm/ffi/reflection/registry.h>
 #include <tvm/runtime/logging.h>
 #include <tvm/tir/op.h>
@@ -28,6 +29,20 @@ int64_t toConcrete(const PrimExpr &expr) {
   auto *imm = expr.as<IntImmNode>();
   ICHECK(imm) << "CuTe algebra requires a concrete integer, got: " << expr;
   return imm->value;
+}
+
+bool tryConstInt(const PrimExpr &expr, int64_t *out) {
+  if (const auto *imm = expr.as<IntImmNode>()) {
+    *out = imm->value;
+    return true;
+  }
+  arith::Analyzer analyzer;
+  PrimExpr simplified = analyzer.Simplify(expr);
+  if (const auto *imm = simplified.as<IntImmNode>()) {
+    *out = imm->value;
+    return true;
+  }
+  return false;
 }
 
 static PrimExpr makeInt(int64_t v) { return make_const(DataType::Int(32), v); }
@@ -197,72 +212,62 @@ CuteAlgebraLayout coalesce(const CuteAlgebraLayout &layout) {
   auto flatStride = flattenExprTuple(layout.stride);
   ICHECK_EQ(flatShape.size(), flatStride.size());
 
-  std::vector<int64_t> resultShape{1};
-  std::vector<int64_t> resultStride{0};
+  // Sentinel (shape 1, stride 0) — matches the original accumulator seed.
+  std::vector<PrimExpr> resultShape{makeInt(1)};
+  std::vector<PrimExpr> resultStride{makeInt(0)};
 
   for (size_t i = 0; i < flatShape.size(); ++i) {
-    auto *shapeImm = flatShape[i].as<IntImmNode>();
-    auto *strideImm = flatStride[i].as<IntImmNode>();
+    int64_t s;
+    bool shapeConst = tryConstInt(flatShape[i], &s);
 
-    // If either is symbolic, we cannot merge — keep as separate mode.
-    if (!shapeImm || !strideImm) {
-      // Flush the current concrete accumulator as-is, then add the
-      // symbolic mode as a standalone entry.  We cannot coalesce across
-      // symbolic boundaries.
-      //
-      // For our use case (block/tiler layouts), all values are concrete,
-      // so this path should not be hit.  We add it for safety.
-      ICHECK(shapeImm && strideImm)
-          << "CuTe coalesce expects concrete modes, got shape=" << flatShape[i]
-          << " stride=" << flatStride[i];
+    // Drop trivial (shape-1) modes.  A symbolic shape can never be proven to
+    // be 1, so it is always kept.
+    if (shapeConst && s == 1)
+      continue;
+
+    int64_t backShape;
+    bool backShapeConst = tryConstInt(resultShape.back(), &backShape);
+
+    // Replace the sentinel / a leading shape-1 mode in place.
+    if (backShapeConst && backShape == 1) {
+      resultShape.back() = flatShape[i];
+      resultStride.back() = flatStride[i];
       continue;
     }
 
-    int64_t s = shapeImm->value;
-    int64_t d = strideImm->value;
-
-    if (s == 1)
-      continue;
-
-    if (resultShape.back() == 1) {
-      resultShape.back() = s;
-      resultStride.back() = d;
-      continue;
-    }
-
-    if (resultShape.back() * resultStride.back() == d) {
-      resultShape.back() *= s;
+    // Merge into the previous mode only when contiguity is provable (all
+    // concrete): back.shape * back.stride == this.stride.  Symbolic modes
+    // cannot be merged and fall through to a standalone entry below.
+    int64_t backStride, d;
+    if (shapeConst && backShapeConst &&
+        tryConstInt(resultStride.back(), &backStride) &&
+        tryConstInt(flatStride[i], &d) && backShape * backStride == d) {
+      resultShape.back() = makeInt(backShape * s);
       continue;
     }
 
-    resultShape.push_back(s);
-    resultStride.push_back(d);
+    resultShape.push_back(flatShape[i]);
+    resultStride.push_back(flatStride[i]);
   }
 
-  std::vector<PrimExpr> rs, rd;
-  rs.reserve(resultShape.size());
-  rd.reserve(resultStride.size());
-  for (size_t i = 0; i < resultShape.size(); ++i) {
-    rs.push_back(makeInt(resultShape[i]));
-    rd.push_back(makeInt(resultStride[i]));
+  if (resultShape.size() == 1) {
+    return CuteAlgebraLayout(resultShape[0], resultStride[0]);
   }
-
-  if (rs.size() == 1) {
-    return CuteAlgebraLayout(rs[0], rd[0]);
-  }
-  return CuteAlgebraLayout(rs, rd);
+  return CuteAlgebraLayout(resultShape, resultStride);
 }
 
 // ---------------------------------------------------------------------------
 // complement
 // ---------------------------------------------------------------------------
 
-CuteAlgebraLayout complement(const CuteAlgebraLayout &layout, int64_t maxIdx) {
+CuteAlgebraLayout complement(const CuteAlgebraLayout &layout, PrimExpr maxIdx) {
   auto flatStride = flattenExprTuple(layout.stride);
   auto flatShape = flattenExprTuple(layout.shape);
   ICHECK_EQ(flatStride.size(), flatShape.size());
 
-  // Build (stride, shape) pairs and sort by concrete stride.
+  // Build (stride, shape) pairs and sort by stride.  The input layout is
+  // always a tiler/block layout, so these are compile-time constants; sorting
+  // modes by stride is inherently a concrete operation.
   std::vector<std::pair<int64_t, int64_t>> pairs;
   pairs.reserve(flatShape.size());
   for (size_t i = 0; i < flatShape.size(); ++i) {
@@ -271,8 +276,8 @@ CuteAlgebraLayout complement(const CuteAlgebraLayout &layout, int64_t maxIdx) {
   std::sort(pairs.begin(), pairs.end(),
             [](const auto &a, const auto &b) { return a.first < b.first; });
 
-  std::vector<int64_t> resultShape;
-  std::vector<int64_t> resultStride;
+  std::vector<PrimExpr> resultShape;
+  std::vector<PrimExpr> resultStride;
   int64_t currentIdx = 1;
 
   for (const auto &[stride, shape] : pairs) {
@@ -281,25 +286,18 @@ CuteAlgebraLayout complement(const CuteAlgebraLayout &layout, int64_t maxIdx) {
     ICHECK(currentIdx <= shape * stride)
         << "complement: currentIdx=" << currentIdx
         << " > shape*stride=" << shape * stride;
-    resultShape.push_back(stride / currentIdx);
-    resultStride.push_back(currentIdx);
+    resultShape.push_back(makeInt(stride / currentIdx));
+    resultStride.push_back(makeInt(currentIdx));
     currentIdx = shape * stride;
   }
 
-  resultShape.push_back(ceilDivInt(maxIdx, currentIdx));
-  resultStride.push_back(currentIdx);
+  // The free-dimension extent is the only possibly-symbolic mode: it carries
+  // the (dynamic) total domain extent maxIdx.  ceildiv folds to an IntImm for
+  // concrete maxIdx and stays symbolic otherwise.
+  resultShape.push_back(tvm::ceildiv(maxIdx, makeInt(currentIdx)));
+  resultStride.push_back(makeInt(currentIdx));
 
-  // Convert to PrimExpr and coalesce.
-  std::vector<PrimExpr> rs, rd;
-  rs.reserve(resultShape.size());
-  rd.reserve(resultStride.size());
-  for (size_t i = 0; i < resultShape.size(); ++i) {
-    rs.push_back(makeInt(resultShape[i]));
-    rd.push_back(makeInt(resultStride[i]));
-  }
-
-  CuteAlgebraLayout result(rs, rd);
-  return coalesce(result);
+  return coalesce(CuteAlgebraLayout(resultShape, resultStride));
 }
 
 // ---------------------------------------------------------------------------
@@ -331,61 +329,69 @@ CuteAlgebraLayout composition(const CuteAlgebraLayout &layoutA,
   }
 
   ICHECK(!layoutB.stride.isTuple);
-  int64_t bStride = toConcrete(layoutB.stride.value);
-  if (bStride == 0) {
+  PrimExpr restStride = layoutB.stride.value;
+  int64_t bStrideConst;
+  if (tryConstInt(restStride, &bStrideConst) && bStrideConst == 0) {
     return CuteAlgebraLayout(layoutB.shape.value, makeInt(0));
   }
 
-  int64_t restShape = toConcrete(layoutB.shape.value);
-  int64_t restStride = bStride;
+  PrimExpr restShape = layoutB.shape.value; // may be symbolic
 
   CuteAlgebraLayout flatA = coalesce(layoutA);
   auto flatAShape = flattenExprTuple(flatA.shape);
   auto flatAStride = flattenExprTuple(flatA.stride);
 
-  std::vector<int64_t> resultShape;
-  std::vector<int64_t> resultStride;
+  std::vector<PrimExpr> resultShape;
+  std::vector<PrimExpr> resultStride;
 
-  for (size_t i = 0; i + 1 < flatAShape.size(); ++i) {
-    int64_t currShape = toConcrete(flatAShape[i]);
-    int64_t currStride = toConcrete(flatAStride[i]);
+  // Splitting a multi-mode left operand across B's stride is inherently
+  // concrete (it makes modular divisibility decisions).  Every layout-
+  // construction path feeds a single-mode A here (the loop is skipped), so it
+  // only runs for the concrete algebra (e.g. zippedProduct); require concrete
+  // operands with a clear message via toConcrete.
+  if (flatAShape.size() > 1) {
+    int64_t restShapeC = toConcrete(restShape);
+    int64_t restStrideC = toConcrete(restStride);
+    for (size_t i = 0; i + 1 < flatAShape.size(); ++i) {
+      int64_t currShape = toConcrete(flatAShape[i]);
+      int64_t currStride = toConcrete(flatAStride[i]);
 
-    if (currShape % restStride != 0 && restStride % currShape != 0) {
-      return CuteAlgebraLayout(int64_t(1), int64_t(0));
+      if (currShape % restStrideC != 0 && restStrideC % currShape != 0) {
+        return CuteAlgebraLayout(int64_t(1), int64_t(0));
+      }
+
+      int64_t newShape =
+          std::min(std::max(int64_t(1), currShape / restStrideC), restShapeC);
+      if (restShapeC % newShape != 0) {
+        return CuteAlgebraLayout(int64_t(1), int64_t(0));
+      }
+
+      if (newShape != 1) {
+        resultShape.push_back(makeInt(newShape));
+        resultStride.push_back(makeInt(restStrideC * currStride));
+      }
+
+      restShapeC /= newShape;
+      restStrideC = ceilDivInt(restStrideC, currShape);
     }
-
-    int64_t newShape =
-        std::min(std::max(int64_t(1), currShape / restStride), restShape);
-    if (restShape % newShape != 0) {
-      return CuteAlgebraLayout(int64_t(1), int64_t(0));
-    }
-
-    if (newShape != 1) {
-      resultShape.push_back(newShape);
-      resultStride.push_back(restStride * currStride);
-    }
-
-    restShape /= newShape;
-    restStride = ceilDivInt(restStride, currShape);
+    restShape = makeInt(restShapeC);
+    restStride = makeInt(restStrideC);
   }
 
-  if (restShape != 1 || resultShape.empty()) {
+  // Final (outermost) mode — pure arithmetic that supports a symbolic
+  // restShape and a symbolic left-operand stride.
+  int64_t restShapeConst;
+  bool restIsOne =
+      tryConstInt(restShape, &restShapeConst) && restShapeConst == 1;
+  if (!restIsOne || resultShape.empty()) {
     resultShape.push_back(restShape);
-    resultStride.push_back(restStride * toConcrete(flatAStride.back()));
+    resultStride.push_back(restStride * flatAStride.back());
   }
 
-  std::vector<PrimExpr> rs, rd;
-  rs.reserve(resultShape.size());
-  rd.reserve(resultStride.size());
-  for (size_t i = 0; i < resultShape.size(); ++i) {
-    rs.push_back(makeInt(resultShape[i]));
-    rd.push_back(makeInt(resultStride[i]));
+  if (resultShape.size() == 1) {
+    return CuteAlgebraLayout(resultShape[0], resultStride[0]);
   }
-
-  if (rs.size() == 1) {
-    return CuteAlgebraLayout(rs[0], rd[0]);
-  }
-  return CuteAlgebraLayout(rs, rd);
+  return CuteAlgebraLayout(resultShape, resultStride);
 }
 
 // ---------------------------------------------------------------------------
@@ -409,9 +415,10 @@ CuteAlgebraLayout logicalProduct(const CuteAlgebraLayout &layoutA,
   }
 
   // logicalProduct(A, B) = (A, composition(complement(A, A.size * B.cosize),
-  // B))
-  int64_t aSize = toConcrete(layoutA.size());
-  int64_t bCosize = toConcrete(layoutB.cosize());
+  // B)).  size()/cosize() are pure products, passed straight to complement as
+  // its (possibly symbolic) maxIdx — no concreteness required here.
+  PrimExpr aSize = layoutA.size();
+  PrimExpr bCosize = layoutB.cosize();
 
   auto comp = complement(layoutA, aSize * bCosize);
   auto composed = composition(comp, layoutB, false);
@@ -448,8 +455,10 @@ CuteAlgebraLayout logicalDivide(const CuteAlgebraLayout &layoutA,
     return CuteAlgebraLayout(modes);
   }
 
-  // Non-byMode: composition(A, (B, complement(B, A.size())))
-  int64_t aSize = toConcrete(layoutA.size());
+  // Non-byMode: composition(A, (B, complement(B, A.size()))).  A.size() is a
+  // pure product passed to complement as maxIdx, so a dynamic extent flows
+  // through here unchanged.
+  PrimExpr aSize = layoutA.size();
   auto comp = complement(layoutB, aSize);
   std::vector<CuteAlgebraLayout> inner{layoutB, comp};
   return composition(layoutA, CuteAlgebraLayout(inner), false);

--- a/src/layout/cute_layout_algebra.h
+++ b/src/layout/cute_layout_algebra.h
@@ -135,6 +135,17 @@ ExprTuple prefixProduct(const ExprTuple &value, PrimExpr init);
 /*! \brief Extract a concrete int64_t from a PrimExpr, with ICHECK. */
 int64_t toConcrete(const PrimExpr &expr);
 
+/*!
+ * \brief Try to read a compile-time constant integer from a PrimExpr.
+ *
+ * Simplifies the expression and, if it folds to an IntImm, writes the value
+ * to \p out and returns true.  Returns false for genuinely symbolic
+ * expressions (e.g. those involving dynamic shape variables).  Used to gate
+ * the opportunistic concrete fast-paths (coalesce merging, trailing-mode
+ * trimming) while letting symbolic values flow through unchanged.
+ */
+bool tryConstInt(const PrimExpr &expr, int64_t *out);
+
 // ---------------------------------------------------------------------------
 // Core CuTe algebra operations
 // ---------------------------------------------------------------------------
@@ -142,8 +153,15 @@ int64_t toConcrete(const PrimExpr &expr);
 /*! \brief Merge compatible consecutive modes. */
 CuteAlgebraLayout coalesce(const CuteAlgebraLayout &layout);
 
-/*! \brief Compute the complement (free index space) of a layout. */
-CuteAlgebraLayout complement(const CuteAlgebraLayout &layout, int64_t maxIdx);
+/*!
+ * \brief Compute the complement (free index space) of a layout.
+ *
+ * The input \p layout is always a tiler/block layout whose modes are
+ * compile-time constants (sorting modes by stride is inherently concrete).
+ * \p maxIdx — the total domain extent — may be symbolic; it appears only in
+ * the final free-dimension extent, so dynamic shapes flow through here.
+ */
+CuteAlgebraLayout complement(const CuteAlgebraLayout &layout, PrimExpr maxIdx);
 
 /*! \brief Compose two layouts. */
 CuteAlgebraLayout composition(const CuteAlgebraLayout &layoutA,

--- a/testing/python/layout/test_tilelang_cute_layout.py
+++ b/testing/python/layout/test_tilelang_cute_layout.py
@@ -555,6 +555,38 @@ class TestDeriveLayoutLike:
         direct = make_nzz(_imms(64, 256), [0, 1], _imms(16, 16), _imms(4, 4))
         assert is_same_layout(derived, direct)
 
+    def test_derive_from_dynamic_2d_source(self):
+        """Derive from a 2D source whose extents are dynamic (one symbolic
+        stride)."""
+        M = tir.Var("m", "int32")
+        K = tir.Var("k", "int32")
+        src = make_zz([M, K], [0, 1], _imms(32, 32))
+        derived = derive_layout_like(src, _imms(256, 64), None)
+        assert derived is not None
+        direct = make_zz(_imms(256, 64), [0, 1], _imms(32, 32))
+        assert is_same_layout(derived, direct)
+
+    def test_derive_from_dynamic_higher_rank_source(self):
+        """RecoverPhysicalOrder (Option A) handles several symbolic strides:
+        derive from a 4D source whose two tiled extents are dynamic.  The
+        non-tiled batch sits physically outside the tiled counts, so the
+        source carries multiple symbolic strides."""
+        S = tir.Var("s", "int32")
+        D = tir.Var("d", "int32")
+        src = make_zz([_imm(2), S, _imm(4), D], [1, 3], _imms(32, 32))
+        derived = derive_layout_like(src, _imms(2, 128, 4, 64), [_imm(1), _imm(3)])
+        assert derived is not None
+        direct = make_zz(_imms(2, 128, 4, 64), [1, 3], _imms(32, 32))
+        assert is_same_layout(derived, direct)
+
+    def test_is_layout_match_dynamic_higher_rank(self):
+        """IsLayoutMatch on a dynamic higher-rank layout: derivation +
+        symbolic SameLayout over several symbolic strides (Option A)."""
+        S = tir.Var("s", "int32")
+        D = tir.Var("d", "int32")
+        dyn = make_zz([_imm(2), S, _imm(4), D], [1, 3], _imms(32, 32))
+        assert is_layout_match(dyn, dyn)
+
 
 class TestDeriveLayoutLikeRankChanging:
     """Tests for DeriveLayoutLike with rank-mismatched src and dst."""

--- a/testing/python/layout/test_tilelang_sunmmio_layouts.py
+++ b/testing/python/layout/test_tilelang_sunmmio_layouts.py
@@ -4,6 +4,7 @@ import random
 
 import pytest
 
+import tilelang.language as T
 from tilelang import tvm as tvm
 from tilelang.layout import is_same_layout, make_zz_layout
 
@@ -89,3 +90,68 @@ def test_make_zz_layout_defaults_to_last_two_axes():
 def test_make_zz_layout_rejects_rank_one_default_axes():
     with pytest.raises(ValueError, match="requires rank >= 2"):
         make_zz_layout((128,))
+
+
+def test_make_dynamic_zz_layout():
+    from tvm.tir.stmt_functor import substitute
+
+    M = T.dynamic("m")
+    K = T.dynamic("k")
+    block_size = (32, 32)
+
+    dyn = make_zz_layout((M, K), block_shape=block_size)
+    print(dyn)
+
+    # Two independent constructions with the same dynamic extents are equal.
+    assert is_same_layout(dyn, make_zz_layout((M, K), block_shape=block_size))
+
+    # The dynamic layout's forward index must match the concrete-shape layout
+    # once concrete extents are substituted in — including non-divisible shapes.
+    for m_val, k_val in [(128, 128), (96, 256), (64, 96), (63, 127)]:
+        concrete = make_zz_layout((m_val, k_val), block_shape=block_size)
+        vmap = {M: _imm(m_val), K: _imm(k_val)}
+        for row, col in [(0, 0), (33, 5), (31, 63), (m_val - 1, k_val - 1)]:
+            dyn_idx = dyn.map_forward_index(_imms(row, col))[0]
+            dyn_off = int(ANA.simplify(substitute(dyn_idx, vmap)))
+            assert dyn_off == _eval(concrete, row, col)
+
+
+@pytest.mark.parametrize(
+    "shape_spec, axes, dyn_vals",
+    [
+        # 3D, two dynamic tiled extents (default axes = last two).
+        ((4, "s", "d"), None, {"s": 128, "d": 96}),
+        # 3D, two dynamic tiled extents, non-divisible.
+        ((4, "s", "d"), None, {"s": 63, "d": 127}),
+        # 4D attention, two dynamic tiled extents on axes (1, 3).
+        ((2, "s", 4, "d"), [1, 3], {"s": 96, "d": 160}),
+        # 4D, three dynamic extents: dynamic (non-tiled) batch + two tiled.
+        # The non-tiled batch sits physically outside the tiled counts, so the
+        # layout has several symbolic strides.
+        (("b", "s", 4, "d"), [1, 3], {"b": 3, "s": 64, "d": 128}),
+    ],
+)
+def test_make_dynamic_zz_layout_higher_rank(shape_spec, axes, dyn_vals):
+    """Higher-rank ZZ with 2-3 dynamic logical extents: the dynamic layout's
+    forward index must match the concrete-shape layout once extents are bound."""
+    from tvm.tir.stmt_functor import substitute
+
+    vars_ = {name: T.dynamic(name) for name in dyn_vals}
+    dyn_shape = tuple(vars_[s] if isinstance(s, str) else s for s in shape_spec)
+    concrete_shape = tuple(dyn_vals[s] if isinstance(s, str) else s for s in shape_spec)
+    block_size = (32, 32)
+
+    dyn = make_zz_layout(dyn_shape, axes=axes, block_shape=block_size)
+    concrete = make_zz_layout(concrete_shape, axes=axes, block_shape=block_size)
+    sub_map = {vars_[name]: _imm(val) for name, val in dyn_vals.items()}
+
+    rank = len(shape_spec)
+    coords = [tuple(0 for _ in range(rank)), tuple(d - 1 for d in concrete_shape)]
+    random.seed(0)
+    for _ in range(30):
+        coords.append(tuple(random.randint(0, d - 1) for d in concrete_shape))
+
+    for c in coords:
+        dyn_idx = dyn.map_forward_index(_imms(*c))[0]
+        dyn_off = int(ANA.simplify(substitute(dyn_idx, sub_map)))
+        assert dyn_off == _eval(concrete, *c)


### PR DESCRIPTION
Resolve the constraints in cute algebra layout on stride Immediate, and therefore support shapes & strides on PrimExpr.
However, we still enforce a constraint that for each logical dimension, we at have 1 dynamic symbol and this symbol has to be the outermost mode.