### PR TITLE
update readme and user guide for sunmmio

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,173 @@
 <div align="center">
 
 # Tile Language for Distributed Memory
-[![PyPI version](https://badge.fury.io/py/tilelang.svg)](https://badge.fury.io/py/tilelang)
-[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/tile-ai/tilelang) [![Discord](https://img.shields.io/badge/Discord-%235865F2.svg?logo=discord&logoColor=white)](https://discord.gg/TUrHyJnKPG)
+
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/tile-ai/tilelang) [![Discord](https://img.shields.io/badge/Discord-%235865F2.svg?logo=discord\&logoColor=white)](https://discord.gg/TUrHyJnKPG)
 
 </div>
 
 ## The Goal
-The goal of this open source project is to extend Tilelang (https://tilelang.com/) as a unified DSL (domain-specific language) to enable high-performance kernel development for Near-Memory Computing, Distributed Memory AI Accelerators, and Networked Accelerators.
+
+The goal of this open source project is to extend Tilelang (<https://tilelang.com/>) as a unified DSL (domain-specific language) to enable high-performance kernel development for Near-Memory Computing, Distributed Memory AI Accelerators, and Networked Accelerators.
 
 Near-memory computing and distributed memory systems have become key approaches to address the huge computing demand of AI, while networked accelerators further promote the decoupling and coordination of computational resources. To support efficient programming for such emerging heterogeneous computing architectures, we need a unified domain-specific language (DSL) aimed at enabling high-performance kernel development. The design goal is to abstract away underlying hardware differences among different Near-Memory Accelerators or Networked Accelerators, and provide a unified interface, allowing developers to focus on algorithm optimization rather than hardware adaptation. The language likely incorporates key techniques such as tensor tiling, dataflow scheduling, memory layouting, and communication-aware compilation, supporting automatic code generation and optimization to achieve efficient kernel execution across various advanced AI acceleration architectures. Through this unified language framework, we aim to significantly reduce the complexity of cross-platform AI operator development, improving both development efficiency and system performance.
 
-## Latest News
-- 10/30/2025 📦:
+## Installation
+
+TileLang-Mesh is a TileLang variant for distributed-memory and Sunmmio-style backends. It keeps the Python import namespace as `tilelang`, but the Python distribution name in this repository is `tilelang-mesh`.
+
+If you only need upstream TileLang, install it from PyPI with `pip install tilelang` as described in the [upstream TileLang README](https://github.com/tile-ai/tilelang). If you need this distributed-memory variant, install from this repository instead.
+
+### Differences from Upstream TileLang
+
+- Upstream TileLang can be installed directly with `pip install tilelang`; that command does not install TileLang-Mesh.
+- This repository builds the `tilelang-mesh` distribution while preserving `import tilelang` compatibility.
+- This repository adds a `3rdparty/NPU-IR` submodule for the Sunmmio/SUVM backend. A recursive clone should include that submodule.
+- `USE_NPUIR` defaults to `ON`. With this enabled, CMake integrates NPU-IR and may fetch or build LLVM/MLIR sources unless you provide an existing LLVM source checkout.
+- The usual TileLang backends are still available: CUDA is selected by default on Linux when not explicitly disabled, ROCm can be selected with `USE_ROCM`, and Metal is selected by default on macOS.
+- Developer rebuilds use the repository `build` directory. After changing C++ files, rebuild from `build` with `ninja`; after adding new C++ files, rerun CMake first.
+
+### Prerequisites
+
+- Linux is the primary development platform for TileLang-Mesh.
+- Python >= 3.9.
+- CMake >= 3.26 and a C++17 compiler.
+- Ninja is recommended for faster native builds.
+- CUDA toolkit if building the default CUDA backend.
+- Git submodules, including `3rdparty/NPU-IR`, if building with `USE_NPUIR=ON`.
+
+On Ubuntu/Debian systems:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y \
+  git python3 python3-dev python3-setuptools \
+  gcc g++ build-essential cmake ninja-build \
+  zlib1g-dev libedit-dev libtinfo-dev libxml2-dev
+```
+
+If your system CMake is too old, install the Python build tools in the target environment:
+
+```bash
+python -m pip install -U pip wheel
+python -m pip install "cmake>=3.26.1" ninja scikit-build-core cython
+```
+
+### Install from Source
+
+Use a recursive clone so the vendored TVM, CUTLASS, Composable Kernel, and NPU-IR sources are present:
+
+```bash
+git clone --recursive https://github.com/Sunmmio/Tilelang-mesh.git
+cd Tilelang-mesh
+git submodule update --init --recursive
+```
+
+Then install in the active Python environment. For normal use, prefer the non-editable install:
+
+```bash
+conda activate mesh
+python -m pip install . -v
+```
+
+If the machine does not have a CUDA toolkit, disable the CUDA backend explicitly:
+
+```bash
+CMAKE_ARGS="-DUSE_CUDA=OFF" python -m pip install . -v
+```
+
+If you also do not need the Sunmmio/SUVM backend in that environment, disable NPU-IR as well:
+
+```bash
+CMAKE_ARGS="-DUSE_CUDA=OFF -DUSE_NPUIR=OFF" python -m pip install . -v
+```
+
+For project development, use an editable install:
+
+```bash
+conda activate mesh
+python -m pip install -e . -v
+```
+
+Verify the import:
+
+```bash
+python -m pip show tilelang-mesh
+python -c "import tilelang; print('tilelang import OK')"
+```
+
+### Common Build Configurations
+
+Default CUDA + NPU-IR build, non-editable:
+
+```bash
+python -m pip install . -v
+```
+
+Default CUDA + NPU-IR build for development:
+
+```bash
+python -m pip install -e . -v
+```
+
+Build with an existing LLVM source checkout for NPU-IR:
+
+```bash
+CMAKE_ARGS="-DNPUIR_USE_LLVM_SOURCE_DIR=/path/to/llvm-project" \
+  python -m pip install . -v
+```
+
+Build with ROCm and without NPU-IR:
+
+```bash
+CMAKE_ARGS="-DUSE_CUDA=OFF -DUSE_ROCM=ON -DUSE_NPUIR=OFF" \
+  python -m pip install . -v
+```
+
+### Faster Rebuild for Developers
+
+For frequent C++ development, configure the native build once and rebuild with Ninja:
+
+```bash
+mkdir -p build
+cd build
+cmake .. -G Ninja -DUSE_CUDA=ON -DUSE_NPUIR=ON
+ninja
+```
+
+When using the source tree directly:
+
+```bash
+export PYTHONPATH=/path/to/Tilelang-mesh:$PYTHONPATH
+python -c "import tilelang; print('tilelang import OK')"
+```
+
+After editing existing C++ files:
+
+```bash
+cd build
+ninja
+```
+
+After adding new C++ files:
+
+```bash
+cd build
+cmake .. -G Ninja -DUSE_CUDA=ON -DUSE_NPUIR=ON
+ninja
+```
+
+### Docker
+
+Dockerfiles are available under `docker/`. The CUDA development image can be built from the repository root:
+
+```bash
+docker build -t sunlune/tilelang:cuda -f docker/Dockerfile.cu130.dev .
+```
+
+See [docker/README.md](docker/README.md) for container launch examples.
+
+## Documentation
+
+- [SunMMIO TileLang User Guide](docs/sunmmio/sunmmio_tilelang_user_guide.md): user-facing guide for writing, migrating, and debugging TileLang kernels on the SunMMIO target.
+- [TileLang docs](docs/index.md): full documentation index, including general TileLang guides and SunMMIO-specific notes.

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,6 +41,13 @@ programming_guides/type_system
 
 :::{toctree}
 :maxdepth: 1
+:caption: SUNMMIO
+
+sunmmio/sunmmio_tilelang_user_guide
+:::
+
+:::{toctree}
+:maxdepth: 1
 :caption: DEEP LEARNING OPERATORS
 
 deeplearning_operators/elementwise

--- a/docs/sunmmio/sunmmio_tilelang_user_guide.md
+++ b/docs/sunmmio/sunmmio_tilelang_user_guide.md
@@ -1,0 +1,1242 @@
+# SunMMIO TileLang 用户说明
+
+本文面向已经熟悉基础 TileLang、但需要在 SunMMIO 目标上编写、迁移或调试 kernel 的用户。重点说明用户在前端编程时需要理解的硬件结构、编程模型、前端函数和常见写法。
+
+文档里的硬件名称使用 `SunMMIO`，TileLang target 字符串使用当前实现中的 `Sunmmio`。
+
+## 1. 硬件结构特点
+
+### 1.1 架构总览
+
+SunMMIO NPU 的核心硬件特征可以概括为：多核 2D mesh、每 core 独立 DRAM、分层片上 SRAM、多类硬件引擎。
+
+SunMMIO 采用 core-level 的执行组织。每个 core 拥有自己的计算、搬运和片上存储资源，core 之间通过二维 mesh 互联。用户编写 kernel 时通常需要显式考虑当前 core 负责哪一块数据，以及需要和哪些相邻或同组 core 交换数据。
+
+硬件上数据流是显式的：数据需要进入对应 SRAM 区域，再由 ODMA、Tensor Core、Vector Core、HLink/VLink 等不同硬件单元消费或转移。因此，SunMMIO 程序通常围绕数据分布、数据搬运、局部计算和核间通讯来组织。
+
+### 1.2 2D Mesh Core
+
+SunMMIO 由多个 core 组成二维 mesh。当前默认设备配置为 `(4, 4)`，即 4 行、4 列，共 16 个 core。
+
+mesh 有明确的 row / column 方向。横向方向连接同一行内的 core，纵向方向连接同一列内的 core。全 mesh 范围的数据移动通常需要横向与纵向链路组合完成。
+
+core 可以用二维坐标 `(row, col)` 表示，也可以线性化为 id：
+
+```text
+core_id = row * ncol + col
+```
+
+这个坐标体系是数据分布和核间通讯的基础。
+
+### 1.3 每 Core 的计算与搬运引擎
+
+每个 core 内部有多类可并行工作的硬件单元：
+
+- Tensor Core：面向 GEMM / MMA。
+- Vector Core：面向 tile 内逐元素算术、比较、类型转换、fill/clear、局部归约等批量处理。
+- ODMA：负责本 core DRAM 与片上 SRAM 之间的块级数据搬运。
+- HLink / VLink：负责 core 间横向/纵向核间通讯。
+
+这些引擎是独立硬件资源，可以并行工作。用户在组织 kernel 时，需要理解计算、搬运和核间通讯可以形成重叠执行空间。
+
+### 1.4 每 Core DRAM 与 SRAM Scope
+
+SunMMIO 的存储层次包含每个 core 配套的 DRAM 和 core 内 SRAM。每个 core 的 DRAM 主要承载该 core 负责的输入 shard、输出 shard 以及片上 SRAM 之外需要保存的数据。
+
+相比片上 SRAM，DRAM 容量更大，但访问延迟更高，带宽也更容易成为瓶颈。片上 SRAM 离计算单元更近，容量有限，适合承载 tile / block 级计算所需的数据。
+
+典型数据流是：每个 core 从自己的 DRAM 搬入某个片上 SRAM 区域，由 Tensor Core、Vector Core 或核间通讯链路消费；计算或核间通讯产生的结果再经由片上 SRAM 写回该 core 的 DRAM。
+
+SunMMIO 的片上 SRAM 按用途分成不同 scope：
+
+- `shared.asram`：主要服务 Tensor Core 的左操作数数据通路。
+- `shared.wsram`：主要服务 Tensor Core 的右操作数数据通路。
+- `shared.rsram`：承载 Tensor Core 的结果操作数、Tensor Core 输出结果和 Vector Core 数据处理，同时承担 DRAM、Tensor Core 结果和 Vector Core 结果之间的数据交换中枢。
+
+不同 SRAM 区域对应不同硬件数据路径。某个硬件单元能否直接消费一块数据，取决于数据当前所在的 SRAM 区域。
+
+### 1.5 Tensor Core / MMA
+
+Tensor Core 是 core 内面向矩阵乘/矩阵累加的计算单元。它通过固定的片上 SRAM 路径获取矩阵数据。
+
+在 Tensor Core 的 MMA 数据通路中：
+
+- `ASRAM` 为 Tensor Core 提供左操作数。
+- `WSRAM` 为 Tensor Core 提供右操作数。
+- `RSRAM` 通常承载结果操作数以及 Tensor Core 输出结果，并作为后续 Vector Core 处理、核间通讯或写回 DRAM 的中转区域。结果操作数承担 GEMM / MMA 的累加和输出角色。
+
+ASRAM、WSRAM、RSRAM 的区分既是 TileLang scope，也对应 Tensor Core 的硬件数据路径。
+
+### 1.6 ODMA 与块级数据搬运
+
+ODMA 是每个 core 内负责本 core DRAM 与片上 SRAM 之间块级数据搬运的硬件单元。它服务的是本 core 的 DRAM 访问路径，主要完成“片外 DRAM shard 与片上 SRAM buffer/region 之间”的数据移动。
+
+在典型 kernel 中，ODMA 负责把输入 shard 从本 core DRAM 搬入片上 SRAM，也负责把片上计算得到的输出 region 写回本 core DRAM。常见方向包括 DRAM 到 RSRAM、DRAM 到 ASRAM/WSRAM，以及 RSRAM 到 DRAM。具体可用路径受 SRAM scope 和硬件数据通路约束，用户在编写 copy 时需要让目标 SRAM 区域匹配后续消费者。
+
+ODMA 独立于 Tensor Core、Vector Core 和 HLink/VLink。一个 core 内可以形成“搬运、计算、核间通讯”并行工作的执行形态：ODMA 准备下一块数据时，Tensor Core 可以消费已经准备好的矩阵 tile，Vector Core 可以处理片上中间结果，HLink/VLink 可以在 core 间传递片上 buffer。用户层面需要明确数据当前位于 DRAM 还是某个 SRAM scope，以及该数据下一步会被哪个硬件单元消费。
+
+### 1.7 Tile 执行粒度与 Vector Core
+
+SunMMIO 的局部计算和访存常以 tile 为基本组织单位。tile 是一块具有明确形状、对齐和访问方向的数据区域，既影响片上 SRAM 中的数据组织，也影响 Vector Core 处理数据的方式。
+
+Vector Core 是 core 内面向 tile 级数据处理的计算单元。它适合处理 tile 内的算术、比较、类型转换、fill/clear、mask 处理、局部归约以及 GEMM 后处理等操作。例如 bias 加法、scale、clamp、局部 reduce、softmax 中的部分片上处理，都属于 Vector Core 适合承载的计算形态。
+
+Vector Core 通常围绕 RSRAM 中的数据工作。Tensor Core 产生的结果操作数进入 RSRAM 后，可以继续由 Vector Core 做后处理，再写回 DRAM 或参与 HLink/VLink 核间通讯。DRAM 搬入 RSRAM 的普通输入 tile，也可以直接由 Vector Core 处理。
+
+Tile 的形状、对齐和访问方向会影响 Vector Core 的执行效率。常见高效写法会让 tile 形状贴合硬件处理宽度，并尽量让片上访问保持规则。对用户而言，选择合适的 tile shape、保持输入输出 region 对齐、避免复杂散乱访问，是写出稳定 SunMMIO kernel 的重要前提。
+
+### 1.8 HLink / VLink 核间通讯
+
+SunMMIO 的核间通讯通过专用链路完成：
+
+- HLink：连接同一行内的 core，主要承载横向核间通讯。
+- VLink：连接同一列内的 core，主要承载纵向核间通讯。
+
+HLink / VLink 独立于 ODMA、Tensor Core 和 Vector Core。它们用于在 core 之间传递片上 buffer 数据，常见核间通讯形态包括 broadcast、point-to-point put、all-gather 和 all-reduce。
+
+横向核间通讯通常沿 HLink 在同一行传播，例如把某个 core 上的分块数据广播给同一行的其他 core。纵向核间通讯通常沿 VLink 在同一列传播，例如把某个 core 上的分块数据广播给同一列的其他 core。需要覆盖整个 mesh 的核间通讯会组合横向和纵向链路，形成多阶段数据移动。
+
+核间通讯除了数据传输本身，还涉及源 core、目标 core、核间通讯方向、接收 buffer 形状以及跨 core 可见性。用户在写程序时应明确当前数据位于哪个 core、要沿哪个方向传输，以及接收端 buffer 是否预留了足够的形状。
+
+## 2. 编程模型
+
+### 2.1 Kernel 执行模型概览
+
+SunMMIO kernel 采用 SPMD（Single Program, Multiple Data）编程形式：所有 core 执行同一份 kernel 程序，输入输出数据由 `MeshTensor` 的 sharding policy 分配到各个 core；kernel 内通过 `cid`、`row`、`col` 定位当前 core 对应的 shard，并决定片上 buffer 使用方式和核间通讯角色。用户通常不需要为每个 core 编写不同的程序分支，而是在同一份程序中用 core 坐标描述数据划分和协作方式。
+
+SunMMIO kernel 也是 persistent kernel：一次 kernel 启动后，各个 core 常驻执行同一份程序，并在 kernel 内通过循环处理分配给自己的 tile 或 work item。已经启动的 core 会持续完成本次 kernel 覆盖的工作，直到程序执行到 kernel 结束位置。一次 kernel 启动中的所有 core 都执行结束后，整个 kernel 才一起完成退出。
+
+在 SPMD 模型下，`MeshTensor` 描述逻辑完整 tensor 的全局形状和分布方式；进入 kernel 后，当前 core 访问的是 sharding 之后分配到该 core 的本地 shard，通常对应该 core 的 DRAM 侧数据分片。跨 core 数据依赖通过 HLink / VLink 相关接口显式表达，片上计算仍然写成当前 core 上的局部计算。
+
+下面的简化骨架展示了 SunMMIO kernel 的典型结构，省略了边界处理和完整循环映射细节。
+
+```python
+import tilelang
+import tilelang.language as T
+from tilelang.carver.arch import driver
+from tilelang.layout import make_zz_layout
+
+device_mesh = driver.get_sunmmio_device_mesh_config()
+nrows, ncols = device_mesh
+ncores = nrows * ncols
+
+M, N, K = 1024, 1024, 1024
+BM, BN, BK = 32, 32, 128
+dtype = "float16"
+accum_dtype = "float32"
+
+shard_policy = T.MeshShardingPolicy(y=0, x=1)
+A_layout = make_zz_layout((M, K), [0, 1], (32, 32))
+B_layout = make_zz_layout((K, N), [0, 1], (32, 32))
+C_layout = make_zz_layout((M, N), [0, 1], (32, 32))
+
+A_ty = T.MeshTensor((M, K), shard_policy, device_mesh, dtype, layout=A_layout)
+B_ty = T.MeshTensor((K, N), shard_policy, device_mesh, dtype, layout=B_layout)
+C_ty = T.MeshTensor((M, N), shard_policy, device_mesh, accum_dtype, layout=C_layout)
+
+@tilelang.jit(target="Sunmmio")
+def gemm_kernel():
+    def main(A: A_ty, B: B_ty, C: C_ty):
+        with T.Kernel(ncores) as cid:
+            row = cid // ncols
+            col = cid % ncols
+            local_m = 0
+            local_n = 0
+
+            A_shared = T.alloc_shared((BM, BK), dtype)
+            B_shared = T.alloc_shared((BK, BN), dtype)
+            C_shared = T.alloc_shared((BM, BN), accum_dtype)
+            T.clear(C_shared)
+
+            for k in T.Pipelined(T.ceildiv(K, BK), num_stages=3):
+                T.copy(A[local_m, k * BK], A_shared)
+                T.copy(B[k * BK, local_n], B_shared)
+                T.gemm(A_shared, B_shared, C_shared)
+
+            T.copy(C_shared, C[local_m, local_n])
+
+    return main
+```
+
+SunMMIO 的编程模型可以概括为：
+
+1. 用 `target="Sunmmio"` 选择目标。
+2. 用 `MeshTensor`、`MeshShardingPolicy` 和 layout 描述逻辑 tensor 如何分布到 2D mesh 以及如何在 DRAM 中组织。
+3. 用 `T.Kernel(ncores)` 以 SPMD 方式按 core 数启动，并通过 `cid -> (row, col)` 确定当前 core 的坐标。
+4. 每个 core 从 sharding 分配给自己的 DRAM shard 搬入片上 SRAM。
+5. 需要跨 core 数据时，用 HLink / VLink 对应的核间通讯接口组织 broadcast、put、all-gather 或 all-reduce。
+6. 用 `T.gemm`、`T.Tiles`、`T.reduce*` 等接口表达片上计算。
+7. 将本 core 负责的结果写回 MeshTensor shard。
+
+### 2.2 Target 设置
+
+设置 target 的目的是告诉 TileLang 当前 kernel 要按照 SunMMIO 的硬件结构和目标规则处理。它会影响 device mesh 配置、memory scope 解释、layout 选择、数据搬运、核间通讯和 GEMM 等目标相关语义。
+
+推荐使用：
+
+```python
+kernel = tilelang.compile(func, target="Sunmmio")
+```
+
+或：
+
+```python
+@tilelang.jit(target="Sunmmio")
+def kernel_factory(...):
+    ...
+```
+
+当前 `auto` 不会自动探测 SunMMIO，因此建议始终显式指定 target。
+
+### 2.3 Kernel 启动模型
+
+SunMMIO kernel 通常按 core 数启动。`T.Kernel(ncores)` 表示为 mesh 中的每个 core 建立一个逻辑执行入口，循环变量 `cid` 是当前 core 的线性 id。
+
+```python
+from tilelang.carver.arch import driver
+
+nrows, ncols = driver.get_sunmmio_device_mesh_config()
+
+with T.Kernel(nrows * ncols) as cid:
+    row = cid // ncols
+    col = cid % ncols
+    ...
+```
+
+用户通常需要用 `cid`、`row`、`col` 决定当前 core 负责哪一块数据，以及核间通讯时当前 core 处于哪一行或哪一列。
+
+从执行语义上看，`T.Kernel(nrows * ncols)` 启动的是一组同时参与同一 kernel 的 persistent core 实例。每个 core 在一次 kernel 启动内持续执行，通常通过循环处理本 core 被分配到的多个 tile 或 work item。即使某些 core 在某个阶段没有实际计算任务，也应按照同一份程序走到 kernel 结束位置；整个 kernel 的完成以所有参与 core 都执行结束为准。
+
+### 2.4 MeshTensor 与 Sharding Policy
+
+`T.MeshTensor` 是 SunMMIO 多 core 输入/输出的主要抽象。它写在函数参数位置，用来描述一个逻辑完整 tensor 如何分布到 2D mesh 上；进入 kernel 后，每个 core 看到的是 sharding 之后分配到该 core 的本地 shard。
+
+```python
+A: T.MeshTensor(
+    (M, K),
+    T.MeshShardingPolicy(y=0, x=1),
+    device_mesh_config,
+    dtype,
+)
+```
+
+`MeshTensor` 需要用户明确给出逻辑全局 shape、sharding policy、device mesh config 和 dtype。`layout` 参数通常可以省略；省略时默认 row-major，后续需要的布局由编译器根据访问模式、buffer 角色和目标规则推断或派生。这里的 `global` 是 TileLang 对 DRAM 侧 tensor 的 scope 命名，对应当前 core 的 DRAM 侧 shard。
+
+`T.MeshShardingPolicy` 决定 tensor 维度如何映射到 mesh 的 row / column 方向。常见写法：
+
+```python
+policy = T.MeshShardingPolicy(y=0, x=1)
+```
+
+含义是 mesh 的 y / row 方向切分 tensor 第 0 维，mesh 的 x / col 方向切分 tensor 第 1 维。对于矩阵类 kernel，通常需要让 sharding 和算法的数据流一致：例如按 M 维分布输出行、按 N 维分布输出列，或者在 K 维上配合 `all_gather` 收集计算所需分块。
+
+复制语义用于表达某些数据在多个 core 上保留相同副本：
+
+- `MeshReplicationType.NONE`：不复制，每个 core 拥有不同 shard。
+- `MeshReplicationType.ROW`：行内复制。
+- `MeshReplicationType.COLUMN`：列内复制。
+- `MeshReplicationType.ALL`：所有 core 复制。
+
+也可以使用：
+
+```python
+T.MeshShardingPolicy(cross_mesh_dim=0)
+```
+
+表示某一维沿整个 mesh 的 `nrows * ncols` 统一切分。`cross_mesh_dim` 与 `x/y` split 互斥。非整除 shape 会形成 tail shard，用户写 kernel 时应避免假设每个 core 的有效数据完全等长。
+
+### 2.5 Layout
+
+Layout 描述 tensor 或 buffer 在内存中的组织方式。它和 sharding 是两个不同层面的概念：sharding 决定完整 tensor 分到哪个 core，layout 决定每个 shard 内部如何排布。
+
+高级场景可用的 layout 构造包括：
+
+```python
+from tilelang.layout import (
+    make_row_major,
+    make_zz_layout,
+    make_zn_layout,
+    make_zzz_layout,
+    make_nzz_layout,
+)
+```
+
+如果 `MeshTensor` 不显式传 `layout`，当前实现会使用 row-major 作为默认全局 layout，并基于 shard shape 派生本地 shard layout。GEMM、块级搬运和核间 gather 等场景下，用户通常不需要手动声明 layout，编译器会根据访问模式、buffer 角色和目标规则推断或派生合适的数据组织。
+
+显式 layout 主要用于高级场景，例如需要与外部固定数据格式对接、复现已有 layout、或调试 layout 相关问题。此时可以手动构造 layout：
+
+```python
+A_layout = make_zz_layout((M, K), [0, 1], (32, 32))
+B_layout = make_zz_layout((K, N), [0, 1], (32, 32))
+C_layout = make_zz_layout((M, N), [0, 1], (32, 32))
+```
+
+### 2.6 TileView
+
+TileView 描述一个 buffer 如何被划分为 tile。它不描述内存物理布局，重点描述 tile loop 和 tile 内计算如何理解 buffer 的逻辑分块。
+
+TileView 的核心信息包括：
+
+- `buffer_shape`：原始 buffer shape。
+- `tile_shape`：每个 tile 的 shape。
+- `index_map`：哪些维度参与 tiling，支持负索引。
+
+例如：
+
+```python
+from tilelang.tileview import make_tileview
+
+T.annotate_tileview({
+    A_shared: make_tileview(A_shared, [32, 32], [-2, -1]),
+})
+```
+
+也可以使用简写：
+
+```python
+T.annotate_tileview({
+    A_shared: ([32, 32], [-2, -1]),
+})
+```
+
+对于 shape 为 `(64, 128)` 的 2D buffer，`tile_shape=(16, 32)`、`index_map=(-2, -1)` 表示按最后两个维度切 tile，逻辑 tiled shape 为 `(4, 4, 16, 32)`。
+
+### 2.7 Copy 语义
+
+用户通常使用 `T.copy` 表达数据搬运：
+
+```python
+T.copy(A[local_m, k * block_K], A_shared)
+T.copy(C_shared, C[local_m, local_n])
+```
+
+下表中的 `DRAM` 指当前 core 的 DRAM 侧 shard。
+
+| 路径                              | 用户语义                         |
+| ------------------------------- | ---------------------------- |
+| DRAM -> RSRAM                   | 从本 core DRAM shard 读取到 RSRAM |
+| RSRAM -> DRAM                   | 从 RSRAM 写回本 core DRAM shard  |
+| DRAM -> ASRAM/WSRAM             | 把输入搬到 Tensor Core 对应操作数区域    |
+| RSRAM -> ASRAM/WSRAM            | 从 RSRAM 准备 Tensor Core 操作数   |
+| RSRAM -> RSRAM                  | 片上 RSRAM 内部拷贝                |
+| ASRAM/WSRAM -> DRAM             | 不支持                          |
+| ASRAM <-> WSRAM                 | 不支持                          |
+| ASRAM -> ASRAM / WSRAM -> WSRAM | 不支持                          |
+
+`T.copy` 可以接受完整 buffer，也可以接受切片或 region。用户应尽量让源、目标 shape 对齐，并让目标 scope 符合后续计算单元的需求：左操作数进入 ASRAM，右操作数进入 WSRAM，结果操作数和多数中间结果放 RSRAM。
+
+### 2.8 T.Tiles
+
+`T.Tiles` 用来表达 tile-level 循环，适合对片上 buffer 做 tile 内逐元素算术、fill/clear、局部 reduce 等操作。
+
+推荐写法：
+
+```python
+for i, j in T.Tiles([block_M, block_N], parallel=True):
+    C_shared[i, j] = C_shared[i, j] + Bias_shared[i, j]
+```
+
+兼容写法：
+
+```python
+for i, j in T.Tiles(C_shared, parallel=True):
+    C_shared[i, j] = C_shared[i, j] + Bias_shared[i, j]
+```
+
+`parallel=True` 表示不同 tile 迭代之间没有 loop-carried dependency。若循环内存在累加、归约或跨迭代依赖，应使用更明确的 reduce 写法，或避免把该循环标成并行。复杂访问模式建议配合 `T.annotate_tileview` 使用。
+
+使用约束：
+
+- 不支持嵌套 `T.Tiles`。
+- scope 内需要有可分析的 buffer access。
+- access pattern 需要能绑定到可行的 1D 或 2D TileView。
+- 隐式 reduction 不支持，reduction 应使用显式 reduce 或 `T.comm.all_reduce`。
+
+### 2.9 核间通讯语义
+
+核间通讯接口用于在 2D core mesh 上交换片上 buffer 数据。核间通讯方向支持：
+
+```text
+horizontal / h
+vertical   / v
+all        / a
+```
+
+core 可以用线性 id，也可以用 `(row, col)` 坐标表示。一般来说，沿行方向交换数据使用 `horizontal`，沿列方向交换数据使用 `vertical`，跨全 mesh 的 collective 使用 `all`。
+
+常用接口：
+
+```python
+T.comm.broadcast(A_shared, B_shared, src_core=(0, 0), direction="horizontal")
+T.comm.put(A_shared, B_shared, src_core=(1, 2), dst_core=(2, 3))
+T.comm.all_gather(A_local, A_gathered, direction="horizontal", axis=-1)
+T.comm.all_reduce(A_shared, Out_shared, "sum", direction="all", dim=-1)
+```
+
+选择接口时可以按语义判断：
+
+- `broadcast`：一个源 core 向某个方向上的多个 core 发送相同数据。
+- `put`：一个源 core 向一个目标 core 发送数据。
+- `all_gather`：多个 core 各自贡献一段数据，并在接收 buffer 中拼接。
+- `all_reduce`：多个 core 的数据做 reduce，并得到 reduce 结果。
+
+`all_gather` 的 recv shape 需要与 direction 和 axis 匹配：
+
+- `axis=None`：recv shape 为 `[K, *send_shape]`。
+- `axis=0`：沿第 0 维拼接。
+- `axis=-1`：沿最后一维拼接。
+
+当前 `axis` 只支持 `0` 或 `-1`。其中 K 是参与 gather 的 core 数：horizontal 为 `ncols`，vertical 为 `nrows`，all 为 `nrows * ncols`。
+
+### 2.10 GEMM
+
+SunMMIO 下 `T.gemm` 表达 Tensor Core GEMM / MMA 计算。左操作数、右操作数和结果操作数在硬件上分别对应 ASRAM、WSRAM、RSRAM 路径；编译器可以根据 `T.gemm(A, B, C)` 中的参数角色推断合适的 SRAM scope。
+
+下面的写法用于说明三类数据在硬件上的对应关系；实际 kernel 中可以先使用普通 shared buffer，让编译器完成 scope 推断：
+
+```python
+A_shared = T.alloc_shared((block_M, block_K), dtype, scope="shared.asram")
+B_shared = T.alloc_shared((block_K, block_N), dtype, scope="shared.wsram")
+C_shared = T.alloc_shared((block_M, block_N), accum_dtype, scope="shared.rsram")
+
+T.gemm(A_shared, B_shared, C_shared)
+```
+
+scope 对应关系：
+
+- 左操作数放 `shared.asram`。
+- 右操作数放 `shared.wsram`。
+- 结果操作数放 `shared.rsram`。
+
+用户真正需要关注的是调用 `T.gemm` 前左右操作数数据是否已经准备好，结果操作数是否已按算法需要初始化或保留累加值。
+
+在 MeshTensor GEMM / SUMMA 类 kernel 中，常见模式是：
+
+1. 每个 core 从自己的 MeshTensor shard 读取局部数据。
+2. 使用 `T.comm.all_gather` 在行/列方向收集完整计算所需分块。
+3. 调用 `T.gemm`。
+4. 将 C 的本地结果写回 MeshTensor shard。
+
+### 2.11 Pipeline
+
+用户一般通过 `T.Pipelined` 表达循环流水线意图：
+
+```python
+for k in T.Pipelined(T.ceildiv(sharded_K, block_K), num_stages=3):
+    T.copy(...)
+    T.comm.all_gather(...)
+    T.gemm(...)
+```
+
+`T.Pipelined` 适合用于 K-loop 或连续 tile 处理，表示循环体中的搬运、核间通讯和计算存在流水化机会。`num_stages` 表示希望保留多少阶段的流水线空间。用户只需要保证循环体内的数据依赖语义正确，底层控制由编译器处理。
+
+## 3. 前端函数说明
+
+本节按类别组织用户会直接接触的前端接口。每个类别下逐个说明函数签名、参数含义和 SunMMIO 使用注意点。示例中的 `buffer` 可以是完整 buffer，也可以是切片或 region。
+
+### 3.1 编译与设备信息
+
+**`tilelang.compile`**
+
+```python
+tilelang.compile(func, target="Sunmmio")
+```
+
+`tilelang.compile` 用于把 TileLang kernel 编译到指定目标。
+
+- `func`：要编译的 kernel factory 或 prim func。
+- `target`：目标后端。SunMMIO 用户应显式写 `target="Sunmmio"`，让编译流程按 SunMMIO 的 mesh、scope、layout、copy、核间通讯和 GEMM 语义处理。
+
+**`tilelang.jit`**
+
+```python
+@tilelang.jit(target="Sunmmio")
+def kernel_factory(...):
+    ...
+```
+
+`tilelang.jit` 用于定义可 JIT 编译的 kernel factory。
+
+- `target`：目标后端。SunMMIO kernel 建议显式写 `target="Sunmmio"`。
+- 被装饰的函数：通常返回一个 `@T.prim_func` 或内部 `main` 函数。
+
+**`driver.get_sunmmio_device_mesh_config`**
+
+```python
+from tilelang.carver.arch import driver
+
+nrows, ncols = driver.get_sunmmio_device_mesh_config()
+```
+
+`get_sunmmio_device_mesh_config()` 返回当前 SunMMIO device mesh 的二维形状。
+
+- 参数：无。
+- 返回值：`(nrows, ncols)`。
+- `nrows`：mesh 的行数，对应纵向 core 数。
+- `ncols`：mesh 的列数，对应横向 core 数。
+- 常见用途：计算 `ncores = nrows * ncols`，并在 `T.Kernel(ncores)` 中把线性 `cid` 映射为 `row = cid // ncols`、`col = cid % ncols`。
+
+**`driver.get_sunmmio_device_properties`**
+
+```python
+props = driver.get_sunmmio_device_properties()
+```
+
+`get_sunmmio_device_properties()` 用于读取 SunMMIO 设备属性。
+
+- 参数：无。
+- 返回值：设备属性对象或字典，具体字段随运行环境提供的设备描述而定。
+- 常见用途：根据设备属性选择 block size、pipeline stage、核间通讯策略或其他 kernel 生成参数。
+
+### 3.2 MeshTensor、Sharding 与 Layout
+
+**`T.MeshShardingPolicy`**
+
+```python
+T.MeshShardingPolicy(
+    x=None,
+    y=None,
+    replicate=T.MeshReplicationType.NONE,
+    cross_mesh_dim=None,
+)
+```
+
+`MeshShardingPolicy` 描述逻辑 tensor 如何映射到 2D mesh。
+
+- `x`：指定 tensor 的哪个维度沿 mesh column 方向切分。若 `x=1`，表示 tensor 第 1 维按 `ncols` 切分。
+- `y`：指定 tensor 的哪个维度沿 mesh row 方向切分。若 `y=0`，表示 tensor 第 0 维按 `nrows` 切分。
+- `replicate`：复制策略，默认 `T.MeshReplicationType.NONE`。
+- `cross_mesh_dim`：指定某一个 tensor 维度沿整个 mesh 切分，即按 `nrows * ncols` 切分。使用 `cross_mesh_dim` 时不要同时指定 `x` 或 `y`。
+
+常用复制策略：
+
+- `T.MeshReplicationType.NONE`：不复制，每个 core 持有不同 shard。
+- `T.MeshReplicationType.ROW`：在同一 row 内复制，不能同时沿 `x` 方向切分。
+- `T.MeshReplicationType.COLUMN`：在同一 column 内复制，不能同时沿 `y` 方向切分。
+- `T.MeshReplicationType.ALL`：所有 core 都持有完整数据。
+
+**`T.MeshTensor`**
+
+```python
+T.MeshTensor(shape, sharding_policy, device_mesh_config, dtype="float32", layout=None)
+```
+
+`MeshTensor` 用在 kernel 函数参数处，声明一个分布在 SunMMIO mesh 上的输入或输出 tensor。
+
+- `shape`：逻辑完整 shape，例如 `(M, K)`。这是用户视角下的全局 tensor shape。
+- `sharding_policy`：`T.MeshShardingPolicy` 对象，描述全局 tensor 如何切到各个 core。
+- `device_mesh_config`：通常来自 `driver.get_sunmmio_device_mesh_config()`，形如 `(nrows, ncols)`。
+- `dtype`：元素类型，例如 `"float16"`、`"bfloat16"`、`"float32"`。
+- `layout`：DRAM 中的全局数据布局。省略时使用默认 row-major，编译器会根据访问模式和目标规则推断或派生后续需要的布局。用户通常不需要手动传入该参数。
+
+进入 kernel 后，`MeshTensor` 参数对应当前 core 可见的本地 shard。`A.shape`、`B.shape` 这类访问得到的是本地 shard shape。
+
+**`make_row_major`**
+
+```python
+from tilelang.layout import make_row_major
+
+layout = make_row_major(shape)
+```
+
+`make_row_major` 构造 row-major layout。
+
+- `shape`：tensor 或 buffer 的逻辑 shape。
+- 返回值：可传给 `T.MeshTensor(..., layout=layout)` 或 `T.annotate_layout` 的 layout 对象。
+- 常见用途：高级场景下需要显式表达 row-major，或调试 layout 相关问题。普通 kernel 通常依赖默认 row-major 和编译器推断。
+
+**`make_zz_layout`**
+
+```python
+from tilelang.layout import make_zz_layout
+
+layout = make_zz_layout(shape_or_buffer, axes=None, block_shape=(32, 32))
+```
+
+`make_zz_layout` 构造块级 ZZ layout。普通 GEMM 或块级访存通常由编译器推断或派生所需布局；该函数主要用于外部固定格式对接、复现已有 layout 或调试。
+
+- `shape_or_buffer`：可以是 shape，也可以是 buffer、buffer load 或 buffer region。
+- `axes`：参与分块布局的维度。省略时默认使用最后两个维度；因此 rank 至少为 2。
+- `block_shape`：每个布局 block 的形状，常见值为 `(32, 32)`。
+- 返回值：layout 对象。
+
+显式构造示例：
+
+```python
+A_layout = make_zz_layout((M, K), [0, 1], (32, 32))
+B_layout = make_zz_layout((K, N), [0, 1], (32, 32))
+C_layout = make_zz_layout((M, N), [0, 1], (32, 32))
+```
+
+**`make_zn_layout`**
+
+```python
+from tilelang.layout import make_zn_layout
+
+layout = make_zn_layout(shape, axes, block_shape)
+```
+
+`make_zn_layout` 构造 ZN layout。
+
+- `shape`：tensor 或 buffer 的逻辑 shape。
+- `axes`：参与布局变换的维度。
+- `block_shape`：分块形状。
+- 返回值：layout 对象。
+- 常见用途：需要特定矩阵操作数格式时显式指定。
+
+**`make_zzz_layout`**
+
+```python
+from tilelang.layout import make_zzz_layout
+
+layout = make_zzz_layout(shape, axes, block_shape, cluster_shape)
+```
+
+`make_zzz_layout` 构造带 cluster 组织的 ZZZ layout。
+
+- `shape`：tensor 或 buffer 的逻辑 shape。
+- `axes`：参与布局变换的维度。
+- `block_shape`：每个 block 的形状。
+- `cluster_shape`：cluster 级组织形状。
+- 返回值：layout 对象。
+
+**`make_nzz_layout`**
+
+```python
+from tilelang.layout import make_nzz_layout
+
+layout = make_nzz_layout(shape, axes, block_shape, cluster_shape)
+```
+
+`make_nzz_layout` 构造带 cluster 组织的 NZZ layout。
+
+- `shape`：tensor 或 buffer 的逻辑 shape。
+- `axes`：参与布局变换的维度。
+- `block_shape`：每个 block 的形状。
+- `cluster_shape`：cluster 级组织形状。
+- 返回值：layout 对象。
+
+**`T.annotate_layout`**
+
+```python
+T.annotate_layout({buffer: layout})
+```
+
+`T.annotate_layout` 给 buffer 或 region 显式附加 layout，属于高级用法。
+
+- 参数：一个 dict，key 是 buffer 或 region，value 是 layout 对象。
+- `buffer`：需要标注布局的对象。
+- `layout`：由 `make_row_major`、`make_zz_layout` 等函数构造。
+- 常见用途：外部固定格式对接、复现已有 layout，或调试 layout 相关问题。普通 kernel 通常依赖编译器推断。
+
+**`make_tileview`**
+
+```python
+from tilelang.tileview import make_tileview
+
+tileview = make_tileview(buffer, tile_shape, index_map)
+```
+
+`make_tileview` 描述 buffer 如何被切成 tile，常和 `T.Tiles` 配合使用。
+
+- `buffer`：要切分的 buffer、buffer load 或 buffer region。
+- `tile_shape`：每个 tile 的形状，例如 `[16, 32]`。
+- `index_map`：参与 tiling 的 buffer 维度，例如 `[-2, -1]` 表示最后两个维度。
+- 返回值：TileView 对象。
+
+SunMMIO 上常见 2D tile 的最后一维为 32，高度常取 8、16 或 32。复杂访问模式建议显式使用 TileView。
+
+**`T.annotate_tileview`**
+
+```python
+T.annotate_tileview({buffer: make_tileview(buffer, tile_shape, index_map)})
+T.annotate_tileview({buffer: (tile_shape, index_map)})
+```
+
+`T.annotate_tileview` 给 buffer 或 region 标注 TileView。
+
+- 参数：一个 dict，key 是 buffer 或 region。
+- value 可以是 `make_tileview(...)` 的返回值。
+- value 也可以写成 `(tile_shape, index_map)` 的 tuple shorthand。
+- `tile_shape`：tile 形状。
+- `index_map`：参与 tiling 的维度。
+
+当 `T.Tiles` 中的访问模式较复杂，或需要稳定表达 tile domain 时，建议使用该接口。
+
+### 3.3 片上存储
+
+**`T.alloc_shared`**
+
+```python
+T.alloc_shared(shape, dtype, scope="shared.dyn")
+```
+
+`T.alloc_shared` 申请 core 内片上 SRAM buffer。
+
+- `shape`：buffer shape，例如 `(block_M, block_N)`。
+- `dtype`：元素类型，例如 `"float16"`、`"bfloat16"`、`"float32"`。
+- `scope`：片上 SRAM scope。默认 `"shared.dyn"`；SunMMIO 常用 `"shared.rsram"`、`"shared.asram"`、`"shared.wsram"`。
+- 返回值：可在 kernel 中读写的 buffer。
+
+常用 scope：
+
+- `shared.asram`：Tensor Core 左操作数路径。
+- `shared.wsram`：Tensor Core 右操作数路径。
+- `shared.rsram`：结果操作数、中间结果、Vector Core 处理数据。
+
+普通 GEMM 代码可以先使用默认 shared buffer；需要明确绑定硬件路径时再显式写 scope。
+
+**`T.clear`**
+
+```python
+T.clear(buffer)
+```
+
+`T.clear` 把 buffer 或 region 清零。
+
+- `buffer`：完整 buffer、slice 或 region。
+- 返回值：表达清零操作的语句。
+- 常见用途：GEMM 前初始化结果操作数，或初始化临时 buffer。
+
+**`T.fill`**
+
+```python
+T.fill(buffer, value)
+```
+
+`T.fill` 用指定值填充 buffer 或 region。
+
+- `buffer`：完整 buffer、slice 或 region。
+- `value`：填充值，类型应能转换到 buffer dtype。
+- 返回值：表达填充操作的语句。
+- 常见用途：初始化常量、设置 mask 默认值、准备 reduce 初值。
+
+### 3.4 数据搬运
+
+**`T.copy`**
+
+```python
+T.copy(
+    src,
+    dst,
+    *,
+    coalesced_width=None,
+    disable_tma=False,
+    eviction_policy=None,
+    annotations=None,
+    loop_layout=None,
+)
+```
+
+`T.copy` 是推荐的数据搬运入口。
+
+- `src`：源 buffer、slice、region 或标量位置。
+- `dst`：目标 buffer、slice、region 或标量位置。
+- `coalesced_width`：合并访问宽度提示，默认 `None`。
+- `disable_tma`：复制路径选择开关，SunMMIO 用户通常保持默认。
+- `eviction_policy`：缓存/替换策略提示，可取 `"evict_normal"`、`"evict_first"`、`"evict_last"` 或 `None`。
+- `annotations`：附加标注 dict。若和单独参数同时出现，dict 中的值优先。
+- `loop_layout`：复制循环的布局提示，普通 SunMMIO 代码通常不需要填写。
+- 返回值：表达 copy 操作的语句。
+
+SunMMIO 常见路径包括 DRAM -> RSRAM、RSRAM -> DRAM、DRAM/RSRAM -> ASRAM、DRAM/RSRAM -> WSRAM、RSRAM -> RSRAM。不支持路径见 2.7。
+
+### 3.5 Tile Loop
+
+**`T.Tiles`**
+
+```python
+for i, j in T.Tiles(domain, parallel=False):
+    ...
+```
+
+`T.Tiles` 构造 tile-level 循环。
+
+- `domain`：循环逻辑域。推荐写显式 shape，例如 `[block_M, block_N]`；也可以传 buffer，表示使用 `buffer.shape`。
+- `parallel`：是否声明不同 tile 迭代之间无跨迭代依赖，默认 `False`。
+- 返回值：tile loop 迭代变量，变量个数由 `domain` rank 决定。
+
+当循环体中存在累加、归约或跨迭代依赖时，不要把 `parallel` 设为 `True`。
+
+### 3.6 核间通讯
+
+核间通讯函数用于在 core 之间传递数据。源数据可以来自片上 buffer，也可以直接来自 DRAM 侧 `MeshTensor` 的 slice/region；后者常用于把本 core DRAM shard 中的某个分块直接作为 broadcast 或 all-gather 的输入。目标通常是接收端片上 buffer，因为后续计算一般会在片上 SRAM 中消费核间通讯结果。
+
+**`T.comm.broadcast`**
+
+```python
+T.comm.broadcast(src, dst, src_core, direction="all", size=-1)
+```
+
+`broadcast` 表达一个源 core 向指定方向上的多个 core 广播数据。
+
+- `src`：源 buffer 或 region，可以是片上 buffer，也可以是 DRAM 侧 `MeshTensor` slice/region。
+- `dst`：接收 buffer 或 region，通常是片上 buffer。
+- `src_core`：源 core，可以是线性 id，也可以是 `(row, col)`。
+- `direction`：广播方向，支持 `"horizontal"` / `"h"`、`"vertical"` / `"v"`、`"all"` / `"a"`。
+- `size`：广播元素数，`-1` 表示使用整个源 region。
+- 返回值：表达 broadcast 的语句。
+
+`horizontal` 沿同一 row 传播，`vertical` 沿同一 column 传播，`all` 覆盖整个 mesh。
+
+**`T.comm.put`**
+
+```python
+T.comm.put(src, dst, src_core, dst_core, size=-1)
+```
+
+`put` 表达点对点发送。
+
+- `src`：源 buffer 或 region，可以是片上 buffer，也可以是 DRAM 侧 `MeshTensor` slice/region。
+- `dst`：目标 buffer 或 region，通常是目标 core 上的片上 buffer。
+- `src_core`：源 core，可以是线性 id，也可以是 `(row, col)`。
+- `dst_core`：目标 core，可以是线性 id，也可以是 `(row, col)`。
+- `size`：发送元素数，`-1` 表示使用整个源 region。
+- 返回值：表达 put 的语句。
+
+`put` 适合一对一数据交付。若同一份数据要发给一行、一列或整个 mesh，通常使用 `broadcast`。
+
+**`T.comm.all_gather`**
+
+```python
+T.comm.all_gather(
+    send_buffer,
+    recv_buffer,
+    direction="all",
+    size=-1,
+    axis=None,
+    src_offset_byte=0,
+)
+```
+
+`all_gather` 表达多个 core 各自贡献局部片段，并在接收 buffer 中拼接。
+
+- `send_buffer`：当前 core 贡献的源 buffer 或 region，可以是片上 buffer，也可以是 DRAM 侧 `MeshTensor` slice/region。
+- `recv_buffer`：接收拼接结果的 buffer 或 region，通常是片上 buffer。
+- `direction`：参与 gather 的方向，支持 `"horizontal"` / `"h"`、`"vertical"` / `"v"`、`"all"` / `"a"`。
+- `size`：每个 core 发送的元素数，`-1` 表示使用整个 `send_buffer`。
+- `axis`：拼接维度。`None` 表示新增第 0 维；`0` 表示沿第 0 维拼接；`-1` 表示沿最后一维拼接。
+- `src_offset_byte`：源地址字节偏移，高级用法一般保持 `0`。
+- 返回值：表达 all-gather 的语句。
+
+接收 shape 需要和 `direction`、`axis` 匹配。若参与 core 数为 `K`：
+
+- `axis=None`：`recv_buffer.shape == [K, *send_buffer.shape]`。
+- `axis=0`：第 0 维扩大为 `K * send_buffer.shape[0]`。
+- `axis=-1`：最后一维扩大为 `K * send_buffer.shape[-1]`。
+
+**`T.comm.all_reduce`**
+
+```python
+T.comm.all_reduce(buffer, out, reduce_type, direction, dim=-1, clear=True)
+```
+
+`all_reduce` 表达跨 core reduce。
+
+- `buffer`：参与 reduce 的输入 buffer 或 region。
+- `out`：保存 reduce 结果的输出 buffer 或 region。
+- `reduce_type`：reduce 类型，支持 `"sum"`、`"abssum"`、`"max"`、`"min"`、`"absmax"`、`"bitand"`、`"bitor"`、`"bitxor"`。
+- `direction`：参与 reduce 的方向，支持 `"horizontal"` / `"h"`、`"vertical"` / `"v"`、`"all"` / `"a"`。
+- `dim`：在本地 buffer 内 reduce 的维度，默认 `-1` 表示最后一维。
+- `clear`：是否在 reduce 前清空 `out`，默认 `True`。
+- 返回值：表达 all-reduce 的语句。
+
+`out` shape 需要等于删除 `dim` 后的 shape，或在 `dim` 上保留长度 1。
+
+### 3.7 GEMM
+
+**`T.gemm`**
+
+```python
+T.gemm(
+    A,
+    B,
+    C,
+    transpose_A=False,
+    transpose_B=False,
+    policy=T.GemmWarpPolicy.Square,
+    clear_accum=False,
+    k_pack=1,
+    wg_wait=0,
+    mbar=None,
+)
+```
+
+`T.gemm` 表达 Tensor Core GEMM / MMA。
+
+- `A`：左操作数 buffer 或 region，硬件路径对应 ASRAM。
+- `B`：右操作数 buffer 或 region，硬件路径对应 WSRAM。
+- `C`：结果操作数 buffer 或 region，硬件路径对应 RSRAM，承担累加和输出角色。
+- `transpose_A`：是否按转置方式解释左操作数，默认 `False`。
+- `transpose_B`：是否按转置方式解释右操作数，默认 `False`。
+- `policy`：GEMM warp 分配策略，SunMMIO 常用默认值。
+- `clear_accum`：是否由 GEMM 操作清空结果操作数，默认 `False`。常见写法是在 GEMM 前显式 `T.clear(C)`。
+- `k_pack`：packed K 参数，SunMMIO 普通用户保持默认 `1`。
+- `wg_wait`：等待批次参数，SunMMIO 普通用户保持默认 `0`。
+- `mbar`：barrier 参数，SunMMIO 普通用户保持默认 `None`。
+- 返回值：表达 GEMM 的语句。
+
+scope 可以根据 `A/B/C` 参数角色推断；显式 scope 写法主要用于说明或需要稳定控制数据路径的场景。
+
+### 3.8 归约
+
+**`T.reduce`**
+
+```python
+T.reduce(buffer, out, reduce_type, dim, clear)
+```
+
+`T.reduce` 表达片上 buffer 的局部 reduce。
+
+- `buffer`：输入 buffer 或 region。
+- `out`：输出 buffer 或 region。
+- `reduce_type`：reduce 类型，例如 `"sum"`、`"max"`、`"min"`、`"abssum"`、`"absmax"`。
+- `dim`：reduce 维度。
+- `clear`：是否在 reduce 前清空输出。
+- 返回值：表达 reduce 的语句。
+
+跨 core reduce 使用 `T.comm.all_reduce`。
+
+**`T.reduce_sum`** **/** **`T.reduce_max`** **/** **`T.reduce_min`**
+
+```python
+T.reduce_sum(buffer, out, dim=-1, clear=True)
+T.reduce_max(buffer, out, dim=-1, clear=True)
+T.reduce_min(buffer, out, dim=-1, clear=True)
+```
+
+这些函数是常用局部 reduce 的快捷入口。
+
+- `buffer`：输入 buffer 或 region。
+- `out`：输出 buffer 或 region。
+- `dim`：reduce 维度，默认最后一维。
+- `clear`：是否在 reduce 前清空输出，默认 `True`。
+- 返回值：表达 reduce 的语句。
+
+**`T.reduce_abssum`** **/** **`T.reduce_absmax`**
+
+```python
+T.reduce_abssum(buffer, out, dim=-1, clear=True)
+T.reduce_absmax(buffer, out, dim=-1, clear=True)
+```
+
+这些函数用于绝对值相关的局部 reduce。
+
+- `buffer`：输入 buffer 或 region。
+- `out`：输出 buffer 或 region。
+- `dim`：reduce 维度，默认最后一维。
+- `clear`：是否在 reduce 前清空输出，默认 `True`。
+- 返回值：表达 reduce 的语句。
+
+**`T.reduce_bitand`** **/** **`T.reduce_bitor`** **/** **`T.reduce_bitxor`**
+
+```python
+T.reduce_bitand(buffer, out, dim=-1, clear=True)
+T.reduce_bitor(buffer, out, dim=-1, clear=True)
+T.reduce_bitxor(buffer, out, dim=-1, clear=True)
+```
+
+这些函数用于整数或 bit mask 场景中的局部 bitwise reduce。
+
+- `buffer`：输入 buffer 或 region。
+- `out`：输出 buffer 或 region。
+- `dim`：reduce 维度，默认最后一维。
+- `clear`：是否在 reduce 前清空输出，默认 `True`。
+- 返回值：表达 reduce 的语句。
+
+### 3.9 Kernel 与循环
+
+**`T.Kernel`**
+
+```python
+with T.Kernel(*blocks, threads=None, is_cpu=False, prelude=None) as cid:
+    ...
+```
+
+`T.Kernel` 建立 kernel/core 执行入口。
+
+- `*blocks`：grid 维度。SunMMIO 常用 `T.Kernel(ncores)`，为 mesh 中每个 core 建立一个逻辑入口。
+- `threads`：线程维度参数。SunMMIO kernel 通常不需要填写。
+- `is_cpu`：是否生成 CPU 形式的 kernel，SunMMIO 用户保持默认 `False`。
+- `prelude`：额外注入代码，SunMMIO 普通用户保持默认 `None`。
+- 返回值：block/core id 绑定。单维 `T.Kernel(ncores)` 返回线性 `cid`。
+
+**`T.serial`**
+
+```python
+T.serial(start, stop=None, step=None, *, annotations=None)
+
+for i in T.serial(stop):
+    ...
+
+for i in T.serial(start, stop, step):
+    ...
+```
+
+`T.serial` 表达串行循环。
+
+- `start`：起始值。若只传一个参数，该参数会作为 `stop`，`start` 默认为 0。
+- `stop`：结束值，循环范围不包含 `stop`。
+- `step`：步长，默认 1。
+- `annotations`：循环标注 dict，普通用户通常不需要填写。
+- 返回值：循环变量。
+
+**`T.Pipelined`**
+
+```python
+T.Pipelined(
+    start,
+    stop=None,
+    num_stages=0,
+    order=None,
+    stage=None,
+    sync=None,
+    group=None,
+)
+
+for k in T.Pipelined(loop_extent, num_stages=3):
+    ...
+```
+
+`T.Pipelined` 表达可流水化循环，常用于 K loop 或连续 tile 处理。
+
+- `start`：若 `stop` 为空，`start` 表示循环次数；若 `stop` 不为空，`start` 表示起始值。
+- `stop`：结束值，默认 `None`。
+- `num_stages`：pipeline stage 数。`0` 表示不启用 pipeline；GEMM K loop 常见值为 2 或 3。
+- `order`：stage 顺序控制，高级用法通常保持默认。
+- `stage`：手动 stage 标注，高级用法通常保持默认。
+- `sync`：同步关系描述，高级用法通常保持默认。
+- `group`：pipeline group 描述，高级用法通常保持默认。
+- 返回值：循环变量。
+
+循环体中通常包含 copy、核间通讯和 compute。用户需要保证数据依赖清晰，例如在使用某个 tile 计算前，相关输入已经搬运或核间通讯完成。
+
+## 4. 示例
+
+本节给出 3 个完整 kernel 示例。为了突出主体结构，示例假设 problem size 能被 block size 和 mesh 切分整除；实际工程代码需要补充边界处理。
+
+### 4.1 本地 Shard GEMM
+
+这个 kernel 中，每个 core 只读取自己 DRAM 中的本地 shard，完成本地 GEMM 后写回自己的输出 shard。
+
+```python
+import tilelang
+import tilelang.language as T
+from tilelang.carver.arch import driver
+from tilelang.layout import make_zz_layout
+
+
+@tilelang.jit(target="Sunmmio")
+def local_shard_gemm(
+    M=128,
+    N=128,
+    K=128,
+    block_M=32,
+    block_N=32,
+    block_K=32,
+    dtype="float16",
+    accum_dtype="float32",
+):
+    device_mesh = driver.get_sunmmio_device_mesh_config()
+    nrows, ncols = device_mesh
+    ncores = nrows * ncols
+
+    policy = T.MeshShardingPolicy(y=0, x=1)
+    A_layout = make_zz_layout((M, K), [0, 1], (32, 32))
+    B_layout = make_zz_layout((K, N), [0, 1], (32, 32))
+    C_layout = make_zz_layout((M, N), [0, 1], (32, 32))
+
+    @T.prim_func
+    def main(
+        A: T.MeshTensor((M, K), policy, device_mesh, dtype, layout=A_layout),  # type: ignore
+        B: T.MeshTensor((K, N), policy, device_mesh, dtype, layout=B_layout),  # type: ignore
+        C: T.MeshTensor((M, N), policy, device_mesh, accum_dtype, layout=C_layout),  # type: ignore
+    ):
+        with T.Kernel(ncores) as _cid:
+            sharded_M, sharded_K = A.shape
+            _, sharded_N = B.shape
+
+            A_tile = T.alloc_shared((block_M, block_K), dtype)
+            B_tile = T.alloc_shared((block_K, block_N), dtype)
+            C_tile = T.alloc_shared((block_M, block_N), accum_dtype)
+
+            for bm in T.serial(T.ceildiv(sharded_M, block_M)):
+                for bn in T.serial(T.ceildiv(sharded_N, block_N)):
+                    T.clear(C_tile)
+                    for bk in T.Pipelined(T.ceildiv(sharded_K, block_K), num_stages=3):
+                        T.copy(
+                            A[
+                                bm * block_M : (bm + 1) * block_M,
+                                bk * block_K : (bk + 1) * block_K,
+                            ],
+                            A_tile,
+                        )
+                        T.copy(
+                            B[
+                                bk * block_K : (bk + 1) * block_K,
+                                bn * block_N : (bn + 1) * block_N,
+                            ],
+                            B_tile,
+                        )
+                        T.gemm(A_tile, B_tile, C_tile)
+
+                    T.copy(C_tile, C[bm * block_M, bn * block_N])
+
+    return main
+```
+
+### 4.2 SUMMA GEMM with HLink / VLink
+
+这个 kernel 展示 SUMMA 风格数据流：同一 row 通过 HLink 收集左操作数分块，同一 column 通过 VLink 收集右操作数分块，然后在本 core 上执行 GEMM。
+
+```python
+import tilelang
+import tilelang.language as T
+from tilelang.carver.arch import driver
+from tilelang.layout import make_zz_layout
+
+
+@tilelang.jit(target="Sunmmio")
+def summa_gemm(
+    M=128,
+    N=128,
+    K=128,
+    block_M=32,
+    block_N=32,
+    block_K=32,
+    dtype="float16",
+    accum_dtype="float32",
+):
+    device_mesh = driver.get_sunmmio_device_mesh_config()
+    nrows, ncols = device_mesh
+    ncores = nrows * ncols
+
+    policy = T.MeshShardingPolicy(y=0, x=1)
+    A_layout = make_zz_layout((M, K), [0, 1], (32, 32))
+    B_layout = make_zz_layout((K, N), [0, 1], (32, 32))
+    C_layout = make_zz_layout((M, N), [0, 1], (32, 32))
+
+    @T.prim_func
+    def main(
+        A: T.MeshTensor((M, K), policy, device_mesh, dtype, layout=A_layout),  # type: ignore
+        B: T.MeshTensor((K, N), policy, device_mesh, dtype, layout=B_layout),  # type: ignore
+        C: T.MeshTensor((M, N), policy, device_mesh, accum_dtype, layout=C_layout),  # type: ignore
+    ):
+        with T.Kernel(ncores) as _cid:
+            sharded_M, sharded_K = A.shape
+            _, sharded_N = B.shape
+
+            A_panel = T.alloc_shared((block_M, block_K * ncols), dtype)
+            B_panel = T.alloc_shared((block_K * nrows, block_N), dtype)
+            C_tile = T.alloc_shared((block_M, block_N), accum_dtype)
+
+            for bm in T.serial(T.ceildiv(sharded_M, block_M)):
+                for bn in T.serial(T.ceildiv(sharded_N, block_N)):
+                    T.clear(C_tile)
+                    for bk in T.Pipelined(T.ceildiv(sharded_K, block_K), num_stages=3):
+                        T.comm.all_gather(
+                            A[
+                                bm * block_M : (bm + 1) * block_M,
+                                bk * block_K : (bk + 1) * block_K,
+                            ],
+                            A_panel,
+                            direction="horizontal",
+                            axis=-1,
+                        )
+                        T.comm.all_gather(
+                            B[
+                                bk * block_K : (bk + 1) * block_K,
+                                bn * block_N : (bn + 1) * block_N,
+                            ],
+                            B_panel,
+                            direction="vertical",
+                            axis=0,
+                        )
+                        T.gemm(A_panel, B_panel, C_tile)
+
+                    T.copy(C_tile, C[bm * block_M, bn * block_N])
+
+    return main
+```
+
+### 4.3 GEMM + Tile 内后处理
+
+这个 kernel 在 GEMM 之后加载一个同 shape 的 bias tile，并使用 `T.Tiles` 对结果 tile 做逐元素加法。
+
+```python
+import tilelang
+import tilelang.language as T
+from tilelang.carver.arch import driver
+from tilelang.layout import make_zz_layout
+
+
+@tilelang.jit(target="Sunmmio")
+def gemm_with_bias(
+    M=128,
+    N=128,
+    K=128,
+    block_M=32,
+    block_N=32,
+    block_K=32,
+    dtype="float16",
+    accum_dtype="float32",
+):
+    device_mesh = driver.get_sunmmio_device_mesh_config()
+    nrows, ncols = device_mesh
+    ncores = nrows * ncols
+
+    policy = T.MeshShardingPolicy(y=0, x=1)
+    A_layout = make_zz_layout((M, K), [0, 1], (32, 32))
+    B_layout = make_zz_layout((K, N), [0, 1], (32, 32))
+    C_layout = make_zz_layout((M, N), [0, 1], (32, 32))
+
+    @T.prim_func
+    def main(
+        A: T.MeshTensor((M, K), policy, device_mesh, dtype, layout=A_layout),  # type: ignore
+        B: T.MeshTensor((K, N), policy, device_mesh, dtype, layout=B_layout),  # type: ignore
+        Bias: T.MeshTensor((M, N), policy, device_mesh, accum_dtype, layout=C_layout),  # type: ignore
+        C: T.MeshTensor((M, N), policy, device_mesh, accum_dtype, layout=C_layout),  # type: ignore
+    ):
+        with T.Kernel(ncores) as _cid:
+            sharded_M, sharded_K = A.shape
+            _, sharded_N = B.shape
+
+            A_tile = T.alloc_shared((block_M, block_K), dtype)
+            B_tile = T.alloc_shared((block_K, block_N), dtype)
+            Bias_tile = T.alloc_shared((block_M, block_N), accum_dtype)
+            C_tile = T.alloc_shared((block_M, block_N), accum_dtype)
+
+            for bm in T.serial(T.ceildiv(sharded_M, block_M)):
+                for bn in T.serial(T.ceildiv(sharded_N, block_N)):
+                    T.clear(C_tile)
+                    for bk in T.Pipelined(T.ceildiv(sharded_K, block_K), num_stages=3):
+                        T.copy(
+                            A[
+                                bm * block_M : (bm + 1) * block_M,
+                                bk * block_K : (bk + 1) * block_K,
+                            ],
+                            A_tile,
+                        )
+                        T.copy(
+                            B[
+                                bk * block_K : (bk + 1) * block_K,
+                                bn * block_N : (bn + 1) * block_N,
+                            ],
+                            B_tile,
+                        )
+                        T.gemm(A_tile, B_tile, C_tile)
+
+                    T.copy(
+                        Bias[
+                            bm * block_M : (bm + 1) * block_M,
+                            bn * block_N : (bn + 1) * block_N,
+                        ],
+                        Bias_tile,
+                    )
+                    for i, j in T.Tiles([block_M, block_N], parallel=True):
+                        C_tile[i, j] = C_tile[i, j] + Bias_tile[i, j]
+
+                    T.copy(C_tile, C[bm * block_M, bn * block_N])
+
+    return main
+```

--- a/docs/sunmmio/sunmmio_tilelang_user_guide_en.md
+++ b/docs/sunmmio/sunmmio_tilelang_user_guide_en.md
@@ -1,0 +1,1242 @@
+# SunMMIO TileLang User Guide
+
+This guide is intended for users who already know basic TileLang and need to write, migrate, or debug kernels for the SunMMIO target. It focuses on the hardware structure, programming model, frontend functions, and common coding patterns that users need to understand when writing frontend code.
+
+This document uses `SunMMIO` for the hardware name, and uses `Sunmmio` for the TileLang target string used by the current implementation.
+
+## 1. Hardware Structure
+
+### 1.1 Architecture Overview
+
+The key hardware characteristics of the SunMMIO NPU can be summarized as: a multi-core 2D mesh, per-core DRAM, hierarchical on-chip SRAM, and multiple types of hardware engines.
+
+SunMMIO uses a core-level execution organization. Each core has its own compute, data movement, and on-chip storage resources. Cores are connected through a 2D mesh. When writing kernels, users usually need to explicitly reason about which data block is owned by the current core, and which neighboring or grouped cores need to exchange data.
+
+The hardware dataflow is explicit: data must enter the corresponding SRAM region before it can be consumed or moved by ODMA, Tensor Core, Vector Core, HLink/VLink, or other hardware units. Therefore, SunMMIO programs are usually organized around data distribution, data movement, local computation, and inter-core communication.
+
+### 1.2 2D Mesh Core
+
+SunMMIO consists of multiple cores organized as a 2D mesh. The current default device configuration is `(4, 4)`, namely 4 rows and 4 columns, with 16 cores in total.
+
+The mesh has explicit row and column directions. The horizontal direction connects cores in the same row, while the vertical direction connects cores in the same column. Data movement across the whole mesh usually combines horizontal and vertical links.
+
+A core can be represented by a 2D coordinate `(row, col)`, or linearized into an id:
+
+```text
+core_id = row * ncol + col
+```
+
+This coordinate system is the basis for data distribution and inter-core communication.
+
+### 1.3 Per-Core Compute and Data Movement Engines
+
+Each core contains multiple hardware units that can work in parallel:
+
+- Tensor Core: for GEMM / MMA.
+- Vector Core: for tile-level arithmetic, comparison, type conversion, fill/clear, local reduction, and other batch-style processing.
+- ODMA: responsible for block-level data movement between the current core's DRAM and on-chip SRAM.
+- HLink / VLink: responsible for horizontal and vertical inter-core communication.
+
+These engines are independent hardware resources and can work in parallel. When organizing a kernel, users need to understand that computation, data movement, and inter-core communication can form overlapping execution opportunities.
+
+### 1.4 Per-Core DRAM and SRAM Scopes
+
+SunMMIO's memory hierarchy includes DRAM paired with each core and SRAM inside each core. Each core's DRAM mainly stores the input shard, output shard, and data that must be kept outside on-chip SRAM for that core.
+
+Compared with on-chip SRAM, DRAM has larger capacity, but higher access latency, and its bandwidth is more likely to become a bottleneck. On-chip SRAM is closer to compute units and has limited capacity, so it is suitable for data needed by tile/block-level computation.
+
+A typical dataflow is: each core loads data from its own DRAM into an on-chip SRAM region; the data is consumed by Tensor Core, Vector Core, or inter-core communication links; results produced by computation or inter-core communication are then written back from on-chip SRAM to the core's DRAM.
+
+SunMMIO on-chip SRAM is divided into different scopes by purpose:
+
+- `shared.asram`: mainly serves the Tensor Core left-operand data path.
+- `shared.wsram`: mainly serves the Tensor Core right-operand data path.
+- `shared.rsram`: stores the Tensor Core result operand, Tensor Core output results, and data processed by Vector Core. It also acts as the data exchange hub among DRAM, Tensor Core results, and Vector Core results.
+
+Different SRAM regions correspond to different hardware data paths. Whether a hardware unit can directly consume a piece of data depends on the SRAM region where the data currently resides.
+
+### 1.5 Tensor Core / MMA
+
+Tensor Core is the compute unit inside a core for matrix multiplication and matrix accumulation. It obtains matrix data through fixed on-chip SRAM paths.
+
+In the Tensor Core MMA data path:
+
+- `ASRAM` provides the left operand to Tensor Core.
+- `WSRAM` provides the right operand to Tensor Core.
+- `RSRAM` usually stores the result operand and Tensor Core output results, and serves as the staging area for later Vector Core processing, inter-core communication, or write-back to DRAM. The result operand carries the accumulation and output role in GEMM / MMA.
+
+The distinction among ASRAM, WSRAM, and RSRAM is both a TileLang scope distinction and a hardware data path distinction for Tensor Core.
+
+### 1.6 ODMA and Block-Level Data Movement
+
+ODMA is the hardware unit inside each core responsible for block-level data movement between that core's DRAM and on-chip SRAM. It serves the current core's DRAM access path, and mainly moves data between the off-chip DRAM shard and on-chip SRAM buffers/regions.
+
+In a typical kernel, ODMA loads input shards from the current core's DRAM into on-chip SRAM, and also writes on-chip computation output regions back to the current core's DRAM. Common directions include DRAM to RSRAM, DRAM to ASRAM/WSRAM, and RSRAM to DRAM. The exact available paths are constrained by SRAM scopes and hardware data paths. When writing copy operations, users should make the destination SRAM region match the next consumer.
+
+ODMA is independent of Tensor Core, Vector Core, and HLink/VLink. Inside one core, execution can overlap data movement, computation, and inter-core communication: while ODMA prepares the next data block, Tensor Core can consume a matrix tile that is already ready, Vector Core can process on-chip intermediate results, and HLink/VLink can transfer on-chip buffers between cores. At the user level, it is important to know whether data is currently in DRAM or in a specific SRAM scope, and which hardware unit will consume it next.
+
+### 1.7 Tile Execution Granularity and Vector Core
+
+SunMMIO local computation and memory access are often organized around tiles. A tile is a data region with an explicit shape, alignment, and access direction. It affects both how data is organized in on-chip SRAM and how Vector Core processes the data.
+
+Vector Core is the compute unit inside a core for tile-level data processing. It is suitable for arithmetic, comparison, type conversion, fill/clear, mask processing, local reduction, and GEMM post-processing within a tile. For example, bias add, scale, clamp, local reduce, and part of the on-chip processing in softmax are all compute patterns that fit Vector Core.
+
+Vector Core usually works on data in RSRAM. After Tensor Core produces a result operand into RSRAM, Vector Core can continue post-processing it before writing it back to DRAM or participating in HLink/VLink inter-core communication. Ordinary input tiles loaded from DRAM into RSRAM can also be processed directly by Vector Core.
+
+Tile shape, alignment, and access direction affect Vector Core execution efficiency. Common efficient code keeps tile shapes aligned with hardware processing widths and keeps on-chip accesses regular. For users, choosing a suitable tile shape, keeping input/output regions aligned, and avoiding complex scattered accesses are important prerequisites for writing stable SunMMIO kernels.
+
+### 1.8 HLink / VLink Inter-Core Communication
+
+SunMMIO inter-core communication is performed through dedicated links:
+
+- HLink: connects cores in the same row and mainly carries horizontal inter-core communication.
+- VLink: connects cores in the same column and mainly carries vertical inter-core communication.
+
+HLink / VLink are independent of ODMA, Tensor Core, and Vector Core. They are used to transfer on-chip buffer data between cores. Common inter-core communication patterns include broadcast, point-to-point put, all-gather, and all-reduce.
+
+Horizontal inter-core communication usually propagates along HLink within the same row, for example broadcasting a data block on one core to other cores in the same row. Vertical inter-core communication usually propagates along VLink within the same column, for example broadcasting a data block on one core to other cores in the same column. Inter-core communication that covers the whole mesh combines horizontal and vertical links and forms multi-stage data movement.
+
+Inter-core communication involves not only data transfer itself, but also the source core, destination core, communication direction, receive buffer shape, and cross-core visibility. When writing programs, users should be clear about which core currently holds the data, which direction the data should move along, and whether the receive buffer has reserved enough shape.
+
+## 2. Programming Model
+
+### 2.1 Kernel Execution Model Overview
+
+SunMMIO kernels use an SPMD (Single Program, Multiple Data) programming form: all cores execute the same kernel program, and input/output data is assigned to different cores by the `MeshTensor` sharding policy. Inside the kernel, `cid`, `row`, and `col` are used to identify the shard corresponding to the current core, and to determine on-chip buffer usage and inter-core communication roles. Users usually do not need to write separate programs for different cores. Instead, the same program uses core coordinates to describe data partitioning and cooperation.
+
+SunMMIO kernels are also persistent kernels: after one kernel launch, all cores stay resident and execute the same program, using loops inside the kernel to process the tiles or work items assigned to them. The launched cores continuously complete the work covered by the current kernel until the program reaches the kernel end. The whole kernel exits together only after all cores in that launch finish execution.
+
+Under the SPMD model, `MeshTensor` describes the global shape and distribution of a complete logical tensor. After entering the kernel, the current core accesses the local shard assigned to it after sharding, usually corresponding to the DRAM-side data shard of that core. Cross-core data dependencies are expressed explicitly through HLink / VLink related APIs, while on-chip computation is still written as local computation on the current core.
+
+The simplified structure below shows a typical SunMMIO kernel. Boundary handling and complete loop mapping details are omitted.
+
+```python
+import tilelang
+import tilelang.language as T
+from tilelang.carver.arch import driver
+from tilelang.layout import make_zz_layout
+
+device_mesh = driver.get_sunmmio_device_mesh_config()
+nrows, ncols = device_mesh
+ncores = nrows * ncols
+
+M, N, K = 1024, 1024, 1024
+BM, BN, BK = 32, 32, 128
+dtype = "float16"
+accum_dtype = "float32"
+
+shard_policy = T.MeshShardingPolicy(y=0, x=1)
+A_layout = make_zz_layout((M, K), [0, 1], (32, 32))
+B_layout = make_zz_layout((K, N), [0, 1], (32, 32))
+C_layout = make_zz_layout((M, N), [0, 1], (32, 32))
+
+A_ty = T.MeshTensor((M, K), shard_policy, device_mesh, dtype, layout=A_layout)
+B_ty = T.MeshTensor((K, N), shard_policy, device_mesh, dtype, layout=B_layout)
+C_ty = T.MeshTensor((M, N), shard_policy, device_mesh, accum_dtype, layout=C_layout)
+
+@tilelang.jit(target="Sunmmio")
+def gemm_kernel():
+    def main(A: A_ty, B: B_ty, C: C_ty):
+        with T.Kernel(ncores) as cid:
+            row = cid // ncols
+            col = cid % ncols
+            local_m = 0
+            local_n = 0
+
+            A_shared = T.alloc_shared((BM, BK), dtype)
+            B_shared = T.alloc_shared((BK, BN), dtype)
+            C_shared = T.alloc_shared((BM, BN), accum_dtype)
+            T.clear(C_shared)
+
+            for k in T.Pipelined(T.ceildiv(K, BK), num_stages=3):
+                T.copy(A[local_m, k * BK], A_shared)
+                T.copy(B[k * BK, local_n], B_shared)
+                T.gemm(A_shared, B_shared, C_shared)
+
+            T.copy(C_shared, C[local_m, local_n])
+
+    return main
+```
+
+The SunMMIO programming model can be summarized as:
+
+1. Use `target="Sunmmio"` to select the target.
+2. Use `MeshTensor`, `MeshShardingPolicy`, and layout to describe how logical tensors are distributed onto the 2D mesh and how they are organized in DRAM.
+3. Use `T.Kernel(ncores)` to launch by core count in SPMD form, and map `cid -> (row, col)` to determine the current core coordinates.
+4. Each core loads data from the DRAM shard assigned to itself by sharding into on-chip SRAM.
+5. When data is needed across cores, use the HLink / VLink inter-core communication APIs to organize broadcast, put, all-gather, or all-reduce.
+6. Use APIs such as `T.gemm`, `T.Tiles`, and `T.reduce*` to express on-chip computation.
+7. Write the result owned by the current core back to the MeshTensor shard.
+
+### 2.2 Target Setting
+
+The purpose of setting the target is to tell TileLang that the current kernel should be handled according to SunMMIO hardware structure and target-specific rules. It affects device mesh configuration, memory scope interpretation, layout selection, data movement, inter-core communication, GEMM, and other target-specific semantics.
+
+Recommended usage:
+
+```python
+kernel = tilelang.compile(func, target="Sunmmio")
+```
+
+Or:
+
+```python
+@tilelang.jit(target="Sunmmio")
+def kernel_factory(...):
+    ...
+```
+
+Currently, `auto` does not automatically detect SunMMIO, so users should always specify the target explicitly.
+
+### 2.3 Kernel Launch Model
+
+SunMMIO kernels are usually launched by core count. `T.Kernel(ncores)` means creating a logical execution entry for each core in the mesh, and the loop variable `cid` is the linear id of the current core.
+
+```python
+from tilelang.carver.arch import driver
+
+nrows, ncols = driver.get_sunmmio_device_mesh_config()
+
+with T.Kernel(nrows * ncols) as cid:
+    row = cid // ncols
+    col = cid % ncols
+    ...
+```
+
+Users usually use `cid`, `row`, and `col` to decide which data block the current core is responsible for, and which row or column the current core belongs to during inter-core communication.
+
+From the execution semantics point of view, `T.Kernel(nrows * ncols)` launches a group of persistent core instances that participate in the same kernel. Each core keeps executing within one kernel launch, usually processing multiple tiles or work items assigned to that core through loops. Even if some cores have no actual computation task at a certain stage, they should still follow the same program to the kernel end. The whole kernel is considered complete only after all participating cores finish execution.
+
+### 2.4 MeshTensor and Sharding Policy
+
+`T.MeshTensor` is the main abstraction for multi-core SunMMIO inputs and outputs. It is written at function parameter positions and describes how a complete logical tensor is distributed onto the 2D mesh. After entering the kernel, each core sees the local shard assigned to that core after sharding.
+
+```python
+A: T.MeshTensor(
+    (M, K),
+    T.MeshShardingPolicy(y=0, x=1),
+    device_mesh_config,
+    dtype,
+)
+```
+
+`MeshTensor` requires users to provide the global logical shape, sharding policy, device mesh config, and dtype. The `layout` parameter can usually be omitted. When omitted, the default is row-major, and later required layouts are inferred or derived by the compiler according to access patterns, buffer roles, and target rules. Here, `global` is TileLang's scope name for DRAM-side tensors, corresponding to the current core's DRAM-side shard.
+
+`T.MeshShardingPolicy` determines how tensor dimensions map to the row / column directions of the mesh. A common form is:
+
+```python
+policy = T.MeshShardingPolicy(y=0, x=1)
+```
+
+This means that the mesh y / row direction splits tensor dimension 0, and the mesh x / column direction splits tensor dimension 1. For matrix kernels, sharding usually needs to match the algorithm dataflow: for example, distributing output rows along the M dimension and output columns along the N dimension, or using `all_gather` along the K dimension to collect the blocks needed for computation.
+
+Replication semantics are used to express that some data keeps identical copies on multiple cores:
+
+- `MeshReplicationType.NONE`: no replication; each core owns a different shard.
+- `MeshReplicationType.ROW`: replicated within each row.
+- `MeshReplicationType.COLUMN`: replicated within each column.
+- `MeshReplicationType.ALL`: replicated on all cores.
+
+You can also use:
+
+```python
+T.MeshShardingPolicy(cross_mesh_dim=0)
+```
+
+This means one dimension is uniformly split along the entire mesh, namely across `nrows * ncols`. `cross_mesh_dim` is mutually exclusive with `x/y` split. Non-divisible shapes form tail shards, so users should avoid assuming that the valid data length is exactly the same on every core.
+
+### 2.5 Layout
+
+Layout describes how a tensor or buffer is organized in memory. It is a different concept from sharding: sharding decides which core receives which part of the complete tensor, while layout decides how each shard is arranged internally.
+
+Layout constructors available for advanced scenarios include:
+
+```python
+from tilelang.layout import (
+    make_row_major,
+    make_zz_layout,
+    make_zn_layout,
+    make_zzz_layout,
+    make_nzz_layout,
+)
+```
+
+If `MeshTensor` does not explicitly pass `layout`, the current implementation uses row-major as the default global layout, and derives the local shard layout based on the shard shape. In scenarios such as GEMM, block-level data movement, and inter-core gather, users usually do not need to declare layout manually. The compiler infers or derives a suitable data organization according to access patterns, buffer roles, and target rules.
+
+Explicit layout is mainly for advanced scenarios, such as interfacing with an externally fixed data format, reproducing an existing layout, or debugging layout-related issues. In those cases, users can manually construct layouts:
+
+```python
+A_layout = make_zz_layout((M, K), [0, 1], (32, 32))
+B_layout = make_zz_layout((K, N), [0, 1], (32, 32))
+C_layout = make_zz_layout((M, N), [0, 1], (32, 32))
+```
+
+### 2.6 TileView
+
+TileView describes how a buffer is divided into tiles. It does not describe the physical memory layout. Its focus is how tile loops and tile-level computation understand the logical tiling of a buffer.
+
+The core information in a TileView includes:
+
+- `buffer_shape`: the original buffer shape.
+- `tile_shape`: the shape of each tile.
+- `index_map`: the dimensions that participate in tiling, with negative indices supported.
+
+For example:
+
+```python
+from tilelang.tileview import make_tileview
+
+T.annotate_tileview({
+    A_shared: make_tileview(A_shared, [32, 32], [-2, -1]),
+})
+```
+
+You can also use a shorthand:
+
+```python
+T.annotate_tileview({
+    A_shared: ([32, 32], [-2, -1]),
+})
+```
+
+For a 2D buffer with shape `(64, 128)`, `tile_shape=(16, 32)` and `index_map=(-2, -1)` means tiling along the last two dimensions, with logical tiled shape `(4, 4, 16, 32)`.
+
+### 2.7 Copy Semantics
+
+Users usually use `T.copy` to express data movement:
+
+```python
+T.copy(A[local_m, k * block_K], A_shared)
+T.copy(C_shared, C[local_m, local_n])
+```
+
+In the table below, `DRAM` refers to the current core's DRAM-side shard.
+
+| Path                            | User Semantics                                      |
+| ------------------------------- | --------------------------------------------------- |
+| DRAM -> RSRAM                   | Read from the current core's DRAM shard into RSRAM  |
+| RSRAM -> DRAM                   | Write from RSRAM back to the current core's DRAM shard |
+| DRAM -> ASRAM/WSRAM             | Move input data to the Tensor Core operand region   |
+| RSRAM -> ASRAM/WSRAM            | Prepare Tensor Core operands from RSRAM             |
+| RSRAM -> RSRAM                  | On-chip copy inside RSRAM                           |
+| ASRAM/WSRAM -> DRAM             | Unsupported                                         |
+| ASRAM <-> WSRAM                 | Unsupported                                         |
+| ASRAM -> ASRAM / WSRAM -> WSRAM | Unsupported                                         |
+
+`T.copy` can accept a complete buffer, slice, or region. Users should keep source and destination shapes aligned as much as possible, and should make the destination scope match the needs of the following compute unit: the left operand goes to ASRAM, the right operand goes to WSRAM, and the result operand and most intermediate results go to RSRAM.
+
+### 2.8 T.Tiles
+
+`T.Tiles` expresses tile-level loops, and is suitable for tile-level arithmetic, fill/clear, local reduce, and similar operations on on-chip buffers.
+
+Recommended form:
+
+```python
+for i, j in T.Tiles([block_M, block_N], parallel=True):
+    C_shared[i, j] = C_shared[i, j] + Bias_shared[i, j]
+```
+
+Compatible form:
+
+```python
+for i, j in T.Tiles(C_shared, parallel=True):
+    C_shared[i, j] = C_shared[i, j] + Bias_shared[i, j]
+```
+
+`parallel=True` means there is no loop-carried dependency between different tile iterations. If the loop body contains accumulation, reduction, or dependencies across iterations, users should use an explicit reduce form or avoid marking the loop as parallel. Complex access patterns are recommended to be used together with `T.annotate_tileview`.
+
+Usage constraints:
+
+- Nested `T.Tiles` is not supported.
+- There must be analyzable buffer accesses inside the scope.
+- The access pattern must be bindable to a feasible 1D or 2D TileView.
+- Implicit reduction is not supported. Reductions should use explicit reduce APIs or `T.comm.all_reduce`.
+
+### 2.9 Inter-Core Communication Semantics
+
+Inter-core communication APIs are used to exchange on-chip buffer data over the 2D core mesh. Supported inter-core communication directions are:
+
+```text
+horizontal / h
+vertical   / v
+all        / a
+```
+
+A core can be represented by a linear id or by `(row, col)` coordinates. In general, row-wise exchange uses `horizontal`, column-wise exchange uses `vertical`, and collectives across the whole mesh use `all`.
+
+Common APIs:
+
+```python
+T.comm.broadcast(A_shared, B_shared, src_core=(0, 0), direction="horizontal")
+T.comm.put(A_shared, B_shared, src_core=(1, 2), dst_core=(2, 3))
+T.comm.all_gather(A_local, A_gathered, direction="horizontal", axis=-1)
+T.comm.all_reduce(A_shared, Out_shared, "sum", direction="all", dim=-1)
+```
+
+Choose an API by its semantics:
+
+- `broadcast`: one source core sends the same data to multiple cores along a direction.
+- `put`: one source core sends data to one destination core.
+- `all_gather`: multiple cores each contribute a data segment, and the receive buffer concatenates the segments.
+- `all_reduce`: data from multiple cores is reduced, producing a reduction result.
+
+The receive shape of `all_gather` must match `direction` and `axis`:
+
+- `axis=None`: the receive shape is `[K, *send_shape]`.
+- `axis=0`: concatenate along dimension 0.
+- `axis=-1`: concatenate along the last dimension.
+
+Currently, `axis` only supports `0` or `-1`. Here, K is the number of cores participating in the gather: `ncols` for horizontal, `nrows` for vertical, and `nrows * ncols` for all.
+
+### 2.10 GEMM
+
+On SunMMIO, `T.gemm` expresses Tensor Core GEMM / MMA computation. The left operand, right operand, and result operand correspond to the ASRAM, WSRAM, and RSRAM hardware paths respectively. The compiler can infer suitable SRAM scopes from the parameter roles in `T.gemm(A, B, C)`.
+
+The following code illustrates the hardware mapping of the three kinds of data. In actual kernels, users can first use ordinary shared buffers and let the compiler infer scopes:
+
+```python
+A_shared = T.alloc_shared((block_M, block_K), dtype, scope="shared.asram")
+B_shared = T.alloc_shared((block_K, block_N), dtype, scope="shared.wsram")
+C_shared = T.alloc_shared((block_M, block_N), accum_dtype, scope="shared.rsram")
+
+T.gemm(A_shared, B_shared, C_shared)
+```
+
+Scope mapping:
+
+- The left operand is placed in `shared.asram`.
+- The right operand is placed in `shared.wsram`.
+- The result operand is placed in `shared.rsram`.
+
+What users really need to care about is whether the left and right operand data has been prepared before calling `T.gemm`, and whether the result operand has been initialized or preserved for accumulation as required by the algorithm.
+
+In MeshTensor GEMM / SUMMA-style kernels, the common pattern is:
+
+1. Each core reads local data from its own MeshTensor shard.
+2. Use `T.comm.all_gather` in the row/column direction to collect the complete blocks needed for computation.
+3. Call `T.gemm`.
+4. Write the local result of C back to the MeshTensor shard.
+
+### 2.11 Pipeline
+
+Users generally use `T.Pipelined` to express loop pipelining intent:
+
+```python
+for k in T.Pipelined(T.ceildiv(sharded_K, block_K), num_stages=3):
+    T.copy(...)
+    T.comm.all_gather(...)
+    T.gemm(...)
+```
+
+`T.Pipelined` is suitable for K loops or consecutive tile processing. It indicates that data movement, inter-core communication, and computation inside the loop body have pipelining opportunities. `num_stages` indicates how many pipeline stages the user wants to keep. Users only need to ensure that the data dependency semantics in the loop body are correct; low-level control is handled by the compiler.
+
+## 3. Frontend Function Reference
+
+This section groups the frontend APIs that users directly interact with. For each category, it describes function signatures, parameter meanings, and SunMMIO usage notes. In examples, `buffer` can be a complete buffer, a slice, or a region.
+
+### 3.1 Compilation and Device Information
+
+**`tilelang.compile`**
+
+```python
+tilelang.compile(func, target="Sunmmio")
+```
+
+`tilelang.compile` compiles a TileLang kernel to the specified target.
+
+- `func`: the kernel factory or prim func to compile.
+- `target`: the target backend. SunMMIO users should explicitly write `target="Sunmmio"` so the compilation flow handles the kernel according to SunMMIO mesh, scope, layout, copy, inter-core communication, and GEMM semantics.
+
+**`tilelang.jit`**
+
+```python
+@tilelang.jit(target="Sunmmio")
+def kernel_factory(...):
+    ...
+```
+
+`tilelang.jit` defines a JIT-compilable kernel factory.
+
+- `target`: the target backend. SunMMIO kernels should explicitly use `target="Sunmmio"`.
+- The decorated function: usually returns a `@T.prim_func` or an inner `main` function.
+
+**`driver.get_sunmmio_device_mesh_config`**
+
+```python
+from tilelang.carver.arch import driver
+
+nrows, ncols = driver.get_sunmmio_device_mesh_config()
+```
+
+`get_sunmmio_device_mesh_config()` returns the 2D shape of the current SunMMIO device mesh.
+
+- Parameters: none.
+- Return value: `(nrows, ncols)`.
+- `nrows`: number of rows in the mesh, corresponding to the number of cores in the vertical direction.
+- `ncols`: number of columns in the mesh, corresponding to the number of cores in the horizontal direction.
+- Common usage: compute `ncores = nrows * ncols`, and map the linear `cid` in `T.Kernel(ncores)` to `row = cid // ncols` and `col = cid % ncols`.
+
+**`driver.get_sunmmio_device_properties`**
+
+```python
+props = driver.get_sunmmio_device_properties()
+```
+
+`get_sunmmio_device_properties()` reads SunMMIO device properties.
+
+- Parameters: none.
+- Return value: a device property object or dictionary. Exact fields depend on the device description provided by the runtime environment.
+- Common usage: choose block size, pipeline stage count, inter-core communication strategy, or other kernel generation parameters according to device properties.
+
+### 3.2 MeshTensor, Sharding, and Layout
+
+**`T.MeshShardingPolicy`**
+
+```python
+T.MeshShardingPolicy(
+    x=None,
+    y=None,
+    replicate=T.MeshReplicationType.NONE,
+    cross_mesh_dim=None,
+)
+```
+
+`MeshShardingPolicy` describes how a logical tensor maps onto the 2D mesh.
+
+- `x`: specifies which tensor dimension is split along the mesh column direction. If `x=1`, tensor dimension 1 is split by `ncols`.
+- `y`: specifies which tensor dimension is split along the mesh row direction. If `y=0`, tensor dimension 0 is split by `nrows`.
+- `replicate`: replication strategy. The default is `T.MeshReplicationType.NONE`.
+- `cross_mesh_dim`: specifies one tensor dimension to be split across the entire mesh, namely by `nrows * ncols`. Do not specify `x` or `y` at the same time when using `cross_mesh_dim`.
+
+Common replication strategies:
+
+- `T.MeshReplicationType.NONE`: no replication; each core holds a different shard.
+- `T.MeshReplicationType.ROW`: replicated within the same row; cannot be used together with splitting along `x`.
+- `T.MeshReplicationType.COLUMN`: replicated within the same column; cannot be used together with splitting along `y`.
+- `T.MeshReplicationType.ALL`: all cores hold the complete data.
+
+**`T.MeshTensor`**
+
+```python
+T.MeshTensor(shape, sharding_policy, device_mesh_config, dtype="float32", layout=None)
+```
+
+`MeshTensor` is used at kernel function parameter positions to declare an input or output tensor distributed on the SunMMIO mesh.
+
+- `shape`: complete logical shape, such as `(M, K)`. This is the global tensor shape from the user perspective.
+- `sharding_policy`: a `T.MeshShardingPolicy` object describing how the global tensor is split across cores.
+- `device_mesh_config`: usually from `driver.get_sunmmio_device_mesh_config()`, shaped like `(nrows, ncols)`.
+- `dtype`: element type, such as `"float16"`, `"bfloat16"`, or `"float32"`.
+- `layout`: global data layout in DRAM. When omitted, the default row-major layout is used, and the compiler infers or derives later required layouts according to access patterns and target rules. Users usually do not need to pass this parameter manually.
+
+After entering the kernel, a `MeshTensor` parameter corresponds to the local shard visible to the current core. Accesses such as `A.shape` and `B.shape` return the local shard shape.
+
+**`make_row_major`**
+
+```python
+from tilelang.layout import make_row_major
+
+layout = make_row_major(shape)
+```
+
+`make_row_major` constructs a row-major layout.
+
+- `shape`: logical shape of the tensor or buffer.
+- Return value: a layout object that can be passed to `T.MeshTensor(..., layout=layout)` or `T.annotate_layout`.
+- Common usage: explicitly express row-major layout in advanced scenarios, or debug layout-related issues. Ordinary kernels usually rely on the default row-major layout and compiler inference.
+
+**`make_zz_layout`**
+
+```python
+from tilelang.layout import make_zz_layout
+
+layout = make_zz_layout(shape_or_buffer, axes=None, block_shape=(32, 32))
+```
+
+`make_zz_layout` constructs a block-level ZZ layout. Ordinary GEMM or block-level memory access usually lets the compiler infer or derive the required layout. This function is mainly for interfacing with externally fixed formats, reproducing an existing layout, or debugging.
+
+- `shape_or_buffer`: can be a shape, buffer, buffer load, or buffer region.
+- `axes`: dimensions that participate in the blocked layout. When omitted, the last two dimensions are used by default, so the rank must be at least 2.
+- `block_shape`: shape of each layout block. A common value is `(32, 32)`.
+- Return value: a layout object.
+
+Explicit construction example:
+
+```python
+A_layout = make_zz_layout((M, K), [0, 1], (32, 32))
+B_layout = make_zz_layout((K, N), [0, 1], (32, 32))
+C_layout = make_zz_layout((M, N), [0, 1], (32, 32))
+```
+
+**`make_zn_layout`**
+
+```python
+from tilelang.layout import make_zn_layout
+
+layout = make_zn_layout(shape, axes, block_shape)
+```
+
+`make_zn_layout` constructs a ZN layout.
+
+- `shape`: logical shape of the tensor or buffer.
+- `axes`: dimensions participating in the layout transform.
+- `block_shape`: block shape.
+- Return value: a layout object.
+- Common usage: explicitly specify a format needed by a specific matrix operand.
+
+**`make_zzz_layout`**
+
+```python
+from tilelang.layout import make_zzz_layout
+
+layout = make_zzz_layout(shape, axes, block_shape, cluster_shape)
+```
+
+`make_zzz_layout` constructs a ZZZ layout with cluster organization.
+
+- `shape`: logical shape of the tensor or buffer.
+- `axes`: dimensions participating in the layout transform.
+- `block_shape`: shape of each block.
+- `cluster_shape`: cluster-level organization shape.
+- Return value: a layout object.
+
+**`make_nzz_layout`**
+
+```python
+from tilelang.layout import make_nzz_layout
+
+layout = make_nzz_layout(shape, axes, block_shape, cluster_shape)
+```
+
+`make_nzz_layout` constructs an NZZ layout with cluster organization.
+
+- `shape`: logical shape of the tensor or buffer.
+- `axes`: dimensions participating in the layout transform.
+- `block_shape`: shape of each block.
+- `cluster_shape`: cluster-level organization shape.
+- Return value: a layout object.
+
+**`T.annotate_layout`**
+
+```python
+T.annotate_layout({buffer: layout})
+```
+
+`T.annotate_layout` explicitly attaches a layout to a buffer or region. This is an advanced usage.
+
+- Parameter: a dict whose key is a buffer or region and whose value is a layout object.
+- `buffer`: the object to annotate with a layout.
+- `layout`: constructed by functions such as `make_row_major` or `make_zz_layout`.
+- Common usage: interfacing with externally fixed formats, reproducing existing layouts, or debugging layout-related issues. Ordinary kernels usually rely on compiler inference.
+
+**`make_tileview`**
+
+```python
+from tilelang.tileview import make_tileview
+
+tileview = make_tileview(buffer, tile_shape, index_map)
+```
+
+`make_tileview` describes how a buffer is divided into tiles, and is often used together with `T.Tiles`.
+
+- `buffer`: the buffer, buffer load, or buffer region to tile.
+- `tile_shape`: shape of each tile, for example `[16, 32]`.
+- `index_map`: buffer dimensions participating in tiling, for example `[-2, -1]` means the last two dimensions.
+- Return value: a TileView object.
+
+For common 2D tiles on SunMMIO, the last dimension is often 32, and the height is often 8, 16, or 32. Complex access patterns should explicitly use TileView.
+
+**`T.annotate_tileview`**
+
+```python
+T.annotate_tileview({buffer: make_tileview(buffer, tile_shape, index_map)})
+T.annotate_tileview({buffer: (tile_shape, index_map)})
+```
+
+`T.annotate_tileview` annotates a buffer or region with a TileView.
+
+- Parameter: a dict whose key is a buffer or region.
+- The value can be the return value of `make_tileview(...)`.
+- The value can also be written as the tuple shorthand `(tile_shape, index_map)`.
+- `tile_shape`: tile shape.
+- `index_map`: dimensions participating in tiling.
+
+Use this API when the access pattern in `T.Tiles` is complex, or when a stable tile domain needs to be expressed.
+
+### 3.3 On-Chip Storage
+
+**`T.alloc_shared`**
+
+```python
+T.alloc_shared(shape, dtype, scope="shared.dyn")
+```
+
+`T.alloc_shared` allocates an on-chip SRAM buffer inside a core.
+
+- `shape`: buffer shape, such as `(block_M, block_N)`.
+- `dtype`: element type, such as `"float16"`, `"bfloat16"`, or `"float32"`.
+- `scope`: on-chip SRAM scope. The default is `"shared.dyn"`. Common SunMMIO scopes include `"shared.rsram"`, `"shared.asram"`, and `"shared.wsram"`.
+- Return value: a buffer that can be read and written inside the kernel.
+
+Common scopes:
+
+- `shared.asram`: Tensor Core left-operand path.
+- `shared.wsram`: Tensor Core right-operand path.
+- `shared.rsram`: result operand, intermediate results, and Vector Core processed data.
+
+Ordinary GEMM code can start with default shared buffers. Explicit scopes are only needed when users want to bind hardware data paths more directly.
+
+**`T.clear`**
+
+```python
+T.clear(buffer)
+```
+
+`T.clear` zeroes a buffer or region.
+
+- `buffer`: a complete buffer, slice, or region.
+- Return value: a statement expressing the clear operation.
+- Common usage: initialize the result operand before GEMM, or initialize a temporary buffer.
+
+**`T.fill`**
+
+```python
+T.fill(buffer, value)
+```
+
+`T.fill` fills a buffer or region with a specified value.
+
+- `buffer`: a complete buffer, slice, or region.
+- `value`: fill value. Its type should be convertible to the buffer dtype.
+- Return value: a statement expressing the fill operation.
+- Common usage: initialize constants, set default mask values, or prepare reduce initial values.
+
+### 3.4 Data Movement
+
+**`T.copy`**
+
+```python
+T.copy(
+    src,
+    dst,
+    *,
+    coalesced_width=None,
+    disable_tma=False,
+    eviction_policy=None,
+    annotations=None,
+    loop_layout=None,
+)
+```
+
+`T.copy` is the recommended entry point for data movement.
+
+- `src`: source buffer, slice, region, or scalar position.
+- `dst`: destination buffer, slice, region, or scalar position.
+- `coalesced_width`: hint for coalesced access width. The default is `None`.
+- `disable_tma`: switch for copy path selection. SunMMIO users usually keep the default.
+- `eviction_policy`: cache/replacement policy hint. It can be `"evict_normal"`, `"evict_first"`, `"evict_last"`, or `None`.
+- `annotations`: additional annotation dict. If it appears together with separate parameters, values in the dict take precedence.
+- `loop_layout`: layout hint for the copy loop. Ordinary SunMMIO code usually does not need to fill this in.
+- Return value: a statement expressing the copy operation.
+
+Common SunMMIO paths include DRAM -> RSRAM, RSRAM -> DRAM, DRAM/RSRAM -> ASRAM, DRAM/RSRAM -> WSRAM, and RSRAM -> RSRAM. Unsupported paths are listed in 2.7.
+
+### 3.5 Tile Loop
+
+**`T.Tiles`**
+
+```python
+for i, j in T.Tiles(domain, parallel=False):
+    ...
+```
+
+`T.Tiles` constructs a tile-level loop.
+
+- `domain`: logical loop domain. The recommended form is an explicit shape, such as `[block_M, block_N]`. A buffer can also be passed, meaning `buffer.shape` is used.
+- `parallel`: whether to declare that there is no cross-iteration dependency between different tile iterations. The default is `False`.
+- Return value: tile loop iteration variables. The number of variables is determined by the rank of `domain`.
+
+When the loop body contains accumulation, reduction, or cross-iteration dependencies, do not set `parallel` to `True`.
+
+### 3.6 Inter-Core Communication
+
+Inter-core communication functions transfer data between cores. Source data can come from an on-chip buffer, or directly from a DRAM-side `MeshTensor` slice/region. The latter is often used to directly take a block from the current core's DRAM shard as the input to broadcast or all-gather. The destination is usually an on-chip buffer on the receiver side, because subsequent computation usually consumes inter-core communication results from on-chip SRAM.
+
+**`T.comm.broadcast`**
+
+```python
+T.comm.broadcast(src, dst, src_core, direction="all", size=-1)
+```
+
+`broadcast` expresses one source core broadcasting data to multiple cores along a specified direction.
+
+- `src`: source buffer or region. It can be an on-chip buffer or a DRAM-side `MeshTensor` slice/region.
+- `dst`: receive buffer or region, usually an on-chip buffer.
+- `src_core`: source core, either a linear id or `(row, col)`.
+- `direction`: broadcast direction. Supported values are `"horizontal"` / `"h"`, `"vertical"` / `"v"`, and `"all"` / `"a"`.
+- `size`: number of elements to broadcast. `-1` means using the whole source region.
+- Return value: a statement expressing the broadcast.
+
+`horizontal` propagates along the same row, `vertical` propagates along the same column, and `all` covers the whole mesh.
+
+**`T.comm.put`**
+
+```python
+T.comm.put(src, dst, src_core, dst_core, size=-1)
+```
+
+`put` expresses point-to-point send.
+
+- `src`: source buffer or region. It can be an on-chip buffer or a DRAM-side `MeshTensor` slice/region.
+- `dst`: destination buffer or region, usually an on-chip buffer on the destination core.
+- `src_core`: source core, either a linear id or `(row, col)`.
+- `dst_core`: destination core, either a linear id or `(row, col)`.
+- `size`: number of elements to send. `-1` means using the whole source region.
+- Return value: a statement expressing the put.
+
+`put` is suitable for one-to-one data delivery. If the same data needs to be sent to a row, a column, or the whole mesh, `broadcast` is usually used.
+
+**`T.comm.all_gather`**
+
+```python
+T.comm.all_gather(
+    send_buffer,
+    recv_buffer,
+    direction="all",
+    size=-1,
+    axis=None,
+    src_offset_byte=0,
+)
+```
+
+`all_gather` expresses that multiple cores each contribute a local segment, and the receive buffer concatenates the segments.
+
+- `send_buffer`: the source buffer or region contributed by the current core. It can be an on-chip buffer or a DRAM-side `MeshTensor` slice/region.
+- `recv_buffer`: buffer or region receiving the concatenated result, usually an on-chip buffer.
+- `direction`: direction of participating cores. Supported values are `"horizontal"` / `"h"`, `"vertical"` / `"v"`, and `"all"` / `"a"`.
+- `size`: number of elements sent by each core. `-1` means using the whole `send_buffer`.
+- `axis`: concatenation dimension. `None` means adding a new dimension 0; `0` means concatenating along dimension 0; `-1` means concatenating along the last dimension.
+- `src_offset_byte`: source address byte offset. Advanced usage usually keeps it as `0`.
+- Return value: a statement expressing all-gather.
+
+The receive shape must match `direction` and `axis`. If the number of participating cores is `K`:
+
+- `axis=None`: `recv_buffer.shape == [K, *send_buffer.shape]`.
+- `axis=0`: dimension 0 expands to `K * send_buffer.shape[0]`.
+- `axis=-1`: the last dimension expands to `K * send_buffer.shape[-1]`.
+
+**`T.comm.all_reduce`**
+
+```python
+T.comm.all_reduce(buffer, out, reduce_type, direction, dim=-1, clear=True)
+```
+
+`all_reduce` expresses cross-core reduction.
+
+- `buffer`: input buffer or region participating in reduce.
+- `out`: output buffer or region storing the reduce result.
+- `reduce_type`: reduce type. Supported values include `"sum"`, `"abssum"`, `"max"`, `"min"`, `"absmax"`, `"bitand"`, `"bitor"`, and `"bitxor"`.
+- `direction`: direction participating in reduce. Supported values are `"horizontal"` / `"h"`, `"vertical"` / `"v"`, and `"all"` / `"a"`.
+- `dim`: reduction dimension inside the local buffer. The default `-1` means the last dimension.
+- `clear`: whether to clear `out` before reduce. The default is `True`.
+- Return value: a statement expressing all-reduce.
+
+The `out` shape must be equal to the shape after removing `dim`, or keep length 1 on `dim`.
+
+### 3.7 GEMM
+
+**`T.gemm`**
+
+```python
+T.gemm(
+    A,
+    B,
+    C,
+    transpose_A=False,
+    transpose_B=False,
+    policy=T.GemmWarpPolicy.Square,
+    clear_accum=False,
+    k_pack=1,
+    wg_wait=0,
+    mbar=None,
+)
+```
+
+`T.gemm` expresses Tensor Core GEMM / MMA.
+
+- `A`: left operand buffer or region. The hardware path corresponds to ASRAM.
+- `B`: right operand buffer or region. The hardware path corresponds to WSRAM.
+- `C`: result operand buffer or region. The hardware path corresponds to RSRAM, and it carries the accumulation and output role.
+- `transpose_A`: whether to interpret the left operand as transposed. The default is `False`.
+- `transpose_B`: whether to interpret the right operand as transposed. The default is `False`.
+- `policy`: GEMM warp allocation policy. SunMMIO usually uses the default.
+- `clear_accum`: whether the GEMM operation clears the result operand. The default is `False`. A common pattern is to explicitly call `T.clear(C)` before GEMM.
+- `k_pack`: packed K parameter. Ordinary SunMMIO users keep the default `1`.
+- `wg_wait`: wait batch parameter. Ordinary SunMMIO users keep the default `0`.
+- `mbar`: barrier parameter. Ordinary SunMMIO users keep the default `None`.
+- Return value: a statement expressing GEMM.
+
+Scopes can be inferred from the parameter roles of `A/B/C`. Explicit scope usage is mainly for explanation or for scenarios that need stable control of data paths.
+
+### 3.8 Reduction
+
+**`T.reduce`**
+
+```python
+T.reduce(buffer, out, reduce_type, dim, clear)
+```
+
+`T.reduce` expresses local reduction on an on-chip buffer.
+
+- `buffer`: input buffer or region.
+- `out`: output buffer or region.
+- `reduce_type`: reduce type, such as `"sum"`, `"max"`, `"min"`, `"abssum"`, or `"absmax"`.
+- `dim`: reduction dimension.
+- `clear`: whether to clear the output before reduce.
+- Return value: a statement expressing reduce.
+
+Use `T.comm.all_reduce` for cross-core reduce.
+
+**`T.reduce_sum`** **/** **`T.reduce_max`** **/** **`T.reduce_min`**
+
+```python
+T.reduce_sum(buffer, out, dim=-1, clear=True)
+T.reduce_max(buffer, out, dim=-1, clear=True)
+T.reduce_min(buffer, out, dim=-1, clear=True)
+```
+
+These functions are shortcut entries for common local reductions.
+
+- `buffer`: input buffer or region.
+- `out`: output buffer or region.
+- `dim`: reduction dimension. The default is the last dimension.
+- `clear`: whether to clear the output before reduce. The default is `True`.
+- Return value: a statement expressing reduce.
+
+**`T.reduce_abssum`** **/** **`T.reduce_absmax`**
+
+```python
+T.reduce_abssum(buffer, out, dim=-1, clear=True)
+T.reduce_absmax(buffer, out, dim=-1, clear=True)
+```
+
+These functions are for absolute-value-related local reductions.
+
+- `buffer`: input buffer or region.
+- `out`: output buffer or region.
+- `dim`: reduction dimension. The default is the last dimension.
+- `clear`: whether to clear the output before reduce. The default is `True`.
+- Return value: a statement expressing reduce.
+
+**`T.reduce_bitand`** **/** **`T.reduce_bitor`** **/** **`T.reduce_bitxor`**
+
+```python
+T.reduce_bitand(buffer, out, dim=-1, clear=True)
+T.reduce_bitor(buffer, out, dim=-1, clear=True)
+T.reduce_bitxor(buffer, out, dim=-1, clear=True)
+```
+
+These functions are for local bitwise reductions in integer or bit-mask scenarios.
+
+- `buffer`: input buffer or region.
+- `out`: output buffer or region.
+- `dim`: reduction dimension. The default is the last dimension.
+- `clear`: whether to clear the output before reduce. The default is `True`.
+- Return value: a statement expressing reduce.
+
+### 3.9 Kernel and Loops
+
+**`T.Kernel`**
+
+```python
+with T.Kernel(*blocks, threads=None, is_cpu=False, prelude=None) as cid:
+    ...
+```
+
+`T.Kernel` creates the kernel/core execution entry.
+
+- `*blocks`: grid dimensions. SunMMIO commonly uses `T.Kernel(ncores)` to create one logical entry for each core in the mesh.
+- `threads`: thread dimension parameter. SunMMIO kernels usually do not need to fill this in.
+- `is_cpu`: whether to generate a CPU-style kernel. SunMMIO users keep the default `False`.
+- `prelude`: extra injected code. Ordinary SunMMIO users keep the default `None`.
+- Return value: block/core id binding. One-dimensional `T.Kernel(ncores)` returns the linear `cid`.
+
+**`T.serial`**
+
+```python
+T.serial(start, stop=None, step=None, *, annotations=None)
+
+for i in T.serial(stop):
+    ...
+
+for i in T.serial(start, stop, step):
+    ...
+```
+
+`T.serial` expresses a serial loop.
+
+- `start`: start value. If only one argument is passed, that argument is used as `stop`, and `start` defaults to 0.
+- `stop`: end value. The loop range excludes `stop`.
+- `step`: step size. The default is 1.
+- `annotations`: loop annotation dict. Ordinary users usually do not need to fill this in.
+- Return value: loop variable.
+
+**`T.Pipelined`**
+
+```python
+T.Pipelined(
+    start,
+    stop=None,
+    num_stages=0,
+    order=None,
+    stage=None,
+    sync=None,
+    group=None,
+)
+
+for k in T.Pipelined(loop_extent, num_stages=3):
+    ...
+```
+
+`T.Pipelined` expresses a loop that can be pipelined, and is often used for K loops or consecutive tile processing.
+
+- `start`: if `stop` is empty, `start` means loop extent; if `stop` is not empty, `start` means the start value.
+- `stop`: end value. The default is `None`.
+- `num_stages`: number of pipeline stages. `0` means pipeline is disabled. Common values for GEMM K loops are 2 or 3.
+- `order`: stage order control. Advanced usage usually keeps the default.
+- `stage`: manual stage annotation. Advanced usage usually keeps the default.
+- `sync`: synchronization relationship description. Advanced usage usually keeps the default.
+- `group`: pipeline group description. Advanced usage usually keeps the default.
+- Return value: loop variable.
+
+The loop body usually contains copy, inter-core communication, and compute. Users need to keep data dependencies clear, for example making sure the related inputs have already been moved or communicated before using a tile for computation.
+
+## 4. Examples
+
+This section gives 3 complete kernel examples. To keep the main structure clear, the examples assume that the problem size is divisible by block size and mesh partitioning. Real engineering code needs additional boundary handling.
+
+### 4.1 Local Shard GEMM
+
+In this kernel, each core only reads the local shard in its own DRAM, performs local GEMM, and writes back to its own output shard.
+
+```python
+import tilelang
+import tilelang.language as T
+from tilelang.carver.arch import driver
+from tilelang.layout import make_zz_layout
+
+
+@tilelang.jit(target="Sunmmio")
+def local_shard_gemm(
+    M=128,
+    N=128,
+    K=128,
+    block_M=32,
+    block_N=32,
+    block_K=32,
+    dtype="float16",
+    accum_dtype="float32",
+):
+    device_mesh = driver.get_sunmmio_device_mesh_config()
+    nrows, ncols = device_mesh
+    ncores = nrows * ncols
+
+    policy = T.MeshShardingPolicy(y=0, x=1)
+    A_layout = make_zz_layout((M, K), [0, 1], (32, 32))
+    B_layout = make_zz_layout((K, N), [0, 1], (32, 32))
+    C_layout = make_zz_layout((M, N), [0, 1], (32, 32))
+
+    @T.prim_func
+    def main(
+        A: T.MeshTensor((M, K), policy, device_mesh, dtype, layout=A_layout),  # type: ignore
+        B: T.MeshTensor((K, N), policy, device_mesh, dtype, layout=B_layout),  # type: ignore
+        C: T.MeshTensor((M, N), policy, device_mesh, accum_dtype, layout=C_layout),  # type: ignore
+    ):
+        with T.Kernel(ncores) as _cid:
+            sharded_M, sharded_K = A.shape
+            _, sharded_N = B.shape
+
+            A_tile = T.alloc_shared((block_M, block_K), dtype)
+            B_tile = T.alloc_shared((block_K, block_N), dtype)
+            C_tile = T.alloc_shared((block_M, block_N), accum_dtype)
+
+            for bm in T.serial(T.ceildiv(sharded_M, block_M)):
+                for bn in T.serial(T.ceildiv(sharded_N, block_N)):
+                    T.clear(C_tile)
+                    for bk in T.Pipelined(T.ceildiv(sharded_K, block_K), num_stages=3):
+                        T.copy(
+                            A[
+                                bm * block_M : (bm + 1) * block_M,
+                                bk * block_K : (bk + 1) * block_K,
+                            ],
+                            A_tile,
+                        )
+                        T.copy(
+                            B[
+                                bk * block_K : (bk + 1) * block_K,
+                                bn * block_N : (bn + 1) * block_N,
+                            ],
+                            B_tile,
+                        )
+                        T.gemm(A_tile, B_tile, C_tile)
+
+                    T.copy(C_tile, C[bm * block_M, bn * block_N])
+
+    return main
+```
+
+### 4.2 SUMMA GEMM with HLink / VLink
+
+This kernel shows a SUMMA-style dataflow: the same row gathers left-operand blocks through HLink, the same column gathers right-operand blocks through VLink, and then GEMM is executed on the current core.
+
+```python
+import tilelang
+import tilelang.language as T
+from tilelang.carver.arch import driver
+from tilelang.layout import make_zz_layout
+
+
+@tilelang.jit(target="Sunmmio")
+def summa_gemm(
+    M=128,
+    N=128,
+    K=128,
+    block_M=32,
+    block_N=32,
+    block_K=32,
+    dtype="float16",
+    accum_dtype="float32",
+):
+    device_mesh = driver.get_sunmmio_device_mesh_config()
+    nrows, ncols = device_mesh
+    ncores = nrows * ncols
+
+    policy = T.MeshShardingPolicy(y=0, x=1)
+    A_layout = make_zz_layout((M, K), [0, 1], (32, 32))
+    B_layout = make_zz_layout((K, N), [0, 1], (32, 32))
+    C_layout = make_zz_layout((M, N), [0, 1], (32, 32))
+
+    @T.prim_func
+    def main(
+        A: T.MeshTensor((M, K), policy, device_mesh, dtype, layout=A_layout),  # type: ignore
+        B: T.MeshTensor((K, N), policy, device_mesh, dtype, layout=B_layout),  # type: ignore
+        C: T.MeshTensor((M, N), policy, device_mesh, accum_dtype, layout=C_layout),  # type: ignore
+    ):
+        with T.Kernel(ncores) as _cid:
+            sharded_M, sharded_K = A.shape
+            _, sharded_N = B.shape
+
+            A_panel = T.alloc_shared((block_M, block_K * ncols), dtype)
+            B_panel = T.alloc_shared((block_K * nrows, block_N), dtype)
+            C_tile = T.alloc_shared((block_M, block_N), accum_dtype)
+
+            for bm in T.serial(T.ceildiv(sharded_M, block_M)):
+                for bn in T.serial(T.ceildiv(sharded_N, block_N)):
+                    T.clear(C_tile)
+                    for bk in T.Pipelined(T.ceildiv(sharded_K, block_K), num_stages=3):
+                        T.comm.all_gather(
+                            A[
+                                bm * block_M : (bm + 1) * block_M,
+                                bk * block_K : (bk + 1) * block_K,
+                            ],
+                            A_panel,
+                            direction="horizontal",
+                            axis=-1,
+                        )
+                        T.comm.all_gather(
+                            B[
+                                bk * block_K : (bk + 1) * block_K,
+                                bn * block_N : (bn + 1) * block_N,
+                            ],
+                            B_panel,
+                            direction="vertical",
+                            axis=0,
+                        )
+                        T.gemm(A_panel, B_panel, C_tile)
+
+                    T.copy(C_tile, C[bm * block_M, bn * block_N])
+
+    return main
+```
+
+### 4.3 GEMM + In-Tile Post-Processing
+
+This kernel loads a bias tile with the same shape after GEMM, and uses `T.Tiles` to perform element-by-element addition on the result tile.
+
+```python
+import tilelang
+import tilelang.language as T
+from tilelang.carver.arch import driver
+from tilelang.layout import make_zz_layout
+
+
+@tilelang.jit(target="Sunmmio")
+def gemm_with_bias(
+    M=128,
+    N=128,
+    K=128,
+    block_M=32,
+    block_N=32,
+    block_K=32,
+    dtype="float16",
+    accum_dtype="float32",
+):
+    device_mesh = driver.get_sunmmio_device_mesh_config()
+    nrows, ncols = device_mesh
+    ncores = nrows * ncols
+
+    policy = T.MeshShardingPolicy(y=0, x=1)
+    A_layout = make_zz_layout((M, K), [0, 1], (32, 32))
+    B_layout = make_zz_layout((K, N), [0, 1], (32, 32))
+    C_layout = make_zz_layout((M, N), [0, 1], (32, 32))
+
+    @T.prim_func
+    def main(
+        A: T.MeshTensor((M, K), policy, device_mesh, dtype, layout=A_layout),  # type: ignore
+        B: T.MeshTensor((K, N), policy, device_mesh, dtype, layout=B_layout),  # type: ignore
+        Bias: T.MeshTensor((M, N), policy, device_mesh, accum_dtype, layout=C_layout),  # type: ignore
+        C: T.MeshTensor((M, N), policy, device_mesh, accum_dtype, layout=C_layout),  # type: ignore
+    ):
+        with T.Kernel(ncores) as _cid:
+            sharded_M, sharded_K = A.shape
+            _, sharded_N = B.shape
+
+            A_tile = T.alloc_shared((block_M, block_K), dtype)
+            B_tile = T.alloc_shared((block_K, block_N), dtype)
+            Bias_tile = T.alloc_shared((block_M, block_N), accum_dtype)
+            C_tile = T.alloc_shared((block_M, block_N), accum_dtype)
+
+            for bm in T.serial(T.ceildiv(sharded_M, block_M)):
+                for bn in T.serial(T.ceildiv(sharded_N, block_N)):
+                    T.clear(C_tile)
+                    for bk in T.Pipelined(T.ceildiv(sharded_K, block_K), num_stages=3):
+                        T.copy(
+                            A[
+                                bm * block_M : (bm + 1) * block_M,
+                                bk * block_K : (bk + 1) * block_K,
+                            ],
+                            A_tile,
+                        )
+                        T.copy(
+                            B[
+                                bk * block_K : (bk + 1) * block_K,
+                                bn * block_N : (bn + 1) * block_N,
+                            ],
+                            B_tile,
+                        )
+                        T.gemm(A_tile, B_tile, C_tile)
+
+                    T.copy(
+                        Bias[
+                            bm * block_M : (bm + 1) * block_M,
+                            bn * block_N : (bn + 1) * block_N,
+                        ],
+                        Bias_tile,
+                    )
+                    for i, j in T.Tiles([block_M, block_N], parallel=True):
+                        C_tile[i, j] = C_tile[i, j] + Bias_tile[i, j]
+
+                    T.copy(C_tile, C[bm * block_M, bn * block_N])
+
+    return main
+```


### PR DESCRIPTION
## Motivation

TileLang-Mesh now includes SunMMIO/SUVM-specific extensions, but the repository documentation did not clearly explain how users should install this variant or how to write kernels for the SunMMIO target.

Users need a single entry point that explains:
- how TileLang-Mesh differs from upstream TileLang
- how to install from source, including non-editable installs and no-CUDA environments
- how the SunMMIO hardware model maps to TileLang frontend concepts
- how to use SunMMIO-specific programming patterns such as MeshTensor sharding, per-core execution, SRAM scopes, inter-core communication, GEMM, tile loops, and reductions

## Solution

This PR updates the documentation around TileLang-Mesh and SunMMIO:

- Expands `README.md` with TileLang-Mesh installation guidance.
  - Clarifies the `tilelang-mesh` distribution vs `import tilelang`.
  - Documents recursive clone requirements and the `3rdparty/NPU-IR` submodule.
  - Prioritizes non-editable source installs.
  - Adds install commands for environments without a CUDA toolkit.
  - Keeps editable install and Ninja rebuild instructions for development workflows.

- Adds SunMMIO documentation to the docs index.
  - Introduces a new `SUNMMIO` section in `docs/index.md`.

- Adds a full SunMMIO TileLang user guide in Chinese and English.
  - Covers SunMMIO hardware structure: 2D mesh, per-core DRAM/SRAM, Tensor Core, Vector Core, ODMA, HLink/VLink.
  - Describes the programming model: SPMD execution, persistent kernels, MeshTensor sharding, layout, TileView, copy semantics, tile loops, inter-core communication, GEMM, and pipeline usage.
  - Provides detailed frontend API explanations and three complete kernel examples.