### PR TITLE
adds SunMMIO codegen support for dynamic kernel parameters and dynamic buffer layouts

### DIFF
--- a/src/target/sunmmio/codegen_sunmmio.cc
+++ b/src/target/sunmmio/codegen_sunmmio.cc
@@ -82,12 +82,20 @@ int64_t RoundUpToMultiple(int64_t value, int64_t multiple) {
   return ((value + multiple - 1) / multiple) * multiple;
 }
 
-std::vector<int64_t>
-BuildRowMajorStridesLocal(const std::vector<int64_t> &shape) {
-  std::vector<int64_t> strides(shape.size(), 1);
+std::vector<PrimExpr>
+BuildRowMajorStrideExprsLocal(const std::vector<int64_t> &shape) {
+  std::vector<PrimExpr> strides(shape.size());
+  if (shape.empty()) {
+    return strides;
+  }
+  std::vector<int64_t> stride_values(shape.size(), 1);
   for (int i = static_cast<int>(shape.size()) - 2; i >= 0; --i) {
-    strides[static_cast<size_t>(i)] =
-        shape[static_cast<size_t>(i + 1)] * strides[static_cast<size_t>(i + 1)];
+    stride_values[static_cast<size_t>(i)] =
+        shape[static_cast<size_t>(i + 1)] *
+        stride_values[static_cast<size_t>(i + 1)];
+  }
+  for (size_t i = 0; i < stride_values.size(); ++i) {
+    strides[i] = IntImm(DataType::Int(32), stride_values[i]);
   }
   return strides;
 }
@@ -135,8 +143,12 @@ void ApplyDebugRsramTailPadding(SunMMIOType *memtensor_type) {
   layout_hshape[layout_hshape.size() - 1] =
       RoundUpToMultiple(layout_hshape[layout_hshape.size() - 1], 32);
 
-  memtensor_type->layout_hshape = layout_hshape;
-  memtensor_type->layout_hstride = BuildRowMajorStridesLocal(layout_hshape);
+  memtensor_type->layout_hshape.clear();
+  memtensor_type->layout_hshape.reserve(layout_hshape.size());
+  for (int64_t dim : layout_hshape) {
+    memtensor_type->layout_hshape.push_back(IntImm(DataType::Int(32), dim));
+  }
+  memtensor_type->layout_hstride = BuildRowMajorStrideExprsLocal(layout_hshape);
   memtensor_type->layout_dim_levels =
       BuildFlatDimLevelsLocal(memtensor_type->shape.size());
 }
@@ -377,6 +389,7 @@ void CodeGenTileLangSunMMIO::AddFunction(const GlobalVar &gvar,
 
   EnterScope();
   std::vector<BuilderArg> args;
+  std::vector<PendingExternalBuffer> pending_external_buffers;
   int arg_index = 0;
   for (const tir::Var &p : f->params) {
     std::string arg_name = "%arg" + std::to_string(arg_index++);
@@ -387,6 +400,7 @@ void CodeGenTileLangSunMMIO::AddFunction(const GlobalVar &gvar,
       args.push_back({arg_name, buf_ty});
       BindVar(p, SunMMIOValue{p.dtype(), arg_name, buf_ty});
       RegisterBuffer(buffer, true, arg_name);
+      pending_external_buffers.push_back({buffer, arg_name, buf_ty});
     } else {
       SunMMIOType arg_ty = MapType(p.dtype());
       args.push_back({arg_name, arg_ty});
@@ -395,6 +409,9 @@ void CodeGenTileLangSunMMIO::AddFunction(const GlobalVar &gvar,
   }
 
   builder_->BeginFunction(gvar->name_hint, args);
+  for (const PendingExternalBuffer &pending : pending_external_buffers) {
+    BindExternalBufferLayout(pending);
+  }
   VisitStmtTracked(f->body);
   builder_->EmitReturn();
   builder_->EndFunction();
@@ -548,6 +565,71 @@ CodeGenTileLangSunMMIO::LookupVar(const tir::VarNode *var) const {
   auto *self = const_cast<CodeGenTileLangSunMMIO *>(this);
   self->BindVar(tvm::ffi::GetRef<tir::Var>(var), fake_value);
   return self->var_table_.find(var)->second;
+}
+
+SunMMIOValue CodeGenTileLangSunMMIO::MaterializeDynamicLayoutExpr(
+    const tvm::PrimExpr &expr) {
+  arith::Analyzer analyzer;
+  PrimExpr simplified = analyzer.Simplify(expr);
+  tir::PostOrderVisit(simplified, [&](const ObjectRef &node) {
+    if (!node.defined()) {
+      return;
+    }
+    if (const auto *var = node.as<VarNode>()) {
+      ICHECK(var_table_.count(var))
+          << "SunMMIO dynamic layout expression depends on unbound runtime "
+             "variable "
+          << var->name_hint << " in " << simplified;
+      return;
+    }
+    ICHECK(!node.as<BufferLoadNode>() && !node.as<ProducerLoadNode>() &&
+           !node.as<CallNode>() && !node.as<RampNode>() &&
+           !node.as<BroadcastNode>() && !node.as<ShuffleNode>() &&
+           !node.as<LetNode>())
+        << "SunMMIO dynamic layout expression must be scalar arithmetic over "
+           "runtime parameters, got unsupported node "
+        << node->GetTypeKey() << " in " << simplified;
+  });
+  return EnsureIndex(EvalExpr(simplified));
+}
+
+std::vector<SunMMIOValue> CodeGenTileLangSunMMIO::CollectDynamicLayoutValues(
+    const std::vector<PrimExpr> &exprs) {
+  std::vector<SunMMIOValue> values;
+  values.reserve(exprs.size());
+  for (const PrimExpr &expr : exprs) {
+    arith::Analyzer analyzer;
+    PrimExpr simplified = analyzer.Simplify(expr);
+    if (simplified.as<IntImmNode>()) {
+      continue;
+    }
+    values.push_back(MaterializeDynamicLayoutExpr(simplified));
+  }
+  return values;
+}
+
+void CodeGenTileLangSunMMIO::BindExternalBufferLayout(
+    const PendingExternalBuffer &pending) {
+  std::vector<SunMMIOValue> dynamic_shapes =
+      CollectDynamicLayoutValues(pending.type.layout_hshape);
+  std::vector<SunMMIOValue> dynamic_strides =
+      CollectDynamicLayoutValues(pending.type.layout_hstride);
+  if (dynamic_shapes.empty() && dynamic_strides.empty()) {
+    return;
+  }
+
+  SunMMIOValue source{pending.buffer->dtype, pending.handle, pending.type};
+  std::string bound_handle = pending.handle + "_layout";
+  SunMMIOValue bound = builder_->BindLayout(bound_handle, source,
+                                            dynamic_shapes, dynamic_strides);
+
+  var_table_[pending.buffer->data.get()] = bound;
+  auto it = buffer_registry_.find(pending.buffer.get());
+  ICHECK(it != buffer_registry_.end())
+      << "Missing registered external buffer for dynamic layout binding: "
+      << pending.buffer->name;
+  it->second.handle = bound.value;
+  it->second.buffer_type = bound.type;
 }
 
 void CodeGenTileLangSunMMIO::RegisterBuffer(const tir::Buffer &buffer,

--- a/src/target/sunmmio/codegen_sunmmio.h
+++ b/src/target/sunmmio/codegen_sunmmio.h
@@ -89,6 +89,11 @@ public:
   virtual SunMMIOValue BindValueAlias(const std::string &result_name,
                                       const SunMMIOValue &value) = 0;
 
+  virtual SunMMIOValue
+  BindLayout(const std::string &result_name, const SunMMIOValue &source,
+             const std::vector<SunMMIOValue> &dynamic_shapes,
+             const std::vector<SunMMIOValue> &dynamic_strides) = 0;
+
   virtual SunMMIOValue Alloc(const std::string &result_name,
                              const SunMMIOType &memref_type,
                              const std::vector<SunMMIOValue> &dyn_extents,
@@ -335,6 +340,12 @@ private:
     SunMMIOValue value;
   };
 
+  struct PendingExternalBuffer {
+    tir::Buffer buffer;
+    std::string handle;
+    SunMMIOType type;
+  };
+
   SunMMIOValue EvalExpr(const tvm::PrimExpr &expr);
   void VisitStmtTracked(const tir::Stmt &stmt);
   void CollectExpectedCoverage(const tir::PrimFunc &f);
@@ -375,6 +386,10 @@ private:
   CompareDomain GetCompareDomain(DataType dtype) const;
   SunMMIOValue BindVar(const tir::Var &var, const SunMMIOValue &value);
   const SunMMIOValue &LookupVar(const tir::VarNode *var) const;
+  SunMMIOValue MaterializeDynamicLayoutExpr(const tvm::PrimExpr &expr);
+  std::vector<SunMMIOValue>
+  CollectDynamicLayoutValues(const std::vector<PrimExpr> &exprs);
+  void BindExternalBufferLayout(const PendingExternalBuffer &pending);
   void RegisterBuffer(const tir::Buffer &buffer, bool is_external,
                       const std::string &handle_hint = "");
   const BufferBinding &LookupBuffer(const tir::Buffer &buffer) const;

--- a/src/target/sunmmio/sunmmio_codegen_tiles_loop.cc
+++ b/src/target/sunmmio/sunmmio_codegen_tiles_loop.cc
@@ -1081,20 +1081,7 @@ bool CodeGenTileLangSunMMIO::TryLowerTilesScope(const tir::ForNode *op) {
     if (src_shape.size() == 2 && dst_shape.size() == 2) {
       std::optional<int64_t> src_unit_axis = unit_axis_for_2d_shape(src_shape);
       std::optional<int64_t> dst_unit_axis = unit_axis_for_2d_shape(dst_shape);
-      if (src_unit_axis.has_value()) {
-        bool can_broadcast = true;
-        for (size_t i = 0; i < src_shape.size(); ++i) {
-          if (src_shape[i] != dst_shape[i] && src_shape[i] != 1) {
-            can_broadcast = false;
-            break;
-          }
-        }
-        if (can_broadcast) {
-          SunMMIOType dst_type = MakeTileType(value.dtype, dst_shape);
-          return builder_->TileBroadcast(NewValueName(), value, dst_type,
-                                         value.dtype);
-        }
-      }
+
       if (src_unit_axis.has_value() && dst_unit_axis.has_value() &&
           unit_vector_extent(src_shape, *src_unit_axis) ==
               unit_vector_extent(dst_shape, *dst_unit_axis)) {
@@ -1808,6 +1795,19 @@ bool CodeGenTileLangSunMMIO::TryLowerTilesScope(const tir::ForNode *op) {
       }
       if (op_node && call->args.size() == 1 && op_node->name == "tir.log") {
         return emit_unary(TileUnaryOp::kLn, call->args[0], call->dtype);
+      }
+      if (op_node && call->args.size() == 1 && op_node->name == "tir.log2") {
+        SunMMIOValue ln_value =
+            emit_unary(TileUnaryOp::kLn, call->args[0], call->dtype);
+        DataType result_dtype = ln_value.dtype;
+        SunMMIOType scale_type{SunMMIOType::Kind::kScalar, result_dtype, 1, {}};
+        SunMMIOValue log2e = builder_->ConstantFloat(
+            NewValueName(), "1.4426950408889634", scale_type, result_dtype);
+        SunMMIOType result_type =
+            MakeTileType(result_dtype, ExtractStaticShape(ln_value.type));
+        return builder_->Binary(NewValueName(), BinaryOp::kMul,
+                                ArithmeticFlavor::kFloat, ln_value, log2e,
+                                result_type, result_dtype);
       }
       if (op_node && call->args.size() == 1 && op_node->name == "tir.round") {
         return emit_unary(TileUnaryOp::kRound, call->args[0], call->dtype,

--- a/src/target/sunmmio/sunmmio_mlir_builder.cc
+++ b/src/target/sunmmio/sunmmio_mlir_builder.cc
@@ -117,6 +117,37 @@ SunMMIOValue SuvmSunmmioBuilder::BindValueAlias(const std::string &result_name,
   return SunMMIOValue{value.dtype, result_name, value.type};
 }
 
+SunMMIOValue SuvmSunmmioBuilder::BindLayout(
+    const std::string &result_name, const SunMMIOValue &source,
+    const std::vector<SunMMIOValue> &dynamic_shapes,
+    const std::vector<SunMMIOValue> &dynamic_strides) {
+  mlir::Value source_value = ctx_.LookupMLIRValue(source.value);
+  ICHECK(source_value) << "Cannot bind layout for missing MLIR value "
+                       << source.value;
+
+  SunmmioMlirType type(ctx_);
+  mlir::SmallVector<mlir::Value, 4> shape_values;
+  mlir::SmallVector<mlir::Value, 4> stride_values;
+  shape_values.reserve(dynamic_shapes.size());
+  stride_values.reserve(dynamic_strides.size());
+  for (const SunMMIOValue &value : dynamic_shapes) {
+    mlir::Value mlir_value = ctx_.LookupMLIRValue(value.value);
+    ICHECK(mlir_value) << "Missing dynamic layout shape value " << value.value;
+    shape_values.push_back(type.EnsureIndex(mlir_value));
+  }
+  for (const SunMMIOValue &value : dynamic_strides) {
+    mlir::Value mlir_value = ctx_.LookupMLIRValue(value.value);
+    ICHECK(mlir_value) << "Missing dynamic layout stride value " << value.value;
+    stride_values.push_back(type.EnsureIndex(mlir_value));
+  }
+
+  auto bind_op = mlir::suvm::BindLayoutOp::create(
+      ctx_.builder, type.MakeDebugLoc("bind_layout"), source_value.getType(),
+      source_value, shape_values, stride_values);
+  ctx_.BindMLIRValue(result_name, bind_op.getResult());
+  return SunMMIOValue{source.dtype, result_name, source.type};
+}
+
 SunMMIOValue
 SuvmSunmmioBuilder::Alloc(const std::string &result_name,
                           const SunMMIOType &memref_type,

--- a/src/target/sunmmio/sunmmio_mlir_builder.h
+++ b/src/target/sunmmio/sunmmio_mlir_builder.h
@@ -62,6 +62,11 @@ public:
   SunMMIOValue BindValueAlias(const std::string &result_name,
                               const SunMMIOValue &value) final;
 
+  SunMMIOValue
+  BindLayout(const std::string &result_name, const SunMMIOValue &source,
+             const std::vector<SunMMIOValue> &dynamic_shapes,
+             const std::vector<SunMMIOValue> &dynamic_strides) final;
+
   SunMMIOValue Alloc(const std::string &result_name,
                      const SunMMIOType &memref_type,
                      const std::vector<SunMMIOValue> &dyn_extents,

--- a/src/target/sunmmio/sunmmio_mlir_context.cc
+++ b/src/target/sunmmio/sunmmio_mlir_context.cc
@@ -2,7 +2,6 @@
 
 #include "../../layout/cute_layout.h"
 
-#include <tvm/arith/analyzer.h>
 #include <tvm/tir/expr.h>
 #include <tvm/tir/op.h>
 
@@ -33,17 +32,6 @@ LookupLayoutInMap(const SunmmioMlirContext::TirLayoutMap &layout_map,
     }
   }
   return ffi::Optional<tl::Layout>();
-}
-
-int64_t StaticIntValue(const PrimExpr &expr, arith::Analyzer *analyzer,
-                       const char *field_name, const tl::Layout &layout) {
-  PrimExpr simplified = analyzer->Simplify(expr);
-  if (const auto *imm = simplified.as<tir::IntImmNode>()) {
-    return imm->value;
-  }
-  LOG(FATAL) << "SunMMIO SUVM layout " << field_name << " must be static, got "
-             << simplified << " in layout: " << layout->DebugOutput();
-  TVM_FFI_UNREACHABLE();
 }
 
 } // namespace
@@ -112,12 +100,10 @@ void SunmmioMlirContext::ApplyLayoutToType(const tir::Buffer &buffer,
   type->layout_dim_levels.clear();
 
   for (const PrimExpr &dim : cute->GetModeShape()) {
-    type->layout_hshape.push_back(
-        StaticIntValue(dim, &analyzer, "mode_shape", layout));
+    type->layout_hshape.push_back(analyzer.Simplify(dim));
   }
   for (const PrimExpr &stride : cute->GetModeStride()) {
-    type->layout_hstride.push_back(
-        StaticIntValue(stride, &analyzer, "mode_stride", layout));
+    type->layout_hstride.push_back(analyzer.Simplify(stride));
   }
   for (const Integer &level : cute->GetDimLevels()) {
     int64_t value = level.IntValue();

--- a/src/target/sunmmio/sunmmio_mlir_memory.cc
+++ b/src/target/sunmmio/sunmmio_mlir_memory.cc
@@ -35,6 +35,14 @@ SunmmioMlirMemory::Alloc(const std::string &result_name,
 
   mlir::suvm::AllocOp alloc = mlir::suvm::AllocOp::create(
       ctx_.builder, ctx_.builder.getUnknownLoc(), tensor_type);
+  mlir::suvm::MemorySpace memory_space =
+      tensor_type.getMemorySpace().getValue();
+  if (memory_space == mlir::suvm::MemorySpace::asram ||
+      memory_space == mlir::suvm::MemorySpace::wsram) {
+    alloc->setAttr("suvm.ping_pong",
+                   mlir::suvm::PingPongAttr::get(&ctx_.mlir_ctx,
+                                                 mlir::suvm::PingPong::ping));
+  }
 
   SunMMIOValue out{dtype, result_name, updated_type};
   ctx_.BindMLIRValue(result_name, alloc.getResult());

--- a/src/target/sunmmio/sunmmio_mlir_type.cc
+++ b/src/target/sunmmio/sunmmio_mlir_type.cc
@@ -5,6 +5,7 @@
 #include "npuir/Dialect/SUVM/IR/Types.h"
 #include "sunmmio_mlir_context.h"
 #include "tvm/runtime/logging.h"
+#include <tvm/arith/analyzer.h>
 
 namespace tvm {
 namespace codegen {
@@ -23,14 +24,30 @@ std::vector<int64_t> ExtractShape(const SunMMIOType &type) {
   return shape;
 }
 
-std::vector<int64_t> BuildRowMajorStrides(llvm::ArrayRef<int64_t> shape) {
-  std::vector<int64_t> strides(shape.size(), 1);
-  for (int i = static_cast<int>(shape.size()) - 2; i >= 0; --i) {
-    if (shape[static_cast<size_t>(i + 1)] == mlir::ShapedType::kDynamic ||
-        strides[static_cast<size_t>(i + 1)] == mlir::ShapedType::kDynamic) {
-      strides[static_cast<size_t>(i)] = mlir::ShapedType::kDynamic;
-      continue;
+std::vector<int64_t> ExtractLayoutExprs(llvm::ArrayRef<PrimExpr> exprs) {
+  arith::Analyzer analyzer;
+  std::vector<int64_t> values;
+  values.reserve(exprs.size());
+  for (const PrimExpr &expr : exprs) {
+    PrimExpr simplified = analyzer.Simplify(expr);
+    const auto *imm = simplified.as<tvm::tir::IntImmNode>();
+    if (imm) {
+      values.push_back(static_cast<int64_t>(imm->value));
+    } else {
+      values.push_back(mlir::ShapedType::kDynamic);
     }
+  }
+  return values;
+}
+
+std::vector<PrimExpr> BuildRowMajorStrideExprs(llvm::ArrayRef<PrimExpr> shape) {
+  std::vector<PrimExpr> strides(shape.size());
+  if (shape.empty()) {
+    return strides;
+  }
+  DataType dtype = shape.back().dtype();
+  strides[strides.size() - 1] = tvm::IntImm(dtype, 1);
+  for (int i = static_cast<int>(shape.size()) - 2; i >= 0; --i) {
     strides[static_cast<size_t>(i)] =
         shape[static_cast<size_t>(i + 1)] * strides[static_cast<size_t>(i + 1)];
   }
@@ -153,13 +170,17 @@ mlir::Type SunmmioMlirType::MapType(const SunMMIOType &type) const {
     mlir::Type elem = MapElementType(canonical_type.dtype);
     std::vector<int64_t> shape = ExtractShape(canonical_type);
 
-    std::vector<int64_t> layout_hshape = canonical_type.layout_hshape.empty()
-                                             ? shape
+    std::vector<PrimExpr> layout_hshape_exprs =
+        canonical_type.layout_hshape.empty() ? canonical_type.shape
                                              : canonical_type.layout_hshape;
-    std::vector<int64_t> layout_hstride =
+    std::vector<PrimExpr> layout_hstride_exprs =
         canonical_type.layout_hstride.empty()
-            ? BuildRowMajorStrides(layout_hshape)
+            ? BuildRowMajorStrideExprs(layout_hshape_exprs)
             : canonical_type.layout_hstride;
+    std::vector<int64_t> layout_hshape =
+        ExtractLayoutExprs(layout_hshape_exprs);
+    std::vector<int64_t> layout_hstride =
+        ExtractLayoutExprs(layout_hstride_exprs);
     std::vector<uint8_t> dim_levels = canonical_type.layout_dim_levels.empty()
                                           ? BuildFlatDimLevels(shape.size())
                                           : canonical_type.layout_dim_levels;

--- a/src/target/sunmmio/sunmmio_mlir_type.h
+++ b/src/target/sunmmio/sunmmio_mlir_type.h
@@ -64,8 +64,8 @@ struct SunMMIOType {
   DataType dtype{DataType::Void()};
   int lanes{1};
   std::vector<PrimExpr> shape;
-  std::vector<int64_t> layout_hshape;
-  std::vector<int64_t> layout_hstride;
+  std::vector<PrimExpr> layout_hshape;
+  std::vector<PrimExpr> layout_hstride;
   std::vector<uint8_t> layout_dim_levels;
   std::string memory_scope;
   int64_t byte_offset{0};

--- a/testing/python/target/test_sunmmio_codegen_allocate_copy_expr_opt_validate.py
+++ b/testing/python/target/test_sunmmio_codegen_allocate_copy_expr_opt_validate.py
@@ -20,7 +20,8 @@ tilelang.env.disable_cache()
 
 # Debug logs from this file:
 os.environ.setdefault("SUNMMIO_TEST_PRINT", "0")
-# os.environ["SUNMMIO_TEST_LOG_IR"] = "1"
+# os.environ["SUNMMIO_TEST_PRINT"] = "1"
+# dtype = T.bfloat16
 
 
 @target("Sunmmio")
@@ -265,7 +266,14 @@ def test_basic_allocate_copy_mma_codegen_validates_with_npuir_opt(tmp_path):
         basic_allocate_copy_mma_kernel(),
         tmp_path,
         mlir_filename="basic_allocate_copy_mma_suvm.mlir",
-        expected_tokens=("suvm.alloc", "suvm.copy_async", "suvm.tc.mma"),
+        expected_tokens=(
+            "suvm.alloc",
+            "suvm.ping_pong = #suvm.ping_pong<ping>",
+            "#suvm.memory_space<asram>",
+            "#suvm.memory_space<wsram>",
+            "suvm.copy_async",
+            "suvm.tc.mma",
+        ),
     )
 
 

--- a/testing/python/target/test_sunmmio_codegen_base_dynamic_opt_validate.py
+++ b/testing/python/target/test_sunmmio_codegen_base_dynamic_opt_validate.py
@@ -1,0 +1,228 @@
+import os
+
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+import tvm_ffi
+from tilelang.carver.arch import driver
+from tilelang.layout import (
+    make_nzz_layout,
+    make_zn_layout,
+    make_zz_layout,
+    make_zzz_layout,
+)
+
+from sunmmio_codegen_validation_utils import (
+    assert_source_contains,
+    lower_sunmmio_kernel_to_device_tir,
+    validate_sunmmio_codegen_with_npuir_opt,
+)
+
+
+tilelang.env.disable_cache()
+
+os.environ["SUNMMIO_TEST_PRINT"] = "0"
+
+
+_layout_logical_shape = tvm_ffi.get_global_func("tl.CuteLayout_logical_shape")
+_layout_mode_shape = tvm_ffi.get_global_func("tl.CuteLayout_mode_shape")
+_layout_mode_stride = tvm_ffi.get_global_func("tl.CuteLayout_mode_stride")
+_layout_dim_levels = tvm_ffi.get_global_func("tl.CuteLayout_dim_levels")
+_layout_covered_shape = tvm_ffi.get_global_func("tl.CuteLayout_covered_shape")
+_layout_storage_size = tvm_ffi.get_global_func("tl.CuteLayout_storage_size")
+
+
+def _as_list(value):
+    return [str(item) for item in value]
+
+
+def _layout_obj(layout):
+    return getattr(layout, "_inner", layout)
+
+
+def get_layout_info(layout):
+    layout = _layout_obj(layout)
+    return {
+        "logical_shape": _as_list(_layout_logical_shape(layout)),
+        "mode_shape": _as_list(_layout_mode_shape(layout)),
+        "mode_stride": _as_list(_layout_mode_stride(layout)),
+        "dim_levels": _as_list(_layout_dim_levels(layout)),
+        "covered_shape": _as_list(_layout_covered_shape(layout)),
+        "storage_size": str(_layout_storage_size(layout)),
+    }
+
+
+def print_layout_info(name, layout):
+    for key, value in get_layout_info(layout).items():
+        print(f"{name}.{key} = {value}")
+
+
+def print_kernel_layouts(name, kernel):
+    print(f"========== {name} tensor layouts ==========")
+    tensor_meta = kernel.attrs["tensor_meta"]
+    for tensor_name in ("A", "B", "C"):
+        meta = tensor_meta[tensor_name]
+        print(f"-- {tensor_name} global_layout --")
+        print_layout_info(f"{tensor_name}.global", meta["global_layout"])
+        print(f"-- {tensor_name} sharded_layout --")
+        print_layout_info(f"{tensor_name}.sharded", meta["sharded_layout"])
+
+
+def dynamic_allocate_copy_mma_kernel(
+    block_M=32,
+    block_N=32,
+    block_K=32,
+    dtype=T.float16,
+):
+    M = T.dynamic("m")
+    N = T.dynamic("n")
+    K = T.dynamic("k")
+    # A_layout = make_zz_layout((M, K))
+    # B_layout = make_zz_layout((K, N))
+    # C_layout = make_zz_layout((M, N))
+
+    device_mesh_config = driver.get_sunmmio_device_mesh_config()
+    nrows, ncols = device_mesh_config
+    ncores = nrows * ncols
+    grid_m = T.ceildiv(M, block_M)
+    grid_n = T.ceildiv(N, block_N)
+
+    shard_policy = T.MeshShardingPolicy()
+
+    @T.prim_func
+    def main(
+        A: T.MeshTensor((M, K), shard_policy, device_mesh_config, dtype),  # type: ignore
+        B: T.MeshTensor((K, N), shard_policy, device_mesh_config, dtype),  # type: ignore
+        C: T.MeshTensor((M, N), shard_policy, device_mesh_config, dtype),  # type: ignore
+    ):
+        with T.Kernel(ncores) as _cid:
+            A_shared = T.alloc_shared((block_M, block_K), dtype)
+            B_shared = T.alloc_shared((block_K, block_N), dtype)
+            C_shared = T.alloc_shared((block_M, block_N), dtype)
+
+            for by in T.serial(grid_m):
+                for bx in T.serial(grid_n):
+                    T.copy(A[by * block_M, 0], A_shared)
+                    T.copy(B[0, bx * block_N], B_shared)
+                    T.gemm(A_shared, B_shared, C_shared, transpose_B=True)
+                    T.copy(C_shared, C[by * block_M, bx * block_N])
+
+    return main
+
+
+def dynamic_zz_allocate_copy_mma_kernel(
+    block_M=32,
+    block_N=32,
+    block_K=32,
+    dtype=T.float16,
+):
+    M = T.dynamic("m")
+    N = T.dynamic("n")
+    K = T.dynamic("k")
+    A_layout = make_zz_layout((M, K))
+    B_layout = make_zz_layout((K, N))
+    C_layout = make_zz_layout((M, N))
+
+    device_mesh_config = driver.get_sunmmio_device_mesh_config()
+    nrows, ncols = device_mesh_config
+    ncores = nrows * ncols
+    grid_m = T.ceildiv(M, block_M)
+    grid_n = T.ceildiv(N, block_N)
+
+    shard_policy = T.MeshShardingPolicy()
+
+    @T.prim_func
+    def main(
+        A: T.MeshTensor((M, K), shard_policy, device_mesh_config, dtype, layout=A_layout),  # type: ignore
+        B: T.MeshTensor((K, N), shard_policy, device_mesh_config, dtype, layout=B_layout),  # type: ignore
+        C: T.MeshTensor((M, N), shard_policy, device_mesh_config, dtype, layout=C_layout),  # type: ignore
+    ):
+        with T.Kernel(ncores) as _cid:
+            A_shared = T.alloc_shared((block_M, block_K), dtype)
+            B_shared = T.alloc_shared((block_K, block_N), dtype)
+            C_shared = T.alloc_shared((block_M, block_N), dtype)
+
+            for by in T.serial(grid_m):
+                for bx in T.serial(grid_n):
+                    T.copy(A[by * block_M, 0], A_shared)
+                    T.copy(B[0, bx * block_N], B_shared)
+                    T.gemm(A_shared, B_shared, C_shared, transpose_B=True)
+                    T.copy(C_shared, C[by * block_M, bx * block_N])
+
+    return main
+
+
+def test_dynamic_named_layout_constructors_accept_symbolic_shapes():
+    M = T.dynamic("m")
+    N = T.dynamic("n")
+    K = T.dynamic("k")
+
+    layouts = {
+        "zz": make_zz_layout((M, K)),
+        "zn": make_zn_layout((M, K), [0, 1], (32, 32)),
+        "zzz": make_zzz_layout((M, N), [0, 1], (32, 32), (2, 2)),
+        "nzz": make_nzz_layout((K, N), [0, 1], (32, 32), (2, 2)),
+    }
+    for name, layout in layouts.items():
+        print_layout_info(name, layout)
+    assert all(layout is not None for layout in layouts.values())
+
+
+def test_print_dynamic_kernel_layouts():
+    print_kernel_layouts("dynamic row-major", dynamic_allocate_copy_mma_kernel())
+    print_kernel_layouts("dynamic zz", dynamic_zz_allocate_copy_mma_kernel())
+
+
+def test_dynamic_allocate_copy_mma_lowers_to_device_tir():
+    device_mod = lower_sunmmio_kernel_to_device_tir(
+        dynamic_allocate_copy_mma_kernel(),
+        print_ir=False,
+    )
+    script = device_mod.script()
+    assert_source_contains(
+        script,
+        (
+            "k: T.int32",
+            "m: T.int32",
+            "n: T.int32",
+            "for by in range((m + 31) // 32)",
+            "for bx_1 in range((n + 31) // 32)",
+            "T.dma_copy",
+            "T.mma_sunmmio",
+        ),
+    )
+
+
+def test_dynamic_zz_allocate_copy_mma_codegen_validates_with_npuir_opt(tmp_path):
+    validate_sunmmio_codegen_with_npuir_opt(
+        dynamic_zz_allocate_copy_mma_kernel(),
+        tmp_path,
+        mlir_filename="dynamic_zz_allocate_copy_mma_suvm.mlir",
+        expected_tokens=(
+            "arith.addi",
+            "arith.divsi",
+            "suvm.bind_layout",
+            "dynamic_shapes =",
+            "dynamic_strides =",
+            "suvm.copy_async",
+            "suvm.tc.mma",
+        ),
+    )
+
+
+def test_dynamic_allocate_copy_mma_codegen_validates_with_npuir_opt(tmp_path):
+    validate_sunmmio_codegen_with_npuir_opt(
+        dynamic_allocate_copy_mma_kernel(),
+        tmp_path,
+        mlir_filename="dynamic_allocate_copy_mma_suvm.mlir",
+        expected_tokens=(
+            "suvm.bind_layout",
+            "suvm.alloc",
+            "suvm.copy_async",
+            "suvm.tc.mma",
+        ),
+    )
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()


### PR DESCRIPTION
## Summary

This PR adds SunMMIO codegen support for dynamic kernel parameters and dynamic buffer layouts, including symbolic layout shapes/strides for external buffers. It also improves SUVM MLIR emission for dynamic layouts and adds validation coverage for dynamic allocate/copy/MMA kernels.

## Changes

- Support dynamic kernel parameters in SunMMIO codegen, including buffers whose layout metadata depends on runtime dimensions.
- Preserve symbolic layout shape/stride expressions instead of requiring layout metadata to be fully static.
- Emit `suvm.bind_layout` for external buffers with dynamic layout shapes or strides.
- Map symbolic layout dimensions to dynamic MLIR dimensions while keeping static dimensions unchanged.
- Add default `suvm.ping_pong = ping` attribute for `asram` and `wsram` allocations.
- Add `tir.log2` lowering through `ln(x) * log2(e)`.
- Remove unused tile broadcast lowering path.
- Add dynamic layout/codegen validation tests for row-major and ZZ-layout allocate/copy/MMA kernels.
- Extend existing allocate/copy/MMA validation to check ping-pong attributes and ASRAM/WSRAM memory spaces.

## Testing

Added/updated validation coverage:

- `testing/python/target/test_sunmmio_codegen_base_dynamic_opt_validate.py`
- `testing/python/target/test_sunmmio_codegen_allocate_copy_expr_opt_validate.py`